### PR TITLE
fix(neis): NEIS INFO- 응답(데이터 없음) 분기에 로그 추가 (#44)

### DIFF
--- a/src/main/java/com/remake/gone/neis/NeisClient.java
+++ b/src/main/java/com/remake/gone/neis/NeisClient.java
@@ -77,6 +77,9 @@ public class NeisClient {
     if (!resultNode.isMissingNode()) {
       String code = resultNode.path("CODE").asText("");
       if (code.startsWith("INFO-")) {
+        log.info(
+            "NEIS API 데이터 없음(정상): resourceKey={}, code={}, message={}",
+            resourceKey, code, resultNode.path("MESSAGE").asText(""));
         return List.of();
       }
       log.error(


### PR DESCRIPTION
## 관련 이슈
#44 (닫지 않음 — 2학기 시간표가 NEIS에 아직 등록되지 않은 근본 원인은 그대로 남아있어, 이번
PR은 이슈에 남겨둔 "남은 작업" 중 로그 개선 항목만 처리한다)

## 작업 내용
`NeisClient.parseRows`가 NEIS의 "데이터 없음"(`RESULT.CODE`가 `INFO-`로 시작) 응답을
조용히 빈 리스트로 반환해서, 나중에 비슷한 문의가 와도 로그만으로 원인 파악이 안 됐다.
`resourceKey`/`code`/`message`를 INFO 레벨로 남기도록 로그 한 줄을 추가한다.

## 변경 사항 상세
- `NeisClient.java`의 `INFO-` 분기에 `log.info("NEIS API 데이터 없음(정상): resourceKey=…,
  code=…, message=…")` 추가. 동작(빈 리스트 반환)은 그대로라 기존 `NeisClientTest.
  returnsEmptyListWhenNoData`가 회귀 없이 통과한다.
- 실서버(dev 프로필)에서 실제로 재현: 현재 NEIS가 2학기 시간표 데이터를 아직 갖고 있지 않아
  (`GET /timetables` 호출 시 `periods: []`), 이 로그가 실제로 찍히는 걸 직접 확인했다
  (`resourceKey=hisTimetable, code=INFO-200, message=해당하는 데이터가 없습니다.`).

## 확인 사항
- [x] 로컬 빌드 통과 (`./gradlew build`)
- [x] Checkstyle 통과 (`./gradlew checkstyleMain`)
- [ ] CI(checkstyle, build-and-test) 통과
- [x] (해당 시) Notion 기능정의서/기획 문서 반영 — 해당 없음(엔드포인트/계약 변경 없음)
- [x] (해당 시) 관련 도메인 라벨 지정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added clearer logging when the NEIS API reports that no data is available.
  * The application continues to handle these responses by returning an empty result.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->