### PR TITLE
feat(auth): JWT Access/Refresh Token 서명키 분리

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,7 +146,9 @@ jobs:
       R2_ENDPOINT: https://dummy.r2.cloudflarestorage.com
       # JwtProperties(@NotBlank/@NotNull) 검증을 통과시키기 위한 더미 값. 실제 서명 검증은
       # JwtProviderTest 등에서 자체 값으로 하므로, 여기서는 컨텍스트 로딩만 통과하면 된다.
-      JWT_SECRET: dummy-jwt-secret-for-ci-context-loading-only
+      # Access/Refresh Token은 서로 다른 키로 서명하므로(#52) 더미 값도 둘로 나눈다.
+      JWT_ACCESS_TOKEN_SECRET: dummy-jwt-access-secret-for-ci-context-loading-only
+      JWT_REFRESH_TOKEN_SECRET: dummy-jwt-refresh-secret-for-ci-context-loading-only
       JWT_ACCESS_TOKEN_EXPIRATION: 1800000
       JWT_REFRESH_TOKEN_EXPIRATION: 1209600000
       # NeisProperties(@NotBlank) 검증을 통과시키기 위한 더미 값. contextLoads()는 실제 NEIS

--- a/docs/domain/auth/52-auth-jwt-secret-split-QA.md
+++ b/docs/domain/auth/52-auth-jwt-secret-split-QA.md
@@ -1,0 +1,49 @@
+# #52 JWT Access/Refresh Token 서명키 분리 — QA 결과
+
+관련 기획서: [52-auth-jwt-secret-split.md](./52-auth-jwt-secret-split.md)
+관련 코드 리뷰: [52-auth-jwt-secret-split-code-review.md](./52-auth-jwt-secret-split-code-review.md)
+(9단계 코드 리뷰 지적 사항은 QA 이전에 전부 반영 완료 — 이 문서는 QA에서 새로 발견된
+것만 다룬다)
+
+## 검증 방법/범위
+- `./gradlew build`(전체: checkstyle + 모든 테스트) 통과 확인 — `JwtProviderTest`(키
+  분리/교차 위조 거부 케이스 포함), `AuthServiceTest`, `@SpringBootTest` 컨텍스트 로딩
+  포함 전부 통과.
+- 로컬 서버 실제 기동(`./gradlew bootRun`, `dev` 프로필, 분리된
+  `application-dev.yml`의 `access-token-secret`/`refresh-token-secret` 사용) — 정상
+  기동 확인(`Started GoneServerV1Application in 16.397 seconds`). `JwtProperties`의
+  `@NotBlank` 검증과 프로퍼티 바인딩이 실제 설정 파일 기준으로도 문제없이 동작함을
+  확인했다.
+- `POST /api/v1/auth/login` 실제 HTTP 요청으로 로그인 시도.
+
+## 발견 사항
+
+### High
+없음.
+
+### Medium
+1. **로그인/재발급/로그아웃 실제 HTTP 흐름을 끝까지 검증하지 못함(환경 제약)** —
+   `POST /api/v1/auth/login` 호출 시 `500`(`COMMON_007`)이 반환됐다. 원인은 이 이슈의
+   변경과 무관하게 **로컬 Redis가 현재 세션 환경에 떠 있지 않아서**다(로그 확인:
+   `io.lettuce.core.RedisConnectionException: Unable to connect to localhost/<unresolved>:6379`,
+   `Connection refused`). `AuthService.login`은 `RedisRepository`(실제 Redis 필요)로
+   Refresh Token을 저장하므로 Redis 없이는 로그인 자체가 불가능하다 — 이 프로젝트의
+   기존 구조상 당연한 실패이지 `JwtProvider`/`JwtProperties` 변경으로 인한 회귀가
+   아니다(스택트레이스에 JWT 관련 코드는 전혀 등장하지 않는다).
+   로컬에 Redis를 새로 띄우거나(Docker 데몬도 이 환경에서 연결되지 않아 즉시 띄우기
+   어려움) 보스의 환경에서 재확인이 필요하다. 대신 아래처럼 이 변경이 실제로 건드리는
+   범위(서명/검증 로직)는 단위 테스트로 이미 실제 키 값을 써서 직접 검증됐다:
+   - `JwtProviderTest`가 `JwtProvider`를 목(mock) 없이 실제 인스턴스로 생성해 발급/검증을
+     왕복시키므로, "로그인 API가 호출하는 코드 경로"의 핵심 로직(서명 생성/검증)은
+     이미 실제 조건과 동일하게 검증된 상태다. Redis 연결은 이 이슈가 건드리지 않은
+     기존 인프라라, 로그인 API 자체의 종단 간(E2E) 재확인만 남아 있다.
+
+### Low
+없음.
+
+## 결론
+Critical/High/Low 없음. 코드 변경 자체(서명 키 분리, 교차 위조 거부)는 단위 테스트로
+실제 값을 써서 직접 검증됐고, 새 설정 스키마로 실제 서버가 정상 기동하는 것도 확인했다.
+**다만 로그인 API를 실제 HTTP 요청으로 끝까지(로그인→재발급→로그아웃) 확인하는 건 이
+세션의 Redis 미기동으로 완료하지 못했다** — Redis가 있는 환경(로컬 Redis 기동 또는
+보스 환경)에서 Postman(`GONE - Auth API` 컬렉션)으로 재확인이 필요하다.

--- a/docs/domain/auth/52-auth-jwt-secret-split-QA.md
+++ b/docs/domain/auth/52-auth-jwt-secret-split-QA.md
@@ -14,36 +14,33 @@
   기동 확인(`Started GoneServerV1Application in 16.397 seconds`). `JwtProperties`의
   `@NotBlank` 검증과 프로퍼티 바인딩이 실제 설정 파일 기준으로도 문제없이 동작함을
   확인했다.
-- `POST /api/v1/auth/login` 실제 HTTP 요청으로 로그인 시도.
+- 최초 시도 시 로컬 Redis가 떠 있지 않아 로그인이 `500`(`COMMON_007`,
+  `RedisConnectionException`)으로 실패했으나(이 이슈의 변경과 무관 — 스택트레이스에
+  JWT 관련 코드 없음), 보스가 로컬 Redis를 기동해준 뒤 재시도해 아래 전체 흐름을 실제
+  HTTP 요청으로 끝까지 검증했다.
+
+## 실제 HTTP E2E 검증 (Redis 기동 후)
+로컬 서버(`http://localhost:9091`)에 실제 계정으로 로그인부터 로그아웃까지 순서대로
+호출했다.
+
+1. `POST /api/v1/auth/login` → `200`, `accessToken`/`refreshToken` 정상 발급
+2. `POST /api/v1/auth/reissue`(발급받은 `refreshToken`으로) → `200`, 새
+   `accessToken`/`refreshToken` 발급(회전 확인)
+3. 재발급받은 `accessToken`으로 `GET /api/v1/users/me` → `200`, 정상 인증 통과
+4. **옛(이미 재발급에 쓴) `refreshToken`으로 다시 재발급 시도 → `401` `AUTH_008`**
+   (재사용 차단, 회전 정상 동작)
+5. **`accessToken`을 `refreshToken` 자리에 넣어 재발급 시도 → `401` `AUTH_008`**
+   (교차 사용 차단 — 이번 이슈가 목표한 "AT/RT 키 분리" 효과가 실제 요청에서도 그대로
+   관찰됨. 서명 키가 분리되기 전에도 `tokenType` 클레임 검사로 같은 응답이 나왔을
+   경로라 이 결과만으로 "서명 검증에서 막혔는지"까지는 HTTP 응답에서 구분되지 않지만,
+   그 지점은 `JwtProviderTest`의 신규 위조 토큰 테스트에서 이미 화이트박스로 확인했다)
+6. `POST /api/v1/auth/logout` → `200`
 
 ## 발견 사항
-
-### High
-없음.
-
-### Medium
-1. **로그인/재발급/로그아웃 실제 HTTP 흐름을 끝까지 검증하지 못함(환경 제약)** —
-   `POST /api/v1/auth/login` 호출 시 `500`(`COMMON_007`)이 반환됐다. 원인은 이 이슈의
-   변경과 무관하게 **로컬 Redis가 현재 세션 환경에 떠 있지 않아서**다(로그 확인:
-   `io.lettuce.core.RedisConnectionException: Unable to connect to localhost/<unresolved>:6379`,
-   `Connection refused`). `AuthService.login`은 `RedisRepository`(실제 Redis 필요)로
-   Refresh Token을 저장하므로 Redis 없이는 로그인 자체가 불가능하다 — 이 프로젝트의
-   기존 구조상 당연한 실패이지 `JwtProvider`/`JwtProperties` 변경으로 인한 회귀가
-   아니다(스택트레이스에 JWT 관련 코드는 전혀 등장하지 않는다).
-   로컬에 Redis를 새로 띄우거나(Docker 데몬도 이 환경에서 연결되지 않아 즉시 띄우기
-   어려움) 보스의 환경에서 재확인이 필요하다. 대신 아래처럼 이 변경이 실제로 건드리는
-   범위(서명/검증 로직)는 단위 테스트로 이미 실제 키 값을 써서 직접 검증됐다:
-   - `JwtProviderTest`가 `JwtProvider`를 목(mock) 없이 실제 인스턴스로 생성해 발급/검증을
-     왕복시키므로, "로그인 API가 호출하는 코드 경로"의 핵심 로직(서명 생성/검증)은
-     이미 실제 조건과 동일하게 검증된 상태다. Redis 연결은 이 이슈가 건드리지 않은
-     기존 인프라라, 로그인 API 자체의 종단 간(E2E) 재확인만 남아 있다.
-
-### Low
-없음.
+Critical/High/Medium/Low 모두 없음.
 
 ## 결론
-Critical/High/Low 없음. 코드 변경 자체(서명 키 분리, 교차 위조 거부)는 단위 테스트로
-실제 값을 써서 직접 검증됐고, 새 설정 스키마로 실제 서버가 정상 기동하는 것도 확인했다.
-**다만 로그인 API를 실제 HTTP 요청으로 끝까지(로그인→재발급→로그아웃) 확인하는 건 이
-세션의 Redis 미기동으로 완료하지 못했다** — Redis가 있는 환경(로컬 Redis 기동 또는
-보스 환경)에서 Postman(`GONE - Auth API` 컬렉션)으로 재확인이 필요하다.
+코드 변경 자체(서명 키 분리, 교차 위조 거부)는 단위 테스트로 실제 값을 써서 직접
+검증됐고, 이번에 실제 서버 + Redis로 로그인→재발급(회전)→인증→재사용 차단→교차 사용
+차단→로그아웃까지 전체 흐름을 HTTP 레벨로 재확인해 기존 동작이 그대로 유지됨을
+확인했다. 이 이슈의 완료 조건(Definition of Done)을 모두 충족한다.

--- a/docs/domain/auth/52-auth-jwt-secret-split-code-review.md
+++ b/docs/domain/auth/52-auth-jwt-secret-split-code-review.md
@@ -1,0 +1,103 @@
+# #52 JWT Access/Refresh Token 서명키 분리 — 코드 리뷰 결과
+
+리뷰 대상: `dev..feat/#52-jwt-secret-split` (커밋 `9d61fb6`, `c5652e0`, `89d90ed`, `cedb547`)
+기준 문서: [52-auth-jwt-secret-split.md](./52-auth-jwt-secret-split.md)(기획서),
+[code-review-template.md](../../rules/code-review-template.md),
+[code-review-isolation.md](../../rules/code-review-isolation.md)
+
+## 리뷰 범위 확인
+- `JwtProperties.java`(필드 분리), `JwtProvider.java`(`key(String tokenType)` 도입),
+  `JwtProviderTest.java`(생성자 갱신 + 신규 위조 토큰 테스트 2건), `.github/workflows/ci.yml`
+  (더미 시크릿 2개 분리) 4개 파일 diff를 모두 읽었다.
+- 기획서의 "변경 전/후" 코드 스니펫과 실제 구현을 한 줄씩 대조했다 — `key(String tokenType)`의
+  삼항 분기, `claims(token, expectedTokenType)`의 키 선택 순서, 클래스/레코드 Javadoc 수정
+  내용이 기획서 그대로 반영됐다.
+- `grep -rn "new JwtProperties"` (전체 `src/`)로 다른 곳에서 구 3-인자 생성자를 쓰는 코드가
+  남아있는지 확인 — `JwtProviderTest.java` 2곳 외에는 없다. `AuthServiceTest`는 기획서가
+  명시한 대로 `@Mock JwtProperties`를 쓰고 `.secret()`을 스텁하지 않아 변경이 불필요했고
+  실제로 손대지 않았다.
+- `grep -rln "JWT_SECRET"` (repo 전체, `.yml`/`.yaml`/`.md`/`.json`)로 다른 워크플로우/설정에
+  구 단일 시크릿 이름이 남아있는지 확인 — 기획서 본문(의도적으로 과거형 서술) 외에는 없다.
+  `.github/workflows/` 아래 CI 워크플로우는 `ci.yml`이 유일하고(`#51`의 배포 워크플로우는
+  아직 존재하지 않음), 그 안의 더미 값도 `JWT_ACCESS_TOKEN_SECRET`/
+  `JWT_REFRESH_TOKEN_SECRET` 두 줄로 정확히 갱신됐다.
+- `application.yml`(git 추적 대상)에는 애초 `jwt.*` 설정이 없다 — 로컬 값은 전부
+  `application-dev.yml`(gitignored)에만 있어 지시받은 대로 diff에서 보이지 않는 부분은
+  리뷰 대상에서 제외했다.
+- `JwtProviderTest.java`의 신규 헬퍼 `forgeTokenWithClaimTypeButWrongKey`가 만드는 위조
+  토큰을 직접 추적: `tokenType` 클레임은 기대값과 **일치**시키고 서명 키만 반대쪽 키로 바꿔서
+  만든다. 이 토큰을 `parseAccessToken`/`getUserIdFromRefreshToken`에 넣으면
+  `claims(token, expectedTokenType)`가 `key(expectedTokenType)`(자신의 access/refresh 키)로
+  `verifyWith`를 시도하는데, 토큰은 반대쪽 키로 서명됐으므로 `parseSignedClaims()`가
+  클레임을 읽기도 전에 서명 불일치로 `JwtException`을 던진다 — `tokenType` 클레임 값은
+  기대값과 같으므로 클레임 검사(코드상 서명 검증 다음 단계)는 통과할 조건이라, 이 테스트가
+  통과한다면 그 원인은 오직 서명 검증 실패뿐이다. 즉 "서명 검증이 1차 방어선"이라는
+  기획서의 핵심 주장을 실제로 증명하는 테스트다(클레임 검사만으로 우연히 통과하는 경우가
+  아님).
+- checkstyle 규칙(100자 제한, import 정렬) 위반 여부를 실제 문자 길이 기준으로 다시 측정—
+  Javadoc의 한글 텍스트를 바이트 길이로 잘못 셀 경우 오탐이 나므로 `String.length()`
+  (UTF-16 코드 유닛, Java `char` 개수와 동일 기준)로 재측정했다. 변경된 3개 Java 파일 모두
+  100자를 넘는 줄이 없다. import 순서도 정적 import → 일반 import 그룹, 알파벳 순 정렬을
+  그대로 지킨다.
+- 테스트 시크릿 문자열(`ACCESS_SECRET`/`REFRESH_SECRET` 등) 길이를 바이트 단위로 계산 —
+  최소 53바이트로 HMAC-SHA 최소 요구치(32바이트) 이상이라 `Keys.hmacShaKeyFor()`가 예외 없이
+  키를 생성한다.
+
+## Critical
+없음 — 위 "리뷰 범위 확인"에서 서술한 대로 키 선택 로직의 모든 실제 호출 경로(4곳: AT
+발급/파싱, RT 발급/파싱)를 추적했고, 서명 검증을 우회하거나 두 키가 뒤섞여 쓰이는 경로를
+찾지 못했다.
+
+## High
+없음 — 기획서 범위를 벗어난 변경(새 엔드포인트, 인증 흐름 변경 등)이 없는지 diff 4개 파일
+전체를 확인했고, `AuthController`/`AuthService`/`SecurityConfig`/`JwtAuthenticationFilter`
+등 이 이슈가 건드리지 않기로 한 파일은 실제로 diff에 없다(`git diff --stat`으로 재확인).
+
+## Medium
+없음 — 기존 컨벤션(코드 스타일, 테스트 구조, Javadoc 배치) 위반을 확인했으나 해당 사항
+없음. `R2Properties`/`NeisProperties`와 비교해 필드 순서(민감정보 필드를 앞쪽에 묶고 나머지를
+뒤에 배치)가 크게 어긋나지 않고, `@Param` Javadoc 순서도 레코드 필드 선언 순서와 일치한다.
+
+## Low
+
+### 1. 🟢 Low — `key(String tokenType)`의 암묵적 else 분기가 알 수 없는 값도 조용히 refresh 키로 처리한다
+
+**문제**: `src/main/java/com/remake/gone/common/security/JwtProvider.java:131-136`
+
+```java
+private SecretKey key(String tokenType) {
+  String secret = TOKEN_TYPE_ACCESS.equals(tokenType)
+      ? jwtProperties.accessTokenSecret()
+      : jwtProperties.refreshTokenSecret();
+  return Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+}
+```
+
+`tokenType`이 `"access"`와 같은지만 검사하고, 그 외 모든 값(`"refresh"`, 오타,
+`null`, 향후 추가될 제3의 토큰 타입 등)을 전부 refresh 키로 매핑한다. 지금은 이 메서드를
+부르는 곳이 4곳뿐이고(`createAccessToken`/`createRefreshToken`/`claims` 내부 2회 호출
+경로), 모두 클래스 내부의 `TOKEN_TYPE_ACCESS`/`TOKEN_TYPE_REFRESH` 상수만 넘기므로 실제
+오작동 사례는 없다. 다만 향후 이 메서드에 세 번째 토큰 종류(예: 이메일 인증 토큰)를 추가하며
+새 문자열 상수를 넘기는 실수를 하면, 컴파일 에러도 런타임 예외도 없이 refresh 키로 서명/검증
+되어버린다 — 이 이슈가 막으려던 "키가 뒤섞이는" 상황을 코드 자체가 조용히 재현할 수 있는
+구조다. 오늘 시점에는 재현 불가능한 잠재적 리스크이며, 실제 발생 시에도 즉시 auth 관련 테스트
+실패로 드러날 가능성이 높다는 점에서 심각도는 낮게 본다.
+
+**해결 방안**:
+1. 삼항 연산자를 `if/else if` + 알 수 없는 값에 대한 명시적 예외(`IllegalArgumentException`
+   또는 `IllegalStateException`)로 바꾼다 — 잘못된 `tokenType`이 들어오면 즉시 실패해서
+   원인을 바로 찾을 수 있다. 다만 지금은 호출부가 전부 내부 상수뿐이라 실질적으로 트리거될
+   경로가 없어 코드량만 늘어나는 방어적 코드가 될 수 있다.
+2. 현재 상태를 유지한다 — 호출부가 이 클래스 내부로 완전히 통제되고(외부에서 임의
+   문자열을 넘길 수 없음), 두 상수 외 다른 값이 들어오는 경로 자체가 존재하지 않는다.
+   추가 방어 코드 없이도 "이 메서드를 호출하는 새 코드를 작성할 때 상수를 재사용한다"는
+   기존 관례로 충분히 안전하다고 볼 수 있고, 기획서에 명시된 구현과 정확히 일치시켜
+   리뷰/승인 범위를 벗어나지 않는 이점이 있다.
+
+이번 PR을 막을 정도의 문제는 아니라고 판단해 병합 자체를 지연시키지 않되, 다음에 토큰
+종류를 하나라도 더 추가하는 변경이 있을 때 이 메서드부터 다시 살펴보는 것을 권장한다.
+
+## 반영 결과 (9단계 자체 점검 직후 즉시 반영)
+- 1. 🟢 Low — **반영**: 해결 방안 1(명시적 분기 + 알 수 없는 값에 대한
+  `IllegalArgumentException`) 채택. 비용이 낮고, 세 번째 토큰 종류를 추가할 때 발생할
+  실수를 컴파일 타임이 아니라도 최소한 즉시 예외로 드러나게 한다.

--- a/docs/domain/auth/52-auth-jwt-secret-split.md
+++ b/docs/domain/auth/52-auth-jwt-secret-split.md
@@ -1,0 +1,155 @@
+# #52 JWT Access/Refresh Token 서명키 분리 — 기획서
+
+관련 이슈: [#52 JWT Access/Refresh Token 서명키 분리](https://github.com/GBSW-ReMake/GONE-server-V1/issues/52)
+
+## 개요/목적
+`JwtProvider`는 지금 Access Token(AT)과 Refresh Token(RT)에 같은 서명 키
+(`JwtProperties.secret`)를 쓰고, `tokenType` 클레임만으로 용도를 구분한다. AT는 매
+요청마다 `Authorization` 헤더로 전송되어 노출 빈도가 훨씬 높고, RT는 로그인/재발급
+시점에만 오간다 — 키를 분리하면 한쪽이 유출돼도 반대쪽 토큰은 위조할 수 없어 피해
+범위가 줄어든다. 새 엔드포인트는 없다. 기존 `AuthController`/`AuthService`의 로그인/
+재발급/로그아웃 흐름은 그대로 두고, 서명에 쓰는 키 개수만 1개에서 2개로 바꾼다.
+
+`#51`(dev EC2 CI/CD) 작업 중 발견된 필요라 그 이슈에서 파생됐지만, 이 변경 자체는
+`auth`/`common/security` 도메인 코드를 직접 고치므로 별도 이슈로 분리했다(`#51`의
+"작업 범위"에 명시). `#51`의 dev 배포 시크릿 목록(`JWT_SECRET` → 2개로 교체)은 이
+이슈가 머지된 뒤 `#51` 쪽에서 갱신한다 — 이 이슈 자체에는 포함하지 않는다.
+
+## 변경 전/후
+
+### `JwtProperties`
+**변경 전**
+```java
+public record JwtProperties(
+    @NotBlank String secret,
+    @NotNull Long accessTokenExpiration,
+    @NotNull Long refreshTokenExpiration
+) {}
+```
+
+**변경 후**
+```java
+public record JwtProperties(
+    @NotBlank String accessTokenSecret,
+    @NotBlank String refreshTokenSecret,
+    @NotNull Long accessTokenExpiration,
+    @NotNull Long refreshTokenExpiration
+) {}
+```
+필드명은 기존 `accessTokenExpiration`/`refreshTokenExpiration`과 같은 네이밍 규칙을
+그대로 따른다(`api-design.md` 원칙 3 "직관적 일관성"). Spring Boot relaxed binding에
+따라 프로퍼티 키는 `jwt.access-token-secret`/`jwt.refresh-token-secret`, 환경변수는
+`JWT_ACCESS_TOKEN_SECRET`/`JWT_REFRESH_TOKEN_SECRET`이 된다.
+
+### `JwtProvider`
+**변경 전**: `createAccessToken`/`createRefreshToken`/`claims(...)` 모두 `key()`
+하나(`jwtProperties.secret()` 기반)를 공유해서 쓴다.
+
+**변경 후**: 토큰 종류별로 다른 키를 쓰도록 `key()`를 `key(String tokenType)`로 바꾼다.
+```java
+public String createAccessToken(Long userId, Set<String> roleCodes) {
+  ...
+  .signWith(key(TOKEN_TYPE_ACCESS))
+  ...
+}
+
+public String createRefreshToken(Long userId) {
+  ...
+  .signWith(key(TOKEN_TYPE_REFRESH))
+  ...
+}
+
+private Claims claims(String token, String expectedTokenType) {
+  Claims claims = Jwts.parser()
+      .verifyWith(key(expectedTokenType))
+      .build()
+      .parseSignedClaims(token)
+      .getPayload();
+  // tokenType 클레임 검사는 그대로 유지(아래 "보안 개선" 참고)
+  ...
+}
+
+private SecretKey key(String tokenType) {
+  String secret = TOKEN_TYPE_ACCESS.equals(tokenType)
+      ? jwtProperties.accessTokenSecret()
+      : jwtProperties.refreshTokenSecret();
+  return Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+}
+```
+`claims(token, expectedTokenType)`는 이미 호출부(`parseAccessToken`/
+`getUserIdFromRefreshToken`)가 "어떤 종류를 기대하는지"를 알고 호출하므로, 검증 시에도
+그 기댓값으로 올바른 키를 먼저 선택한 뒤 서명을 확인할 수 있다 — 별도 분기 추가 비용이
+거의 없다.
+
+**보안 개선(부수 효과)**: 지금은 "AT를 RT로 사용/그 반대"를 막는 방어가 `tokenType`
+클레임 검사(서명 검증 *이후* 단계) 하나뿐이었다. 키를 분리하면 애초에 다른 키로 서명된
+토큰은 **서명 검증 단계에서부터** 실패한다(`JwtException`) — `tokenType` 클레임 검사는
+방어선으로 그대로 남기되(같은 키를 실수로 재사용하는 미래의 회귀를 잡아주는 안전망 역할),
+실제 방어의 1차 저지선이 서명 검증으로 옮겨간다.
+
+클래스 상단 Javadoc의 "두 토큰 모두 같은 서명 키를 쓰지만" 설명도 "각자 다른 서명 키를
+쓰고, tokenType 클레임은 부가 방어선으로 남긴다"로 함께 수정한다.
+
+## 데이터 모델 변경
+없음 — JWT는 서버가 상태를 갖지 않는 서명 토큰이라 DB/Redis 스키마에 영향이 없다.
+
+## 영향 받는 기존 코드/설정
+- `JwtProperties`: 필드 변경(위 참고).
+- `JwtProvider`: `key()` → `key(String tokenType)`, 클래스 Javadoc 수정.
+- `application-dev.yml`: `jwt.secret` 한 줄을 `jwt.access-token-secret`/
+  `jwt.refresh-token-secret` 두 줄로 교체(로컬 실행이 계속 되려면 실제 값 2개가 필요 —
+  기존 값을 `access-token-secret`에 재사용하고 `refresh-token-secret`은 새로 생성해
+  실제로 다른 값이 되게 한다. 둘을 같은 값으로 두면 "키 분리"라는 목적 자체가 무의미해짐).
+- `.github/workflows/ci.yml`: `build-and-test` job의 `env:` 블록에서 `JWT_SECRET:
+  dummy-jwt-secret-for-ci-context-loading-only` 한 줄을
+  `JWT_ACCESS_TOKEN_SECRET`/`JWT_REFRESH_TOKEN_SECRET` 두 줄로 교체(둘 다 더미 값,
+  `contextLoads()`만 통과하면 됨 — 기존 R2/NEIS 더미 값과 같은 성격).
+- `JwtProviderTest`: `new JwtProperties(...)` 호출부 2곳(`JwtProviderTest.java:28`,
+  `:71`)의 인자 개수/순서 갱신. 신규 테스트 케이스 추가(아래 "테스트 방법" 참고).
+- `AuthServiceTest`는 `JwtProperties`를 Mockito `@Mock`으로 쓰고 `.secret()`을
+  스텁하는 곳이 없어(`accessTokenExpiration()`만 스텁) 변경 불필요.
+- `#51`(dev EC2 CI/CD)의 GitHub Secrets 목록/워크플로우는 이 이슈가 머지된 뒤 별도로
+  갱신(이 이슈 범위 밖, 위 "개요/목적" 참고).
+
+## API 설계 6원칙 체크
+1. **한 가지를 잘하기**: 새 엔드포인트 없음, 서명 키 구조만 바꾼다.
+2. **빠르게 시작하기**: 해당 없음(내부 인프라 변경, 외부에 노출되는 요청/응답 스키마
+   변화 없음).
+3. **일관성**: 신규 필드명이 기존 `accessTokenExpiration`/`refreshTokenExpiration`
+   네이밍과 대칭을 이룬다.
+4. **의미 있는 오류**: 클라이언트가 관찰하는 에러 동작은 바뀌지 않는다(서명 위조 시
+   여전히 `AuthErrorCode.INVALID_REFRESH_TOKEN` 등 기존 경로로 처리).
+5. **확장성/성능**: 해당 없음.
+6. **하위 호환성**: **서버 설정(환경변수/프로퍼티) 차원의 breaking change다** — 배포
+   환경에 `JWT_SECRET` 대신 `JWT_ACCESS_TOKEN_SECRET`/`JWT_REFRESH_TOKEN_SECRET`을
+   등록해야 앱이 뜬다. 클라이언트(API 계약) 관점에서는 영향 없음 — 이미 발급된 토큰은
+   이 배포 시점에 서버가 재시작되며 무효화되지만(서명 키 자체가 바뀌므로), 이 프로젝트가
+   아직 실사용자가 없는 개발 단계라 영향이 제한적이다(`api-design.md` "하위 호환성"
+   원칙이 명시한 예외 상황과 동일한 근거).
+
+## 리스크 및 고려사항
+- **배포 시 두 시크릿을 모두 등록해야 앱이 기동한다** — `@NotBlank`라 하나라도 빠지면
+  `contextLoads()`/실제 기동 모두 즉시 실패한다(기존 R2/NEIS와 같은 실패 모드, 새로운
+  리스크는 아님).
+- **`access-token-secret`과 `refresh-token-secret`을 같은 값으로 등록하면 분리 효과가
+  없다** — 실수 방지를 위해 로컬(`application-dev.yml`) 값부터 실제로 다른 문자열로
+  채운다(위 "영향 받는 기존 코드/설정" 참고).
+- **`#51`과의 순서 의존성**: `#51`의 `deploy-dev`가 이 이슈보다 먼저 머지/배포되면
+  `JWT_SECRET` 하나만 있는 상태로 배포되므로 문제가 없다(이 이슈가 아직 안 들어갔으니
+  앱도 여전히 `secret` 필드 하나만 기대함). 반대로 이 이슈가 먼저 머지되면 `dev`
+  브랜치의 앱은 두 시크릿을 요구하는데 `#51`이 아직 안 갱신됐다면 dev EC2 배포가
+  실패한다(`.env`에 없는 프로퍼티) — 병합 순서를 보스와 맞추거나, 이 이슈 머지 직후
+  바로 `#51`의 시크릿 목록을 갱신해야 한다.
+
+## 테스트 방법
+1. `JwtProviderTest`의 기존 두 생성자 호출부를 새 필드 순서로 갱신 — 이미 있는 라운드
+   트립(발급→파싱) 케이스들은 그대로 통과해야 한다(AT는 AT 키로, RT는 RT 키로 서명/검증
+   하므로).
+2. 신규 케이스 추가: "AT 서명 키로 만든 토큰으로 `getUserIdFromRefreshToken` 호출 시
+   `JwtException`", 그 반대 방향(RT 키 토큰을 `parseAccessToken`에)도 동일하게 추가 —
+   지금까지는 같은 키였기 때문에 성립할 수 없었던 새 실패 시나리오라, 이번에 처음 검증
+   가능해진다.
+3. 로컬 서버 기동 후 회원가입/로그인/재발급/로그아웃 흐름을 Postman(`GONE - Auth API`
+   컬렉션)으로 재검증 — 기존 요청/응답 스키마가 그대로인지 확인(계약 자체는 안 바뀜).
+4. `./gradlew build`, `./gradlew checkstyleMain` 로컬 통과 + CI 통과 확인(새 더미
+   시크릿 2개로 `contextLoads()` 통과 확인).

--- a/docs/domain/notification/1_notification-domain.md
+++ b/docs/domain/notification/1_notification-domain.md
@@ -1,0 +1,389 @@
+# 알림(Notification) 도메인 — 기능 기획서 (초안)
+
+> 관련 백로그 이슈: [#37 알림 시스템 도입 (외출증 승인/거절, 스쿨캠핑 리마인더 등)](https://github.com/GBSW-ReMake/GONE-server-V1/issues/37)
+>
+> 이 문서는 `outing`/`schoolcamp`처럼 알림 도메인 전체를 다루는 마스터 기획서다. 실제
+> 구현은 이 문서에서 파생되는 하위 이슈 단위로 진행하며, 문서명은
+> `docs/domain/notification/{이슈번호}-notification-{제목}.md` 규칙을 따른다(첫 파생 문서:
+> [37-notification-inbox.md](./37-notification-inbox.md)). 각 이슈별 문서가 실제 최신
+> 판단의 기준이고, 이 마스터 문서는 최초 설계 의도의 기록으로 남긴다([api-design.md](../../rules/api-design.md)
+> "마스터 기획서 재검토" 원칙과 동일).
+
+## 개요/목적
+`outing`(외출증 승인/거절, 복귀 리마인더)과 `schoolcamp`(팀원 초대, 외출 미신청 리마인더)
+양쪽 마스터 기획서 모두 "학생 기기에 알림을 보내야 한다"는 요구를 이미 갖고 있지만, 이
+프로젝트에는 아직 어떤 형태의 알림 인프라도 없다. 이 문서는 그 공통 인프라를 독립된
+도메인(`notification`)으로 분리해 설계한다.
+
+> ⚠️ **설계 리뷰로 정정된 우선순위**: 최초 초안은 "FCM 실시간 푸시"를 메인으로 두고
+> 인앱 알림 조회를 후순위로 미뤘으나, 검토 결과 뒤집었다. **서버가 알림을 저장하고
+> 사용자가 목록으로 조회/읽음 처리하는 "인앱 알림함"이 메인이고, FCM 푸시(디바이스
+> 토큰 등록/발송)는 그 알림이 왔다는 걸 앱을 안 켜도 바로 알 수 있게 해주는 실시간
+> 보조 수단이다.** 이유는 두 가지다.
+> 1. **알림을 놓쳤을 때의 최종 안전망이 인앱 알림함이다.** FCM 푸시는 기기 설정(알림
+>    권한 거부), 네트워크 상태, 토큰 만료 등으로 도달이 보장되지 않는 "best-effort"
+>    채널이다(위 "정책 가정" 참고). 반면 인앱 알림함은 앱만 열면 항상 정확한 이력을
+>    볼 수 있다 — "알림을 못 받았다"는 문의가 들어왔을 때도 서버 DB만 보면 실제로
+>    발송(저장)됐는지 바로 확인 가능하다.
+> 2. **FCM(Firebase) 없이도 핵심 기능이 완결된다.** 인앱 알림함은 이 프로젝트 인프라
+>    (DB)만으로 완성되고, Firebase 프로젝트 생성/서비스 계정 발급 같은 외부 종속성이
+>    전혀 없어 먼저 출시해 검증하기 쉽다. FCM은 그 위에 "실시간성"만 더하는 순수
+>    추가 계층이라, 나중에 붙여도(또는 일정상 밀려도) 인앱 알림함의 계약을 전혀
+>    건드리지 않는다(아래 "단계 구분" 참고).
+
+## 목차
+1. [단계 구분](#단계-구분)
+2. [용어 정리](#용어-정리)
+3. [정책 가정](#정책-가정-확정-전--리뷰-시-조율-필요)
+4. [권한 모델](#권한-모델)
+5. [도메인 모델](#도메인-모델)
+6. [엔드포인트](#엔드포인트)
+7. [공통 발송 모듈](#공통-발송-모듈-notificationservice)
+8. [도메인 연동 지점 (참고, 각 도메인 마스터 기획서가 원 출처)](#도메인-연동-지점-참고-각-도메인-마스터-기획서가-원-출처)
+9. [에러 코드](#에러-코드-notificationerrorcode-신규-패키지-notification)
+10. [공통 구현 고려사항](#공통-구현-고려사항)
+11. [아직 결정 안 된 것](#아직-결정-안-된-것-리뷰-필요)
+
+## 단계 구분
+| 단계 | 내용 | 외부 종속성 | 상태 |
+|---|---|---|---|
+| **1단계 (메인)** | `Notification` 저장 + 목록 조회 + 읽음 처리, `NotificationService.send(...)`가 DB에 저장까지만 담당 | 없음(이 프로젝트 DB만) | [37-notification-inbox.md](./37-notification-inbox.md), 착수 |
+| **2단계 (보조)** | FCM 디바이스 토큰 등록/삭제, `NotificationService.send(...)`에 FCM 발송 추가(1단계 시그니처 그대로, 내부 동작만 확장) | Firebase 프로젝트/서비스 계정 | 후속 이슈(미생성) |
+| **3단계 이후** | `outing` 승인/거절·복귀 리마인더, `schoolcamp` 초대·리마인더가 `NotificationService.send(...)` 실제 호출 | 각 도메인 상태 | 각 도메인 후속 이슈(미생성) |
+
+2단계가 1단계의 `send(userId, title, body)` 시그니처를 바꾸지 않는 이유는 아래 "공통 발송
+모듈" 절 참고 — 호출하는 도메인(3단계) 입장에서는 몇 단계까지 구현됐는지 몰라도 된다.
+
+## 용어 정리
+- **알림(Notification)**: 서버가 특정 사용자에게 보낸 알림 1건의 저장 기록. 인앱
+  알림함 화면의 목록 항목이 된다.
+- **디바이스 토큰**: 클라이언트 앱이 FCM(Firebase Cloud Messaging)에 등록해 발급받는
+  문자열. 서버가 이 값을 알아야 그 기기로 실시간 푸시를 보낼 수 있다(2단계).
+- **공통 발송 모듈(`NotificationService`)**: 도메인 이벤트(외출증 승인 등)가 발생했을 때
+  "이 사용자에게 이런 알림을 보내라"만 호출하면 되도록 저장/푸시 세부사항을 감추는 서비스.
+
+## 정책 가정 (확정 전 — 리뷰 시 조율 필요)
+- **알림은 항상 DB에 저장된다(메인 동작, 예외 없음).** FCM 디바이스 토큰이 없어도, FCM
+  발송이 실패해도 `Notification` 저장 자체는 항상 성공해야 한다 — "실시간으로 못 받았어도
+  나중에 앱 켜면 볼 수 있다"가 이 설계의 핵심 안전망이다.
+- **FCM 발송은 best-effort 보조 수단이다.** 실패해도 예외를 던지지 않고 로그만 남기고
+  삼킨다(swallow) — 호출하는 쪽(예: 외출증 승인 서비스 로직)의 핵심 트랜잭션이 "푸시
+  발송 실패" 때문에 롤백되면 안 된다. 반면 **저장(1단계)이 실패하면 그건 진짜 예외로
+  전파한다** — 알림 저장은 이 모듈의 핵심 책임이라 조용히 삼키면 안 된다(이 부분이
+  `send(...)` 호출자 트랜잭션과 같은 트랜잭션으로 묶여도 괜찮은 이유이기도 하다 — 알림
+  저장 실패가 승인 자체를 롤백시키는 건 오히려 타당하다).
+- **사용자당 디바이스 토큰 1개만 저장한다(다중 기기 미지원, 2단계 MVP).** 새로 등록하면
+  기존 값을 덮어쓴다 — `REFRESH_TOKEN`(Redis, `auth:refresh:{userId}`)이 이미 "최신 값으로
+  교체(rotation)"하는 것과 같은 결의 단순화다.
+- **FCM이 "이 토큰은 더 이상 유효하지 않다"고 응답하면(`UNREGISTERED`) 저장된 토큰을 즉시
+  삭제한다(self-healing, 2단계).**
+- **동기 호출로 설계한다(비동기/큐 도입 없음, YAGNI).** DB 저장은 어차피 호출자의 기존
+  트랜잭션 안에서 동기로 일어나는 게 자연스럽다. FCM 발송(2단계)까지 같은 트랜잭션
+  안에서 동기 호출하면 외부 HTTP 응답을 기다리는 동안 DB 락 보유 시간이 늘어질 수 있다 —
+  이 트레이드오프는 2단계 구현 시 재검토 대상으로 남긴다.
+
+## 권한 모델
+- 인앱 알림 조회/읽음 처리, 디바이스 토큰 등록/삭제: 인증된 사용자 누구나(역할 무관,
+  본인 것만 — 요청 파라미터로 대상 지정하지 않고 항상 `principal.userId()` 기준).
+- `NotificationService`는 컨트롤러가 없는 순수 내부 서비스라 별도 인가가 필요 없다(호출하는
+  쪽 도메인의 인가를 그대로 따른다).
+
+## 도메인 모델
+
+### `Notification` 엔티티 (`notification` 테이블, 신규, **1단계**)
+- `id` — 내부 PK
+- `user_id` — 수신자(`User` FK)
+- `title` — 알림 제목
+- `body` — 알림 본문
+- `type` — 발송한 도메인이 자유롭게 붙이는 분류 태그(`VARCHAR(50)`, nullable, 예:
+  `"OUTING_APPROVED"`). **알림 도메인은 이 값의 의미를 모른다** — 클라이언트가 아이콘
+  선택/화면 이동(딥링크)에 쓸 수 있도록 문자열 그대로 전달만 한다. `outing`/`schoolcamp`
+  같은 구체 도메인의 enum을 `notification` 패키지가 참조하면 역방향 의존이 생기므로
+  일부러 자유 문자열로 둔다.
+- `is_read` — 읽음 여부(`BOOLEAN`, 기본 `false`)
+- `created_at` — 발송(저장) 시각
+
+인덱스: `(user_id, created_at)` — 본인 알림을 최신순으로 조회하는 목록 API가 이 조합으로
+정렬/필터하므로 필요.
+
+### `DeviceToken` 엔티티 (`device_token` 테이블, 신규, **2단계**)
+- `id` — 내부 PK
+- `user_id` — 토큰을 등록한 사용자(`User` FK, **UNIQUE** — 사용자당 1행, 위 "정책 가정"
+  참고)
+- `fcm_token` — FCM 등록 토큰 문자열(`VARCHAR(255)`, 현재 FCM 토큰 형식 기준 여유 있는
+  길이로 가정 — 실제 길이는 구현 시 재확인)
+- `updated_at` — 마지막으로 등록/갱신된 시각(등록 시마다 갱신, `@UpdateTimestamp`)
+
+### Flyway 마이그레이션
+- `V9__add_notification.sql`(1단계) — `notification` 테이블 생성
+- `V10__add_device_token.sql`(2단계) — `device_token` 테이블 생성 + `user_id` UNIQUE 제약
+
+(정확한 V 번호는 구현 착수 시점에 재확인 — `outing`의 "번호는 사전 예약이 아니라 구현
+순서대로 확정" 원칙과 동일.)
+
+---
+
+## 엔드포인트
+
+### 1단계 (메인, 인앱 알림함)
+
+#### 1. `GET /api/v1/notifications?page=&size=` — 본인 알림 목록 조회
+**권한**: 인증된 사용자 누구나(본인 것만)
+
+**요청**: `page`(선택, 기본 0), `size`(선택, 기본 20, 1~100 — 기존 `outing` 목록 조회
+API와 동일한 페이지네이션 파라미터/제약 재사용)
+
+**응답** (`200 OK`)
+```json
+{
+  "success": true,
+  "data": {
+    "content": [
+      {
+        "id": 501,
+        "title": "외출증이 승인되었습니다",
+        "body": "김선생님이 12:30 외출을 승인했어요.",
+        "type": "OUTING_APPROVED",
+        "isRead": false,
+        "createdAt": "2026-08-14T12:29:10"
+      }
+    ],
+    "page": 0,
+    "size": 20,
+    "totalElements": 1,
+    "totalPages": 1,
+    "hasNext": false
+  },
+  "message": "알림 목록을 조회했습니다.",
+  "code": null
+}
+```
+
+**구현 로직**
+1. `notificationRepository.findByUserIdOrderByCreatedAtDesc(...)`를 페이지네이션 조회
+   (`outing`의 `PageResponse` 재사용 — 신규 페이지 응답 타입 만들지 않음)
+2. DTO 변환 반환
+
+**에러**: `page`/`size` 범위 벗어남 → `400`(`outing`의 `INVALID_PAGE_PARAMS`와 같은 성격,
+번호는 구현 시 확정)
+
+---
+
+#### 2. `PATCH /api/v1/notifications/{id}/read` — 알림 읽음 처리
+**권한**: 그 알림의 수신자 본인
+
+**요청**: 바디 없음
+
+**응답** (`200 OK`) — 바디 최소화
+```json
+{ "success": true, "data": null, "message": "알림을 읽음 처리했습니다.", "code": null }
+```
+
+**구현 로직**
+1. `id`로 `Notification` 조회, 없으면 `404`
+2. `principal.userId() == notification.getUserId()` 확인(소유권), 아니면 `403`
+3. `is_read = true`로 갱신(이미 `true`여도 그대로 `200` — 멱등)
+
+**에러**
+- 본인 알림이 아님 → `403`
+- 존재하지 않는 `id` → `404`
+
+---
+
+#### 3. `PATCH /api/v1/notifications/read-all` — 알림 모두 읽음 처리
+**권한**: 인증된 사용자 누구나(본인 것만)
+
+**요청**: 바디 없음
+
+**응답** (`200 OK`)
+```json
+{ "success": true, "data": null, "message": "모든 알림을 읽음 처리했습니다.", "code": null }
+```
+
+**구현 로직**: `notificationRepository`에 벌크 갱신 쿼리(`@Modifying @Query("UPDATE
+Notification n SET n.isRead = true WHERE n.userId = :userId AND n.isRead = false")`)를
+추가해 한 번에 처리한다. 읽지 않은 알림을 하나씩 불러와 `save()`하는 방식(N+1)은 쓰지
+않는다 — 2번 엔드포인트(단건 읽음)와 달리 이 엔드포인트는 애초에 "여러 건을 한 번에"가
+목적이라 벌크 쿼리가 자연스럽다. 읽지 않은 알림이 원래 0건이어도 그대로 `200`(멱등).
+
+**에러**: 없음(항상 성공 — 인증되지 않은 요청만 `401`).
+
+---
+
+#### 4. `GET /api/v1/notifications/unread-count` — 안 읽은 알림 개수 조회
+**권한**: 인증된 사용자 누구나(본인 것만)
+
+**요청**: 파라미터 없음
+
+**응답** (`200 OK`)
+```json
+{ "success": true, "data": { "unreadCount": 3 }, "message": "안 읽은 알림 개수를 조회했습니다.", "code": null }
+```
+
+**구현 로직**: `notificationRepository.countByUserIdAndIsReadFalse(principal.userId())` →
+단순 `COUNT` 쿼리 하나. 메인 화면(홈)에서 "새 알림 있음" 뱃지/점 표시에 쓰는 용도 —
+가볍게 자주 호출될 수 있어(앱 진입/포그라운드 복귀 시마다) 목록 전체를 안 불러오고
+개수만 반환하는 전용 엔드포인트로 분리했다.
+
+**에러**: 없음(인증되지 않은 요청만 `401`).
+
+---
+
+### 2단계 (보조, FCM 푸시)
+
+#### 5. `PUT /api/v1/notifications/device-token` — 디바이스 토큰 등록/갱신
+**권한**: 인증된 사용자 누구나
+
+**요청**
+```json
+{ "fcmToken": "dGhpcyBpcyBhIGZha2UgZmNtIHRva2Vu..." }
+```
+- `fcmToken`: 필수, not blank, 최대 255자
+
+**응답** (`200 OK`)
+```json
+{ "success": true, "data": null, "message": "디바이스 토큰이 등록되었습니다.", "code": null }
+```
+
+**구현 로직**: `deviceTokenRepository.findByUserId(principal.userId())`로 기존 행 조회 →
+있으면 `fcmToken`/`updatedAt` 갱신, 없으면 신규 생성(upsert). `PUT`을 쓰는 이유: "이
+사용자의 현재 디바이스 토큰을 이 값으로 둔다"는 멱등 동작이라 `POST`보다 의미에 맞는다.
+
+**에러**: `fcmToken` 빈 값/255자 초과 → `400` `COMMON_001`
+
+---
+
+#### 6. `DELETE /api/v1/notifications/device-token` — 디바이스 토큰 삭제
+**권한**: 인증된 사용자 누구나(본인 것만)
+
+**요청**: 바디 없음
+
+**응답** (`200 OK`)
+```json
+{ "success": true, "data": null, "message": "디바이스 토큰이 삭제되었습니다.", "code": null }
+```
+
+**구현 로직**: `deviceTokenRepository.deleteByUserId(principal.userId())`. **멱등 처리** —
+원래 없었어도 `404`가 아니라 `200`(로그아웃 시점에 "혹시 몰라 항상 호출"하는 식의 사용을
+편하게 만든다).
+
+---
+
+## 공통 발송 모듈 (`NotificationService`)
+
+### 1단계 구현
+```java
+@Service
+@RequiredArgsConstructor
+public class NotificationService {
+
+  private final NotificationRepository notificationRepository;
+
+  public void send(Long userId, String title, String body, String type) {
+    Notification notification = Notification.builder()
+        .userId(userId).title(title).body(body).type(type).isRead(false).build();
+    notificationRepository.save(notification); // 저장 실패는 그대로 예외 전파(정책 가정 참고)
+  }
+}
+```
+다른 도메인(`outing`, `schoolcamp`)은 이 빈을 주입받아 `notificationService.send(userId,
+"외출증이 승인되었습니다", "...", "OUTING_APPROVED")`처럼 호출하기만 하면 된다.
+
+### 2단계에서의 확장 (FCM 추가, 시그니처 불변)
+```java
+public void send(Long userId, String title, String body, String type) {
+  Notification notification = Notification.builder()
+      .userId(userId).title(title).body(body).type(type).isRead(false).build();
+  notificationRepository.save(notification);
+
+  deviceTokenRepository.findByUserId(userId).ifPresent(deviceToken -> {
+    try {
+      Message message = Message.builder()
+          .setToken(deviceToken.getFcmToken())
+          .setNotification(FcmNotification.builder().setTitle(title).setBody(body).build())
+          .build();
+      firebaseMessagingProvider.getObject().send(message);
+    } catch (FirebaseMessagingException e) {
+      if (e.getMessagingErrorCode() == MessagingErrorCode.UNREGISTERED) {
+        deviceTokenRepository.deleteByUserId(userId);
+      } else {
+        log.error("FCM 발송 실패(userId={})", userId, e);
+      }
+    }
+  });
+}
+```
+**호출부(3단계, `outing`/`schoolcamp`)는 2단계가 언제 구현되든 코드를 전혀 고칠 필요가
+없다** — `send(...)` 시그니처가 1단계부터 고정이고, 2단계는 그 내부 구현만 확장한다(
+`api-design.md` 원칙 6 "하위 호환성"과 같은 결).
+
+### 신규 의존성(2단계) — Firebase Admin SDK
+`build.gradle`에 `implementation 'com.google.firebase:firebase-admin:9.x'`(정확한 최신
+GA 버전은 2단계 구현 시 재확인).
+
+### `FirebaseProperties`(2단계, `@ConfigurationProperties(prefix = "firebase")`)
+`R2Properties`/`NeisProperties`와 같은 패턴 — 로컬 값은 `application-dev.yml`(git 미포함).
+- `credentialsJson` — Firebase 서비스 계정 키 JSON 전체를 문자열 하나로(`@NotBlank`).
+  파일 경로 방식 대신 문자열 방식을 택한 이유: 기존 시크릿(R2/JWT/NEIS)이 전부 "환경변수
+  문자열 하나" 패턴이라 일관성을 유지한다.
+
+> ⚠️ **`@Lazy`가 필요한 이유(2단계, CI `contextLoads()` 보호)**: `GoogleCredentials.
+> fromStream(...)`은 빈 생성 시점에 문자열을 실제로 파싱해 RSA 개인키까지 구성하므로,
+> R2/NEIS처럼 `dummy-...` 더미 문자열로는 컨텍스트 로딩 자체가 실패한다. `FirebaseApp`/
+> `FirebaseMessaging` 빈을 `@Lazy`로, `NotificationService`는 `FirebaseMessaging`을
+> `ObjectProvider<FirebaseMessaging>`로 받아 실제 발송 시점에만 꺼내 쓰게 하면, 3단계
+> 호출부가 아직 없거나 CI처럼 더미 값만 있는 환경에서도 빈이 만들어지지 않아 안전하다.
+> CI에는 `FIREBASE_CREDENTIALS_JSON: '{}'`(비어있지 않은 문자열이면 충분) 더미 값을
+> 추가한다.
+
+---
+
+## 도메인 연동 지점 (참고, 각 도메인 마스터 기획서가 원 출처)
+아래 두 지점(3단계)은 이 문서에서 새로 설계하지 않는다 — 이미 각 도메인 마스터 기획서에
+"무엇을, 언제, 누구에게" 보낼지가 정의되어 있고, `NotificationService.send(...)`가
+준비되면 그대로 호출하기만 하면 된다.
+
+- **`outing` 도메인** — 승인/거절 결과 알림, 복귀 리마인더(위치 기반 + 시간 초과 감지),
+  담당 선생님/선도부에게 미복귀 알림. 상세 로직:
+  [`1_outing-domain.md`의 "복귀 리마인더 (백그라운드 스케줄러)"](../outing/1_outing-domain.md#복귀-리마인더-백그라운드-스케줄러)
+- **`schoolcamp` 도메인** — 팀원으로 초대됐을 때 알림, 오늘 스쿨캠핑인데 점심 외출 미신청
+  시 리마인더. 상세 로직:
+  [`1_schoolcamp-domain.md`의 "외출 도메인 연동 — 리마인더"](../schoolcamp/1_schoolcamp-domain.md#외출-도메인-연동--리마인더)
+
+## 에러 코드 (`NotificationErrorCode`, 신규 패키지 `notification`)
+1단계부터 소유권 체크(읽음 처리 2번 엔드포인트)가 있어 전용 코드가 필요하다 — `outing`/
+`user` 등 기존 도메인과 같은 `{DOMAIN}_NNN` 네이밍을 따른다.
+1. `NOTIFICATION_001` (404) — 알림을 찾을 수 없습니다
+2. `NOTIFICATION_002` (403) — 본인 알림만 읽음 처리할 수 있습니다
+3. 목록 조회 페이지 파라미터 오류 코드(번호 미정, 400) — `outing`의
+   `INVALID_PAGE_PARAMS`와 동일 성격, 구현 시 확정
+
+모두 읽음 처리(3번 엔드포인트)/안 읽은 개수 조회(4번 엔드포인트)는 대상을 `id`로 특정하지
+않고 항상 호출자 본인 기준이라 소유권 위반(403)/존재하지 않음(404) 케이스 자체가 없다 —
+전용 코드 불필요.
+
+2단계(디바이스 토큰)는 유일한 실패 케이스(빈 값 검증, 인증 실패)가 이미 있는
+`CommonErrorCode`로 충분해 전용 코드가 필요 없다.
+
+## 공통 구현 고려사항
+- **저장(1단계)과 발송(2단계 FCM)의 실패 처리를 다르게 가져간다** — 위 "정책 가정" 참고.
+  저장 실패는 전파, FCM 실패는 삼킴. 이 비대칭이 이 도메인의 핵심 설계 결정이다.
+- **`send(...)` 시그니처는 1단계에서 확정하고 2단계는 내부만 확장**한다 — 위 "공통 발송
+  모듈" 절 참고. 호출하는 도메인 코드가 단계와 무관하게 안정적으로 동작하게 하기 위함.
+- **`@Lazy` + `ObjectProvider<FirebaseMessaging>`**는 2단계에서만 필요(1단계는 Firebase
+  의존성 자체가 없어 해당 없음).
+- **`type` 필드는 자유 문자열**이라 `notification` 패키지가 다른 도메인의 enum을 참조하지
+  않는다 — 순수하게 저장/전달만 한다(위 "도메인 모델" 참고).
+- **시크릿 관리**(2단계)는 R2/JWT/NEIS와 동일하게 `application-dev.yml`(git 미포함) + CI
+  환경변수 더미 값 패턴을 따른다.
+
+## 아직 결정 안 된 것 (리뷰 필요)
+- **알림 목록 보존 기간**(무기한 저장 vs 일정 기간 후 삭제) — 개인정보/저장 공간 관점에서
+  정책 필요.
+- **다중 기기 지원 여부**(2단계) — 지금은 사용자당 토큰 1개. 여러 기기 동시 지원이
+  필요해지면 `device_token`을 `user_id` UNIQUE에서 1:N으로 바꾸는 마이그레이션 필요.
+- **`fcm_token` 컬럼 길이(255자 가정, 2단계)** — 실제 FCM 토큰 최대 길이를 구현 시 재확인.
+- **Firebase 프로젝트/서비스 계정 실제 발급(2단계)** — 실제 Firebase 콘솔 작업은 2단계
+  착수 시점에 진행(관리자 계정 필요 — 보스 확인 필요할 수 있음).
+- **`outing`/`schoolcamp` 연동(3단계) 착수 순서** — 각 도메인 진행 상황에 맞춰 그때그때
+  판단.

--- a/docs/domain/notification/37-notification-inbox.md
+++ b/docs/domain/notification/37-notification-inbox.md
@@ -1,0 +1,230 @@
+# #37 알림 인프라 도입 (1단계) — 인앱 알림함 저장/조회/읽음 처리
+
+관련 이슈: [#37 알림 시스템 도입 (외출증 승인/거절, 스쿨캠핑 리마인더 등)](https://github.com/GBSW-ReMake/GONE-server-V1/issues/37)
+전체 도메인 마스터 기획서: [1_notification-domain.md](./1_notification-domain.md) — 이
+문서는 그중 **"1단계(메인): 인앱 알림함"** 만 좁힌 것. FCM 푸시(2단계)와 `outing`/
+`schoolcamp` 실제 연동(3단계)은 이번 이슈 범위 밖 — 마스터 기획서의 "단계 구분" 절 참고.
+
+## 개요/목적
+알림 도메인의 메인은 "서버가 알림을 저장하고 사용자가 목록으로 조회/읽음 처리하는 인앱
+알림함"이다(FCM 실시간 푸시는 그 위에 얹는 보조 수단 — 마스터 기획서 "개요/목적"의
+"설계 리뷰로 정정된 우선순위" 참고). 이 이슈는 그 메인 기능만 구현한다:
+
+1. `Notification` 엔티티 + 저장 담당 `NotificationService.send(...)`
+2. 본인 알림 목록 조회 API(페이지네이션)
+3. 알림 읽음 처리 API(단건 + 모두 읽음 일괄)
+4. 안 읽은 알림 개수 조회 API(메인 화면 뱃지 표시용)
+
+Firebase/FCM 관련 작업은 전혀 포함하지 않는다 — 이 이슈는 외부 종속성 없이 DB만으로
+완결된다(마스터 기획서 "개요/목적"의 근거 2 참고). 아직 이 `send(...)`를 실제로 호출하는
+곳(외출증 승인 등)은 없다 — 3단계 후속 이슈에서 연결한다.
+
+## 엔드포인트
+
+### 1. `GET /api/v1/notifications?page=&size=` — 본인 알림 목록 조회
+**권한**: 인증된 사용자 누구나(본인 것만, `principal.userId()` 기준 — 요청 파라미터로
+대상 지정 불가)
+
+**요청**: `page`(선택, 기본 0), `size`(선택, 기본 20, 1~100)
+
+**응답** (`200 OK`)
+```json
+{
+  "success": true,
+  "data": {
+    "content": [
+      {
+        "id": 501,
+        "title": "테스트 알림 제목",
+        "body": "테스트 알림 본문입니다.",
+        "type": "TEST",
+        "isRead": false,
+        "createdAt": "2026-08-14T12:29:10"
+      }
+    ],
+    "page": 0,
+    "size": 20,
+    "totalElements": 1,
+    "totalPages": 1,
+    "hasNext": false
+  },
+  "message": "알림 목록을 조회했습니다.",
+  "code": null
+}
+```
+
+**구현 로직**
+1. `page`/`size` 검증(`outing`의 `validatePageParams`와 동일 규칙: `page >= 0`,
+   `1 <= size <= 100`)
+2. `notificationRepository.findByUserIdOrderByCreatedAtDesc(principal.userId())` 조회
+3. `PageResponse.of(...)`로 페이지 잘라 DTO 변환 반환(`outing`의 `getMyRequests`와 동일
+   패턴 — 신규 페이지 응답 타입 만들지 않고 기존 `PageResponse` 재사용)
+
+**에러**
+- `page < 0` 또는 `size`가 1~100 범위 밖 → `400` `NOTIFICATION_003`(가칭, 아래 "에러 코드"
+  참고)
+
+---
+
+### 2. `PATCH /api/v1/notifications/{id}/read` — 알림 읽음 처리
+**권한**: 그 알림의 수신자 본인
+
+**요청**: 바디 없음
+
+**응답** (`200 OK`)
+```json
+{ "success": true, "data": null, "message": "알림을 읽음 처리했습니다.", "code": null }
+```
+
+**구현 로직**
+1. `id`로 `Notification` 조회, 없으면 `404`
+2. `principal.userId() == notification.getUserId()` 확인(소유권), 아니면 `403`
+3. `is_read = true`로 갱신 후 저장(이미 `true`여도 그대로 `200` 반환 — 멱등, 재요청이
+   실패로 취급될 이유가 없다)
+
+**에러**
+- 본인 알림이 아님 → `403` `NOTIFICATION_002`
+- 존재하지 않는 `id` → `404` `NOTIFICATION_001`
+
+---
+
+### 3. `PATCH /api/v1/notifications/read-all` — 알림 모두 읽음 처리
+**권한**: 인증된 사용자 누구나(본인 것만)
+
+**요청**: 바디 없음
+
+**응답** (`200 OK`)
+```json
+{ "success": true, "data": null, "message": "모든 알림을 읽음 처리했습니다.", "code": null }
+```
+
+**구현 로직**: `NotificationRepository`에 벌크 갱신 쿼리(`@Modifying @Query("UPDATE
+Notification n SET n.isRead = true WHERE n.userId = :userId AND n.isRead = false")`)를
+추가해 한 번에 처리한다 — 읽지 않은 알림을 하나씩 불러와 `save()`하는 N+1 방식은 쓰지
+않는다. 읽지 않은 알림이 원래 0건이어도 그대로 `200`(멱등).
+
+**에러**: 없음(인증되지 않은 요청만 `401`).
+
+---
+
+### 4. `GET /api/v1/notifications/unread-count` — 안 읽은 알림 개수 조회
+**권한**: 인증된 사용자 누구나(본인 것만)
+
+**요청**: 파라미터 없음
+
+**응답** (`200 OK`)
+```json
+{ "success": true, "data": { "unreadCount": 3 }, "message": "안 읽은 알림 개수를 조회했습니다.", "code": null }
+```
+
+**구현 로직**: `notificationRepository.countByUserIdAndIsReadFalse(principal.userId())` →
+단순 `COUNT` 쿼리 하나. 메인 화면(홈)에서 "새 알림 있음" 뱃지/점 표시에 쓰는 용도 —
+앱 진입/포그라운드 복귀 시마다 자주 호출될 수 있어 목록 전체가 아니라 개수만 반환하는
+전용 엔드포인트로 분리했다.
+
+**에러**: 없음(인증되지 않은 요청만 `401`).
+
+---
+
+## 공통 발송 모듈 — `NotificationService` (1단계)
+```java
+@Service
+@RequiredArgsConstructor
+public class NotificationService {
+
+  private final NotificationRepository notificationRepository;
+
+  public void send(Long userId, String title, String body, String type) {
+    Notification notification = Notification.builder()
+        .userId(userId)
+        .title(title)
+        .body(body)
+        .type(type)
+        .isRead(false)
+        .build();
+    notificationRepository.save(notification);
+  }
+}
+```
+- 저장 실패는 그대로 예외 전파한다(삼키지 않음) — 알림 저장은 이 모듈의 핵심 책임이라,
+  호출자(향후 `outing`/`schoolcamp`) 트랜잭션과 함께 롤백되는 게 오히려 맞는 동작이다(
+  마스터 기획서 "정책 가정" 참고).
+- `type`은 자유 문자열(예: `"OUTING_APPROVED"`) — `notification` 패키지가 다른 도메인의
+  enum을 참조하지 않기 위해 의도적으로 비타입 문자열로 둔다.
+- **이번 이슈에는 이 메서드를 실제로 호출하는 곳이 없다** — 단위 테스트로만 동작을
+  검증하고, `outing`/`schoolcamp` 연동은 3단계 후속 이슈에서 진행한다. 컨트롤러 없는
+  서비스만 먼저 만들어두는 게 이상해 보일 수 있으나, 마스터 기획서가 이미 "저장 →
+  FCM(2단계) → 실제 호출(3단계)" 순서로 계획을 명시해뒀다.
+
+## 데이터 모델 변경
+### `Notification` 엔티티 (`notification` 테이블, 신규)
+- `id` — 내부 PK
+- `user_id` — 수신자(`User` FK)
+- `title` — 알림 제목(`VARCHAR(100)`, 가정)
+- `body` — 알림 본문(`VARCHAR(500)`, 가정)
+- `type` — 발송 도메인이 붙이는 분류 태그(`VARCHAR(50)`, nullable)
+- `is_read` — 읽음 여부(`BOOLEAN NOT NULL DEFAULT false`)
+- `created_at` — 발송(저장) 시각(`@CreationTimestamp`)
+
+인덱스: `(user_id, created_at)` — 목록 조회가 이 조합으로 정렬/필터.
+
+### Flyway 마이그레이션
+`V9__add_notification.sql`(신규) — `notification` 테이블 생성.
+
+## 영향 받는 기존 코드
+- `SecurityConfig`: `.requestMatchers("/api/v1/notifications/**").authenticated()` 추가.
+- 신규 패키지 `notification`(`controller`/`dto`/`entity`/`repository`/`service`/
+  `exception`) — 이 프로젝트에 새 도메인 패키지가 추가되는 사례(`outing`/`schoolcamp`와
+  같은 하위 폴더 구조).
+- 신규 테스트: `NotificationServiceTest`(저장 성공, `type` null 허용), `NotificationController
+  Test`(목록 조회 페이지네이션, 읽음 처리 성공/403/404, 모두 읽음 처리, 안 읽은 개수 조회,
+  페이지 파라미터 검증 400).
+
+## 에러 코드 (`NotificationErrorCode`, 신규 패키지 `notification`)
+1. `NOTIFICATION_001` (404) — 알림을 찾을 수 없습니다
+2. `NOTIFICATION_002` (403) — 본인 알림만 처리할 수 있습니다
+3. `NOTIFICATION_003` (400) — 페이지 조회 조건이 올바르지 않습니다(`outing`의
+   `INVALID_PAGE_PARAMS`와 동일 성격 — 별도 도메인이라 코드는 새로 받는다)
+
+모두 읽음 처리(3번)/안 읽은 개수 조회(4번)는 대상을 `id`로 특정하지 않고 항상 호출자
+본인 기준이라 소유권 위반(403)/존재하지 않음(404) 케이스 자체가 없다 — 전용 코드 불필요.
+
+## API 설계 6원칙 체크
+1. **한 가지를 잘하기**: 저장/조회/읽음 처리만 책임진다. FCM 발송, 실제 도메인 연동은
+   후속 이슈로 분리했다.
+2. **빠르게 시작하기**: 요청/응답 예시 위에 명시.
+3. **일관성**: `ApiResponse`/`PageResponse`/`CustomException` 패턴을 `outing`과 동일하게
+   재사용. 페이지네이션 파라미터 이름/기본값/제약도 `outing`과 동일하게 맞췄다.
+4. **의미 있는 오류**: 소유권 위반(403)과 존재하지 않음(404)을 분리 — 원인이 다르므로
+   `api-design.md` 원칙 4에 부합.
+5. **확장성/성능**: 목록 조회에 페이지네이션 적용(무제한 조회 금지). `(user_id,
+   created_at)` 인덱스로 목록 조회 성능 확보.
+6. **하위 호환성**: 완전히 새로운 도메인이라 기존 API에 영향 없음. `NotificationService.
+   send(...)` 시그니처는 2단계(FCM)에서도 그대로 유지할 계획이라(마스터 기획서 참고)
+   향후 확장에도 호출자 영향이 없다.
+
+## 리스크 및 고려사항
+- **아직 아무도 호출하지 않는 서비스를 먼저 만드는 것에 대한 우려**: `send(...)`의 실제
+  호출부가 이번 이슈에 없어, 이 자체만으로는 사용자가 체감할 기능이 없다(테스트로만
+  검증). 다만 (1) 다음 이슈(외출증 알림 연동 등)에서 바로 재사용 가능한 상태로 만들어두는
+  것이 목적이고, (2) 조회/읽음 API는 `Notification` 데이터가 있어야 QA 가능하므로 QA
+  시점에는 테스트 데이터를 직접 INSERT하거나 별도 테스트용 임시 엔드포인트/단위 테스트로
+  검증한다(아래 "테스트 방법" 참고).
+- **알림 목록 보존 기간 미정** — 마스터 기획서 "아직 결정 안 된 것"에 남김, 이번 이슈에서
+  삭제/보존 정책을 구현하지 않는다(무기한 저장).
+- **모두 읽음 처리의 벌크 쿼리 vs 단건 반복**: 읽지 않은 알림 수가 아주 많은 사용자가
+  있다면 벌크 `UPDATE` 한 번이 단건 반복보다 항상 유리하다 — 별도 트레이드오프 없음.
+
+## 테스트 방법
+이번 이슈는 `send(...)`의 실제 호출부가 없어 Postman으로 "알림이 생성되는 흐름"까지는
+검증할 수 없다. 아래 순서로 진행한다.
+
+1. 단위/통합 테스트(`NotificationServiceTest`)로 `send(...)` 저장 동작 검증(정상 저장,
+   `type` null 허용 등)
+2. 로컬 DB에 테스트 알림을 여러 건 직접 `INSERT`한 뒤, Postman으로 아래를 검증
+   - 목록 조회(정상/페이지 파라미터 400)
+   - 단건 읽음 처리(정상/403/404)
+   - 모두 읽음 처리 → 이후 목록 조회 시 전부 `isRead: true`로 바뀌었는지 확인
+   - 안 읽은 개수 조회 → 읽음 처리 전후로 값이 정확히 줄어드는지 확인
+3. `./gradlew build`, `./gradlew test`, `./gradlew checkstyleMain` 로컬 통과 확인 + CI
+   통과 확인

--- a/src/main/java/com/remake/gone/common/security/JwtProperties.java
+++ b/src/main/java/com/remake/gone/common/security/JwtProperties.java
@@ -8,14 +8,19 @@ import org.springframework.validation.annotation.Validated;
 /**
  * JWT 발급/검증에 필요한 설정 값.
  *
- * @param secret                 서명에 사용할 비밀키 (HMAC-SHA256, Base64 인코딩 문자열)
+ * <p>Access Token과 Refresh Token은 서로 다른 서명 키를 쓴다(#52) — 한쪽 키가 유출돼도
+ * 반대쪽 토큰은 위조할 수 없도록 피해 범위를 분리하기 위함이다.
+ *
+ * @param accessTokenSecret      Access Token 서명에 사용할 비밀키 (HMAC-SHA256, Base64 인코딩 문자열)
+ * @param refreshTokenSecret     Refresh Token 서명에 사용할 비밀키 (HMAC-SHA256, Base64 인코딩 문자열)
  * @param accessTokenExpiration  Access Token 만료 시간(밀리초)
  * @param refreshTokenExpiration Refresh Token 만료 시간(밀리초)
  */
 @ConfigurationProperties(prefix = "jwt")
 @Validated
 public record JwtProperties(
-    @NotBlank String secret,
+    @NotBlank String accessTokenSecret,
+    @NotBlank String refreshTokenSecret,
     @NotNull Long accessTokenExpiration,
     @NotNull Long refreshTokenExpiration
 ) {}

--- a/src/main/java/com/remake/gone/common/security/JwtProvider.java
+++ b/src/main/java/com/remake/gone/common/security/JwtProvider.java
@@ -129,9 +129,17 @@ public class JwtProvider {
   }
 
   private SecretKey key(String tokenType) {
-    String secret = TOKEN_TYPE_ACCESS.equals(tokenType)
-        ? jwtProperties.accessTokenSecret()
-        : jwtProperties.refreshTokenSecret();
+    String secret;
+    if (TOKEN_TYPE_ACCESS.equals(tokenType)) {
+      secret = jwtProperties.accessTokenSecret();
+    } else if (TOKEN_TYPE_REFRESH.equals(tokenType)) {
+      secret = jwtProperties.refreshTokenSecret();
+    } else {
+      // 알 수 없는 tokenType이 조용히 refresh 키로 처리되는 걸 막는다(#52 코드 리뷰) —
+      // 이 메서드는 클래스 내부의 TOKEN_TYPE_* 상수만 넘겨받아야 하므로, 여기 도달하면
+      // 호출부 실수(예: 세 번째 토큰 종류를 상수 재사용 없이 추가)를 뜻한다.
+      throw new IllegalArgumentException("unknown token type: " + tokenType);
+    }
     return Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
   }
 }

--- a/src/main/java/com/remake/gone/common/security/JwtProvider.java
+++ b/src/main/java/com/remake/gone/common/security/JwtProvider.java
@@ -15,10 +15,11 @@ import lombok.RequiredArgsConstructor;
 /**
  * Access/Refresh Token의 발급과 검증을 담당한다.
  *
- * <p>두 토큰 모두 같은 서명 키를 쓰지만, {@code tokenType} 클레임으로 종류를 구분한다.
- * Access Token으로 재발급을 시도하거나 그 반대로 쓰는 것을 막기 위함이다. 역할(role) 정보는
- * Access Token에만 담는다 — Refresh Token에 담으면 역할이 바뀐 뒤에도 재발급 때마다 옛 역할이
- * 계속 실려 나가기 때문이다.
+ * <p>두 토큰은 서로 다른 서명 키를 쓴다(#52) — 한쪽 키가 유출돼도 반대쪽 토큰까지 위조할 수
+ * 없도록 피해 범위를 분리한다. {@code tokenType} 클레임도 함께 남겨 종류를 구분하는데, 이제는
+ * 서명 검증(다른 키로 서명된 토큰은 이 단계에서부터 실패)이 1차 방어선이고 클레임 검사는
+ * 그 위에 남겨두는 안전망이다. 역할(role) 정보는 Access Token에만 담는다 — Refresh Token에
+ * 담으면 역할이 바뀐 뒤에도 재발급 때마다 옛 역할이 계속 실려 나가기 때문이다.
  *
  * <p>{@code @Component}가 아니라 {@code SecurityConfig}의 {@code @Bean} 메서드로 등록한다.
  * {@code @WebMvcTest} 슬라이스는 {@code Filter}/{@code Controller} 등 정해진 역할이 아닌 일반
@@ -58,7 +59,7 @@ public class JwtProvider {
         .claim(CLAIM_ROLES, roleCodes)
         .issuedAt(now)
         .expiration(new Date(now.getTime() + jwtProperties.accessTokenExpiration()))
-        .signWith(key())
+        .signWith(key(TOKEN_TYPE_ACCESS))
         .compact();
   }
 
@@ -75,7 +76,7 @@ public class JwtProvider {
         .claim(CLAIM_TOKEN_TYPE, TOKEN_TYPE_REFRESH)
         .issuedAt(now)
         .expiration(new Date(now.getTime() + jwtProperties.refreshTokenExpiration()))
-        .signWith(key())
+        .signWith(key(TOKEN_TYPE_REFRESH))
         .compact();
   }
 
@@ -110,13 +111,16 @@ public class JwtProvider {
   }
 
   private Claims claims(String token, String expectedTokenType) {
+    // 기대하는 토큰 종류의 키로 먼저 검증한다 — 다른 종류로 서명된 토큰(예: Refresh Token
+    // 키로 서명된 토큰을 Access Token으로 파싱 시도)은 아래 클레임 검사까지 가지도 못하고
+    // 여기서 서명 불일치로 곧바로 실패한다.
     Claims claims = Jwts.parser()
-        .verifyWith(key())
+        .verifyWith(key(expectedTokenType))
         .build()
         .parseSignedClaims(token)
         .getPayload();
 
-    // Access Token을 재발급에, Refresh Token을 인증에 쓰는 등 용도 밖 사용을 막는다.
+    // 서명 키가 우연히 같아지는 등의 회귀를 잡는 안전망으로 클레임 검사도 유지한다.
     if (!expectedTokenType.equals(claims.get(CLAIM_TOKEN_TYPE, String.class))) {
       throw new JwtException("expected token type " + expectedTokenType + " but was different");
     }
@@ -124,7 +128,10 @@ public class JwtProvider {
     return claims;
   }
 
-  private SecretKey key() {
-    return Keys.hmacShaKeyFor(jwtProperties.secret().getBytes(StandardCharsets.UTF_8));
+  private SecretKey key(String tokenType) {
+    String secret = TOKEN_TYPE_ACCESS.equals(tokenType)
+        ? jwtProperties.accessTokenSecret()
+        : jwtProperties.refreshTokenSecret();
+    return Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
   }
 }

--- a/src/test/java/com/remake/gone/common/security/JwtProviderTest.java
+++ b/src/test/java/com/remake/gone/common/security/JwtProviderTest.java
@@ -4,7 +4,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
 import java.util.Set;
+import javax.crypto.SecretKey;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -20,14 +25,34 @@ class JwtProviderTest {
 
   private static final Long USER_ID = 1L;
   private static final Set<String> ROLES = Set.of("STUDENT", "DISCIPLINE");
+  private static final String ACCESS_SECRET =
+      "test-access-secret-key-for-jwt-provider-unit-test-32b+";
+  private static final String REFRESH_SECRET =
+      "test-refresh-secret-key-for-jwt-provider-unit-test-32b+";
 
   private JwtProvider jwtProvider;
 
   @BeforeEach
   void setUp() {
-    JwtProperties properties = new JwtProperties(
-        "test-secret-key-for-jwt-provider-unit-test-32bytes+", 1_800_000L, 1_209_600_000L);
+    JwtProperties properties =
+        new JwtProperties(ACCESS_SECRET, REFRESH_SECRET, 1_800_000L, 1_209_600_000L);
     jwtProvider = new JwtProvider(properties);
+  }
+
+  /**
+   * {@code tokenType} 클레임은 의도한 값으로 두되, 서명 키만 다른(반대쪽) 키를 쓰는 위조
+   * 토큰을 만든다. 클레임 검사가 아니라 서명 검증 자체가 막아내는지를 확인하기 위한 헬퍼다.
+   */
+  private String forgeTokenWithClaimTypeButWrongKey(String claimTokenType, String wrongSecret) {
+    SecretKey key = Keys.hmacShaKeyFor(wrongSecret.getBytes(StandardCharsets.UTF_8));
+    Date now = new Date();
+    return Jwts.builder()
+        .subject(String.valueOf(USER_ID))
+        .claim("tokenType", claimTokenType)
+        .issuedAt(now)
+        .expiration(new Date(now.getTime() + 1_800_000L))
+        .signWith(key)
+        .compact();
   }
 
   @Nested
@@ -67,10 +92,20 @@ class JwtProviderTest {
     @Test
     @DisplayName("서명이 다른 키로 발급된 토큰은 거부한다")
     void rejectsTokenSignedWithDifferentKey() {
-      JwtProvider otherProvider = new JwtProvider(
-          new JwtProperties("different-secret-key-for-forged-token-test-32b", 1_800_000L,
-              1_209_600_000L));
+      JwtProvider otherProvider = new JwtProvider(new JwtProperties(
+          "different-access-secret-key-for-forged-token-test-32b",
+          "different-refresh-secret-key-for-forged-token-test-32b",
+          1_800_000L, 1_209_600_000L));
       String forgedToken = otherProvider.createAccessToken(USER_ID, ROLES);
+
+      assertThatThrownBy(() -> jwtProvider.parseAccessToken(forgedToken))
+          .isInstanceOf(JwtException.class);
+    }
+
+    @Test
+    @DisplayName("#52: tokenType 클레임은 access여도 Refresh Token 키로 서명됐으면 거부한다")
+    void rejectsAccessClaimSignedWithRefreshKey() {
+      String forgedToken = forgeTokenWithClaimTypeButWrongKey("access", REFRESH_SECRET);
 
       assertThatThrownBy(() -> jwtProvider.parseAccessToken(forgedToken))
           .isInstanceOf(JwtException.class);
@@ -95,6 +130,15 @@ class JwtProviderTest {
       String accessToken = jwtProvider.createAccessToken(USER_ID, ROLES);
 
       assertThatThrownBy(() -> jwtProvider.getUserIdFromRefreshToken(accessToken))
+          .isInstanceOf(JwtException.class);
+    }
+
+    @Test
+    @DisplayName("#52: tokenType 클레임은 refresh여도 Access Token 키로 서명됐으면 거부한다")
+    void rejectsRefreshClaimSignedWithAccessKey() {
+      String forgedToken = forgeTokenWithClaimTypeButWrongKey("refresh", ACCESS_SECRET);
+
+      assertThatThrownBy(() -> jwtProvider.getUserIdFromRefreshToken(forgedToken))
           .isInstanceOf(JwtException.class);
     }
   }


### PR DESCRIPTION
## 관련 이슈
closes #52

## 작업 내용
Access Token과 Refresh Token이 같은 서명 키를 공유하던 것을 분리했다. 한쪽 키가
유출돼도 반대쪽 토큰은 위조할 수 없도록 피해 범위를 줄이기 위함이다(#51 dev EC2
CI/CD 시크릿 등록 작업 중 필요성이 확인돼 별도 이슈로 분리).

## 변경 사항 상세
- `JwtProperties`: `secret` 필드 하나를 `accessTokenSecret`/`refreshTokenSecret` 둘로
  분리(기존 `accessTokenExpiration`/`refreshTokenExpiration`과 네이밍 대칭).
- `JwtProvider`: `key()` → `key(String tokenType)`로 바꿔 토큰 종류에 맞는 키로
  서명/검증. 다른 종류로 서명된 토큰은 이제 서명 검증 단계에서부터 거부된다(기존
  `tokenType` 클레임 검사는 안전망으로 유지). 코드 리뷰 반영으로 알 수 없는
  `tokenType`이 들어오면 조용히 refresh 키로 처리되지 않고 즉시 예외를 던지도록
  명시적 분기 추가.
- `application-dev.yml`(로컬, git 미포함): `jwt.secret` 한 줄 → `access-token-secret`/
  `refresh-token-secret` 두 값(실제로 다른 값)으로 교체.
- `.github/workflows/ci.yml`: `JWT_SECRET` 더미 값 → `JWT_ACCESS_TOKEN_SECRET`/
  `JWT_REFRESH_TOKEN_SECRET` 두 개로 분리.
- `JwtProviderTest`: 생성자 호출부 갱신 + "tokenType 클레임은 맞지만 반대쪽 키로
  서명된 토큰은 거부한다" 위조 토큰 테스트 양방향 추가.
- 기획서/코드 리뷰/QA 문서: `docs/domain/auth/52-auth-jwt-secret-split.md` /
  `-code-review.md` / `-QA.md`.

기획서와 실제 구현 간 차이 없음 — 기획서에 정의된 설계 그대로 구현했고, 코드 리뷰에서
나온 Low 1건(알 수 없는 `tokenType` 처리)만 추가로 반영했다.

**후속 작업(이 PR 범위 아님)**: dev EC2 배포용 GitHub Secrets를 `JWT_SECRET` 1개에서
`JWT_ACCESS_TOKEN_SECRET`/`JWT_REFRESH_TOKEN_SECRET` 2개로 교체하는 작업은 #51 쪽에서
이 PR이 머지된 뒤 별도로 진행한다.

## 확인 사항
- [x] 로컬 빌드 통과 (`./gradlew build`)
- [x] Checkstyle 통과 (`./gradlew checkstyleMain`)
- [ ] CI(checkstyle, build-and-test) 통과 — PR 생성 후 GitHub Actions에서 확인
- [ ] (해당 시) Notion 기능정의서/기획 문서 반영 — 신규/변경 엔드포인트 없어 해당 없음
- [x] (해당 시) 관련 도메인 라벨 지정 (`domain:AUTH`)

추가로 실제 서버 + 로컬 Redis 기동 후 로그인→재발급(회전)→인증→옛 RT 재사용 차단→
AT/RT 교차 사용 차단→로그아웃까지 실제 HTTP 요청으로 전체 흐름을 재검증했다(QA 문서
참고).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Enhancements**
  * Access and refresh tokens now use separate signing secrets, improving token isolation.
  * Tokens signed with the wrong secret are rejected, and invalid token types are handled more safely.
  * Deployments must provide separate Base64-encoded secrets for access and refresh tokens.

* **Documentation**
  * Added design and implementation plans for in-app notifications.
  * Added QA and code review documentation covering the token-signing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->