### PR TITLE
fix: 서버 포트 9091 → 9090 변경

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -434,7 +434,7 @@ jobs:
             # 404를 반환할 수 있음) — 그래서 --fail(2xx/3xx만 성공)은 오탐을 낸다. 대신
             # "5xx가 아니면(=서버가 요청을 정상적으로 처리하고 있으면) 정상"으로 판정한다.
             for i in $(seq 1 30); do
-              code=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:9091 || echo 000)
+              code=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:9090 || echo 000)
               if [ "$code" != "000" ] && [ "$code" -lt 500 ]; then
                 echo "healthy (HTTP $code)"
                 exit 0

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,5 +3,5 @@ WORKDIR /app
 RUN useradd --system --no-create-home appuser
 COPY build/libs/*.jar app.jar
 USER appuser
-EXPOSE 9091
+EXPOSE 9090
 ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/deploy/docker-compose.dev.yml
+++ b/deploy/docker-compose.dev.yml
@@ -22,7 +22,7 @@ services:
       - redis
     env_file: .env
     ports:
-      - "9091:9091"
+      - "9090:9090"
 
 volumes:
   mysql-data:

--- a/docs/domain/chore/51-chore-dev-cicd.md
+++ b/docs/domain/chore/51-chore-dev-cicd.md
@@ -60,7 +60,7 @@ WORKDIR /app
 RUN useradd --system --no-create-home appuser
 COPY build/libs/*.jar app.jar
 USER appuser
-EXPOSE 9091
+EXPOSE 9090
 ENTRYPOINT ["java", "-jar", "app.jar"]
 ```
 CI가 이미 `./gradlew build`로 테스트까지 통과한 jar를 만들어두므로, 이미지 안에서 다시
@@ -116,7 +116,7 @@ services:
       - redis
     env_file: .env
     ports:
-      - "9091:9091"
+      - "9090:9090"
 
 volumes:
   mysql-data:
@@ -125,7 +125,13 @@ volumes:
 이 파일 자체는 시크릿 값을 담지 않는다(`environment`/`env_file` 모두 값만 별도 파일에서
 읽어온다). 저장소에 커밋되고, 배포할 때마다 최신 버전을 EC2로 scp해서 덮어쓴다 — 서비스
 정의(볼륨, 환경변수 이름 등)가 바뀌면 다음 배포에 자동 반영된다. 호스트에 포트를 여는
-서비스는 `app`(`9091`) 하나뿐이다.
+서비스는 `app`(`9090`) 하나뿐이다.
+
+> 🔧 **후속 반영(첫 배포 이후)**: `9091` 인바운드 규칙이 EC2 보안그룹에 없어 외부에서
+> 접근이 안 됐다. 새 인바운드 규칙을 여는 대신, 이미 열려 있던 `9090`을 그대로 쓰기로
+> 하고 `server.port`(애플리케이션 레벨, `application.yml`)와 `EXPOSE`/포트 매핑을 전부
+> `9090`으로 통일했다 — 컨테이너 내부/외부 포트가 항상 같으므로 별도 포트 포워딩
+> 매핑(`외부:내부`가 다른 값)은 두지 않는다.
 
 `.env`는 저장소에 없고 `deploy-dev` job이 매 배포마다 GitHub Secrets 값으로 새로 생성한다
 (아래 "GitHub Actions 워크플로우" 참고). 생성되는 내용:

--- a/postman/environments/gone-local-dev.postman_environment.json
+++ b/postman/environments/gone-local-dev.postman_environment.json
@@ -3,7 +3,7 @@
   "values": [
     {
       "key": "baseUrl",
-      "value": "http://localhost:9091",
+      "value": "http://localhost:9090",
       "type": "default",
       "enabled": true
     },

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -23,4 +23,4 @@ spring:
       port: 6379
 
 server:
-  port: 9091
+  port: 9090


### PR DESCRIPTION
## 관련 이슈
관련: #51 (이미 closed — 새 이슈 없이 운영 조정)

## 작업 내용
dev EC2의 보안그룹에 9091 인바운드 규칙이 없어 첫 배포 후에도 외부에서 접근이 안 됐다.
새 인바운드 규칙을 여는 대신, 이미 열려 있던 9090 포트를 쓰도록 서버 포트를 통일한다.

## 변경 사항 상세
- `src/main/resources/application.yml`: `server.port` 9091 → 9090.
- `Dockerfile`: `EXPOSE` 9091 → 9090.
- `deploy/docker-compose.dev.yml`: `app` 포트 매핑 `9091:9091` → `9090:9090`.
- `.github/workflows/ci.yml`: `deploy-dev`의 헬스체크 curl 대상 포트 9091 → 9090.
- `postman/environments/gone-local-dev.postman_environment.json`: `baseUrl` 9091 → 9090
  (로컬 실행도 같은 `application.yml`을 쓰므로 함께 맞춤).
- `docs/domain/chore/51-chore-dev-cicd.md`: 위 변경 내용과 사유를 기획서에 반영.

## 확인 사항
- [x] 로컬 빌드 통과 (`./gradlew build`)
- [x] Checkstyle 통과 (`./gradlew checkstyleMain`)
- [ ] CI(checkstyle, build-and-test) 통과 — PR 생성 후 확인
- [ ] (해당 시) Notion 기능정의서/기획 문서 반영 — 해당 없음
- [x] (해당 시) 관련 도메인 라벨 지정 (`chore`)

머지되면 `deploy-dev`가 다시 실행되어 `app` 컨테이너가 9090으로 재배포된다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Standardized the application port to **9090** across local development, containerized deployments, health checks, and API testing.
  * Updated the development deployment setup to use direct port mapping without translation.

* **Documentation**
  * Updated development deployment guidance to reflect the new application, container, and external port.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->