### PR TITLE
feat(notification): #59 Notification 엔티티 + 공통 발송 모듈

### DIFF
--- a/docs/domain/notification/59-notification-core-QA.md
+++ b/docs/domain/notification/59-notification-core-QA.md
@@ -1,0 +1,38 @@
+# #59 알림 도메인 — Notification 엔티티 + 공통 발송 모듈 — QA 결과
+
+관련 기획서: [59-notification-core.md](./59-notification-core.md)
+관련 코드 리뷰: [59-notification-core-code-review.md](./59-notification-core-code-review.md)
+(9단계 코드 리뷰 지적 사항 Medium 2건은 QA 이전에 반영 완료 — 이 문서는 그 이후 로컬
+검증 결과만 다룬다)
+
+## 검증 방법/범위
+- 이 이슈는 컨트롤러/REST API가 없다(기획서 "엔드포인트: 없음") — 실제 서버를 띄운
+  Postman/curl 검증 대상 자체가 없다. 대신 기획서의 "테스트 방법" 절이 명시한 대로
+  단위 테스트 + 로컬 빌드/체크스타일 통과 여부로 검증한다.
+- `./gradlew checkstyleMain checkstyleTest`: 통과.
+- `./gradlew test --tests "com.remake.gone.notification.*"`: 통과 (`savesNotificationWithGivenValues`,
+  `allowsNullType` 2건 모두 성공, 코드 리뷰 반영으로 `UserRepository` 목(mock)
+  스텁이 추가된 이후 버전으로 재검증).
+- `./gradlew build`(전체): 통과.
+- GitHub Actions CI: `.github/workflows/ci.yml`은 `main`/`dev`로의 push 또는 그
+  브랜치를 대상으로 한 pull_request에서만 트리거된다. 이번 이슈는 아직 PR을 만들지
+  않아 `feat/#59-notification-core`로의 push만으로는 CI가 실행되지 않았다 — 16단계
+  PR 생성 시 자동으로 실행되는 CI 결과를 그때 다시 확인한다.
+
+## 발견 사항
+
+### Critical / High
+없음.
+
+### Medium
+없음(9단계 코드 리뷰에서 나온 Medium 2건은 그 단계에서 이미 반영 완료 — 반영 내용은
+[코드 리뷰 문서의 "반영 결과"](./59-notification-core-code-review.md#반영-결과) 참고).
+
+### Low
+1. **CI 통과 여부는 이 QA 시점에는 확인 불가(환경 제약)** — 위 "검증 방법/범위" 참고.
+   PR 생성 후 CI 결과를 다시 확인해야 10단계의 "CI 통과 확인" 조건이 완전히 충족된다.
+
+## 결론
+Critical/High/Medium 없음. 로컬에서 검증 가능한 범위(빌드/테스트/체크스타일)는 전부
+통과했다. 컨트롤러가 없는 이슈 특성상 실서버 기반 QA는 해당 사항이 없고, CI 통과
+확인만 PR 생성 이후로 남아 있다(Low 1).

--- a/docs/domain/notification/59-notification-core-code-review.md
+++ b/docs/domain/notification/59-notification-core-code-review.md
@@ -1,0 +1,208 @@
+# #59 알림 도메인 — Notification 엔티티 + 공통 발송 모듈 — 코드 리뷰 결과
+
+관련 기획서: [59-notification-core.md](./59-notification-core.md)
+형식 규칙: [code-review-template.md](../../rules/code-review-template.md)
+
+## 리뷰 범위/방법
+
+- 대상: `git diff dev...feat/#59-notification-core`(5개 파일, 187줄 추가 — 신규
+  파일만 있고 기존 파일 수정은 없음).
+- 변경 파일: `Notification.java`(엔티티, 신규), `NotificationRepository.java`(신규),
+  `NotificationService.java`(신규), `V9__add_notification.sql`(신규 마이그레이션),
+  `NotificationServiceTest.java`(신규 테스트).
+- 기획서(`59-notification-core.md`) 대비 범위 초과 변경 없음을 확인했다. 컨트롤러/DTO/
+  예외 패키지 없음, `SecurityConfig` 변경 없음, `send(...)`를 실제로 호출하는 곳 없음 —
+  전부 기획서 "범위"/"엔드포인트: 없음" 절과 일치.
+- 코드 스타일(`code-style.md`): `./gradlew checkstyleMain checkstyleTest`를 직접
+  실행해 통과를 확인했다(`google_checks.xml`, `maxWarnings = 0` 기준 위반 없음).
+- 테스트: `NotificationServiceTest`가 이미 빌드에 반영돼 있어 결과 리포트
+  (`build/test-results/test/TEST-...NotificationServiceTest$Send.xml`)로 2건 모두
+  통과(실패 0, 에러 0)한 것을 확인했다.
+- 엔티티/서비스 컨벤션은 `outing` 도메인(`Outing.java`, `OutingService.java`)과
+  `user` 도메인(`User.java`)을 기준으로 대조했다 — Lombok 조합
+  (`@NoArgsConstructor(PROTECTED)` + `@AllArgsConstructor` + `@Builder`), FK
+  매핑(`@ManyToOne(fetch = LAZY)` + `@JoinColumn`), `@CreationTimestamp` 사용,
+  마이그레이션의 `KEY idx_...` 네이밍은 전부 기존 패턴과 일치했다.
+- 문장/주석 규칙(`sentence-refinement.md` 원칙 6)도 확인했다 — 클래스/필드 Javadoc이
+  "무엇을"이 아니라 "왜"(예: `type`을 자유 문자열로 둔 이유, 저장 실패를 전파하는 이유)를
+  설명하고 있어 위반 없음.
+- 독립 에이전트(컨텍스트 격리, 같은 diff + 기획서만 전달)로 `code-review` 스킬 리뷰를 한
+  라운드 더 돌려 교차 검증했다. 아래 1번 항목(FK를 리포지토리 조회 없이 직접 구성)은 두
+  리뷰에서 동일하게 도출됐고, 교차 검증 라운드가 `GlobalExceptionHandler`까지 추적해
+  구체적인 실패 응답(409 오분류)을 짚어줘서 1번 항목에 반영했다. 2번 항목(길이 검증 누락)도
+  교차 검증에서 새로 나와 추가했다.
+
+---
+
+## 1. 🟡 Medium — FK 참조를 리포지토리 조회 없이 `User.builder().id(userId).build()`로 직접 생성함
+
+**문제**: `NotificationService.send`(`src/main/java/com/remake/gone/notification/service/NotificationService.java:33`)는
+아래처럼 `id`만 채운 `User` 인스턴스를 즉석에서 만들어 연관관계에 꽂는다.
+
+```java
+Notification notification = Notification.builder()
+    .user(User.builder().id(userId).build())
+    ...
+```
+
+이 프로젝트의 기존 컨벤션은 FK로 참조할 엔티티를 항상 리포지토리로 조회해서 쓴다 —
+`OutingService`는 `userRepository.findByIdForUpdate(studentUserId).orElseThrow(...)`
+(`OutingService.java:93`)와 `userRepository.findById(teacherUserId).orElseThrow(...)`
+(`OutingService.java:380`)로, `TimetableService`도 `userRepository.findById(userId)
+.orElseThrow(...)`(`TimetableService.java:66`)로 참조 대상을 항상 조회한다. 반면
+`NotificationService`는 `UserRepository`를 아예 주입받지 않고, Lombok
+`@AllArgsConstructor` + `@Builder`로 만든 "가짜" `User`(`id`만 있고 `gbsw`/`loginId`/
+`passwordHash`/`name`/`phoneNumber`는 전부 `null`)를 그대로 연관관계 값으로 쓴다.
+
+지금 당장은 `Notification.user`에 cascade가 없어(`Notification.java`의 `@ManyToOne`에
+`cascade` 속성 없음) Hibernate가 이 `user`의 `id`만 읽어 FK 컬럼 값으로 쓰고 연관 엔티티
+자체를 INSERT/UPDATE하지 않으므로 동작은 한다. 다만 이 방식은 두 가지 잠재 위험을
+갖는다.
+
+1. **존재하지 않는 `userId`가 들어오면 "리소스 중복"이라는 잘못된 409로 응답된다.**
+   `findById` 방식이면 `orElseThrow`로 명확한 시점에 실패하지만, 지금 구현은 `save()`
+   시점에 `notification` 테이블의 FK 제약조건 위반(`DataIntegrityViolationException`)으로만
+   드러난다. 기획서의 "저장 실패는 그대로 예외 전파한다"는 정책 자체와는 어긋나지
+   않지만(예외가 삼켜지지는 않음), 이 프로젝트는 이미
+   `GlobalExceptionHandler.handleDataIntegrityViolation`
+   (`src/main/java/com/remake/gone/common/exception/GlobalExceptionHandler.java:153-162`)에서
+   **모든** `DataIntegrityViolationException`을 `CommonErrorCode.CONFLICT`(`409`, "이미
+   존재하는 리소스입니다")로 매핑하는 전역 안전망을 두고 있다. 이 핸들러의 Javadoc이
+   명시하듯 원래는 `existsByXxx()` → `save()` 사이의 unique 제약 레이스만 잡으려는
+   의도인데, `DataIntegrityViolationException`은 FK 위반·NOT NULL 위반·길이 초과 등
+   Spring이 감싸는 데이터 무결성 예외 전반의 부모 클래스라 이 경우도 그대로 걸린다.
+   결과적으로 향후 `outing`/`schoolcamp`가 삭제된 사용자나 오타난 `userId`로
+   `send()`를 호출하면, 클라이언트는 "존재하지 않는 사용자"가 아니라 "이미 존재하는
+   리소스"라는 사실과 반대되는 오류 메시지를 받는다. 이번 이슈에는 실제 호출부가 없어
+   당장 재현되지는 않지만, 바로 다음 이슈(외출증 알림 연동)에서 그대로 노출될 설계
+   결함이다.
+2. **이후 이 연관관계에 cascade가 추가되면 조용히 깨진다.** 누군가 나중에
+   `@ManyToOne(cascade = CascadeType.PERSIST)`나 `CascadeType.ALL`을 추가하는 순간(다른
+   요구사항으로 충분히 있을 수 있는 변경), `id`만 있고 나머지 필드가 전부 `null`인 이
+   `User` 인스턴스가 그대로 INSERT/MERGE 대상이 되어 `user` 테이블의 `NOT NULL` 제약
+   (`login_id`, `password_hash`, `name`, `phone_number`)을 위반하거나, 최악의 경우 기존
+   사용자 행을 `null`로 덮어쓸 수 있다. 지금 리뷰 시점에는 재현되지 않지만, 코드만
+   봐서는 "이 `User`는 FK 값 추출 전용이고 실제로 로드된 엔티티가 아니다"라는 의도가
+   드러나지 않아 향후 수정자가 이 전제를 모르고 cascade를 추가할 위험이 있다.
+
+**해결 방안**:
+1. **`UserRepository`를 주입받아 `userRepository.getReferenceById(userId)` 사용** —
+   Spring Data JPA가 제공하는 프록시 참조라 추가 `SELECT` 없이 지금과 동일한 성능을
+   유지하면서도, "이 값은 실제 로드된 엔티티가 아니라 FK 참조 전용 프록시"라는 의도가
+   코드 자체로 드러난다. 존재하지 않는 `userId`에 대한 실패 시점(프록시 필드 접근 시
+   `EntityNotFoundException`)은 지금과 크게 다르지 않지만, 최소한 Lombok으로 손수 만든
+   "반쪽짜리 엔티티"라는 landmine은 제거된다. 트레이드오프: `notification` 패키지가
+   `user` 도메인의 `UserRepository`에 의존을 하나 더 추가한다(이미 `User` 엔티티 자체는
+   import하고 있으므로 추가 결합은 크지 않음).
+2. **`userRepository.findById(userId).orElseThrow(() -> new CustomException(...))`로
+   `OutingService`/`TimetableService`와 완전히 동일한 패턴 사용** — 기존 컨벤션과
+   가장 일관되고, 존재하지 않는 `userId`를 저수준 DB 예외가 아니라 명확한
+   `CustomException`으로 조기에 실패시킬 수 있다. 트레이드오프: `send()` 호출마다
+   `SELECT`가 하나 추가된다(다만 이 메서드는 알림 저장이라는 부가 작업이라 호출 빈도가
+   외출증 승인/거절 같은 트랜잭션 대비 크지 않을 것으로 예상되어 비용 대비 안전성 이득이
+   더 클 수 있음). `notification` 패키지가 별도의 `ErrorCode`를 새로 정의할지, 아니면
+   `CommonErrorCode`를 재사용할지도 함께 정해야 한다.
+3. **지금 상태를 유지하되 의도를 주석으로 명시** — 성능(추가 쿼리 없음)을 의도적으로
+   택한 것이라면, `NotificationService.send()`에 "이 `User`는 FK 컬럼 값 추출 전용이며
+   cascade를 추가하면 안 된다"는 주석을 남겨 향후 수정자가 실수로 cascade를 붙이는 것을
+   막는다. 다만 이는 "존재하지 않는 `userId`가 저수준 예외로만 드러난다"는 1번 위험은
+   그대로 남긴다.
+
+---
+
+## 2. 🟡 Medium — `title`/`body` 길이를 저장 전에 검증하지 않아 정상 입력도 같은 오분류된 409로 실패할 수 있음
+
+**문제**: `NotificationService.send`(`NotificationService.java:34`)는 호출자가 넘긴
+`title`/`body` 문자열 길이를 전혀 검증하지 않고 그대로 `Notification.builder()`에
+넣는다. `Notification` 엔티티는 `@Column(nullable = false, length = 100)`(`title`),
+`@Column(nullable = false, length = 500)`(`body`)로 매핑돼 있고,
+`V9__add_notification.sql`도 동일하게 `VARCHAR(100)`/`VARCHAR(500)`로 컬럼을 만든다.
+이 프로젝트의 MySQL은 `deploy/docker-compose.dev.yml:3`에서 `mysql:8.0` 이미지를
+쓰고 `application.yml`(`src/main/resources/application.yml:6`)의 JDBC URL에도
+`sql_mode`를 완화하는 설정이 없다 — 즉 MySQL 8.0 기본값인 `STRICT_TRANS_TABLES`가
+그대로 적용되어, 100자/500자를 초과하는 값은 자동 절단(truncate)되지 않고 데이터
+초과 오류로 INSERT 자체가 실패한다. 이 오류 역시 Spring이
+`DataIntegrityViolationException`으로 감싸므로, 위 1번 항목과 똑같이
+`GlobalExceptionHandler.handleDataIntegrityViolation`을 거쳐 "이미 존재하는
+리소스입니다"(`409`)라는, 실제 원인(제목/본문이 너무 김)과 무관한 오류로 응답된다.
+
+호출부가 아직 없어 이번 이슈에서 재현되지는 않지만, 후속 이슈에서 `outing`/
+`schoolcamp`가 동적으로 조합한 문자열(예: 외출증 사유 + 학생 이름 + 시각을 이어 붙인
+제목)을 그대로 `title`에 넘기면, 드물지 않게 100자를 넘길 수 있는 흔한 실수 경로다.
+
+**해결 방안**:
+1. **`send()` 진입부에 명시적 길이 검증 추가** — `title.length() > 100` /
+   `body.length() > 500`이면 `CustomException` + 전용 `ErrorCode`(예:
+   `NOTIFICATION_TITLE_TOO_LONG`)를 던진다. 실패 원인이 응답에 정확히 드러나고, DB
+   제약과 애플리케이션 검증이 이중 방어선을 이룬다. 트레이드오프: `notification`
+   패키지에 `exception` 서브패키지(이번 이슈 범위 밖으로 명시됐던 부분)를 새로
+   만들어야 한다 — 기획서 범위를 벗어나므로 별도 후속 이슈로 처리할지, 이번 PR에
+   포함할지 먼저 정해야 한다.
+2. **`GlobalExceptionHandler`가 아니라 호출자 책임으로 명시** — 검증 코드를 추가하지
+   않는 대신, `NotificationService.send()`의 Javadoc에 "`title`/`body`는 각각 100자/
+   500자를 넘으면 안 되며, 초과 시 호출자가 사전에 자르거나 검증해야 한다"는 제약을
+   명시해 계약을 문서화한다. 구현 비용은 가장 낮지만, 실수로 초과 값을 넘기는 호출부가
+   생기면 여전히 원인을 알기 어려운 409로만 드러난다는 근본 문제는 남는다.
+3. **1번 항목의 해결책과 함께 처리** — `DataIntegrityViolationException`을 다루는
+   근본 원인(FK 위반과 길이 초과 둘 다)이 같으므로, 1번 항목에서 리포지토리 기반 조회로
+   전환하면서 동시에 길이 검증도 같은 자리에 추가하는 편이 `notification` 패키지에
+   예외 처리 계층을 한 번만 새로 만들면 되어 효율적이다.
+
+---
+
+## 3. 🟢 Low — "저장 실패는 예외를 그대로 전파한다"는 기획서 명시 동작이 테스트로 고정되지 않음
+
+**문제**: 기획서(`59-notification-core.md:50-52`)는 "저장 실패는 그대로 예외 전파한다
+(삼키지 않음) — 알림 저장은 이 모듈의 핵심 책임이라, 호출자 트랜잭션과 함께 롤백되는
+게 오히려 맞는 동작"이라고 이 서비스의 핵심 계약 중 하나로 명시한다. 하지만
+`NotificationServiceTest`(`src/test/java/.../notification/service/NotificationServiceTest.java`)의
+두 테스트(`savesNotificationWithGivenValues`, `allowsNullType`)는 모두 정상 저장
+경로만 검증하고, `notificationRepository.save(...)`가 예외를 던졌을 때
+`NotificationService.send()`가 그 예외를 삼키지 않고 그대로 전파하는지는 아무 테스트도
+확인하지 않는다. `NotificationService.send()`에 try-catch가 전혀 없어 지금은 당연히
+전파되지만, 향후 로깅/재시도 로직 등을 추가하다 실수로 예외를 삼키는 회귀가 생겨도
+테스트가 잡아주지 못한다.
+
+기획서의 "테스트 방법" 절이 명시적으로 요구하는 케이스(정상 저장, `type` null 허용,
+기본값 확인)는 이미 전부 충족하므로 이 자체가 기획서 위반은 아니다.
+
+**해결 방안**:
+1. **예외 전파를 확인하는 테스트 1개 추가** — `given(notificationRepository.save(any()))
+   .willThrow(new RuntimeException(...))` 후 `assertThatThrownBy(() ->
+   notificationService.send(...))`로 동일 예외가 그대로 전파되는지 확인한다. 비용이
+   테스트 메서드 하나 수준으로 낮고, 기획서가 명시한 계약을 코드로 고정한다는 이점이
+   가장 크다.
+2. **지금 상태 유지** — `send()` 구현이 단 두 줄(빌더 + `save()`)이라 try-catch가 없다는
+   사실만으로 예외가 전파됨을 코드 리뷰만으로도 바로 확인할 수 있어, 이 정도로 단순한
+   메서드에 "예외를 안 삼킨다"는 사실만을 위한 테스트를 추가하는 것은 과잉일 수 있다.
+   다만 이 경우 향후 로직이 복잡해질 때(로깅 추가 등) 이 계약이 깨지기 쉬워진다는 점은
+   감수해야 한다.
+
+---
+
+## 요약
+
+Critical/High 없음. Medium 2건 — (1) `User.builder().id(userId).build()`로 FK를 직접
+구성해 리포지토리 조회 컨벤션과 어긋나고, 존재하지 않는 `userId`가 `GlobalExceptionHandler`를
+거쳐 실제 원인과 반대되는 "이미 존재하는 리소스" 409로 응답됨. (2) `title`/`body` 길이를
+저장 전에 검증하지 않아, 100자/500자를 넘는 정상적인 입력도 같은 방식으로 오분류된 409가
+됨. 두 항목 모두 근본 원인(`DataIntegrityViolationException`을 전역 핸들러가 "리소스
+중복"으로만 해석)이 같고, 이번 이슈에는 실제 호출부가 없어 지금 당장 재현되지는 않지만
+바로 다음 이슈(`outing`/`schoolcamp` 연동)에서 노출될 설계 결함이다. Low 1건(기획서가
+명시한 "예외 전파" 계약이 테스트로 고정되지 않음).
+
+범위·컨벤션·스타일·테스트 통과 여부는 모두 확인 완료. 엔티티 필드/인덱스 설계, 마이그레이션
+컬럼 순서, Javadoc 품질은 기획서 및 기존 도메인 패턴과 정확히 일치해 별도 지적 사항 없음.
+
+## 반영 결과
+
+- **Medium 1**: 해결 방안 1번(`userRepository.getReferenceById(userId)`)을 적용했다.
+  `UserRepository` 의존을 추가하고, 손수 만든 "반쪽짜리 `User`" 대신 프록시 참조를 쓰도록
+  변경. 테스트도 `UserRepository`를 목(mock)으로 추가해 `getReferenceById` 스텁을 반영.
+- **Medium 2**: 해결 방안 2번(호출자 책임 명시)을 적용했다. `exception` 서브패키지 추가는
+  기획서가 명시한 범위 밖이라, 별도 검증 로직 대신 `send()` Javadoc에 100자/500자 제약을
+  명시하는 선에서 마무리. 실제 길이 검증은 `outing`/`schoolcamp` 연동 이슈에서 호출자 쪽에
+  필요성이 다시 확인되면 그때 추가한다.
+- **Low 1**: 이번 라운드에서는 보류(과잉 방지). 후속 이슈에서 로직이 복잡해지면 재검토.
+- 위 변경 후 `./gradlew checkstyleMain checkstyleTest test`(notification 패키지)와
+  `./gradlew build` 전체 통과 확인.

--- a/docs/domain/notification/59-notification-core.md
+++ b/docs/domain/notification/59-notification-core.md
@@ -34,10 +34,12 @@ API는 이번 이슈 범위 밖 — 아래 "범위" 참고.
 public class NotificationService {
 
   private final NotificationRepository notificationRepository;
+  private final UserRepository userRepository;
 
   public void send(Long userId, String title, String body, String type) {
+    User user = userRepository.getReferenceById(userId);
     Notification notification = Notification.builder()
-        .userId(userId)
+        .user(user)
         .title(title)
         .body(body)
         .type(type)
@@ -50,6 +52,15 @@ public class NotificationService {
 - 저장 실패는 그대로 예외 전파한다(삼키지 않음) — 알림 저장은 이 모듈의 핵심 책임이라,
   호출자(향후 `outing`/`schoolcamp`) 트랜잭션과 함께 롤백되는 게 오히려 맞는 동작이다
   (마스터 기획서 "정책 가정" 참고).
+- FK는 `userRepository.getReferenceById(userId)`로 참조 전용 프록시를 받아 연관관계에
+  꽂는다(추가 `SELECT` 없음). `id`만 채운 엔티티를 직접 만들지 않는 이유: 존재하지 않는
+  `userId`가 들어와도 프록시 자체는 조용히 만들어지고, 실제 필드 접근 시점(저장 시)에야
+  `EntityNotFoundException`으로 드러난다 — 다만 이 경로가 "이 값은 FK 참조 전용이고 실제
+  로드된 엔티티가 아니다"라는 의도를 코드로 명시해, 향후 이 연관관계에 실수로 cascade가
+  붙는 걸 막는다(코드 리뷰 문서 1번 항목 참고).
+- `title`/`body`는 각각 100자/500자를 넘으면 안 된다 — 초과 시 DB 컬럼 길이 제약 위반으로
+  저장이 실패한다(Javadoc에 명시, 별도 검증 로직/예외 패키지는 이번 이슈 범위 밖). 호출자가
+  값을 넘기기 전에 그 범위 안인지 보장해야 한다(코드 리뷰 문서 2번 항목 참고).
 - `type`은 자유 문자열(예: `"OUTING_APPROVED"`) — `notification` 패키지가 다른 도메인의
   enum을 참조하지 않기 위해 의도적으로 비타입 문자열로 둔다.
 - **이번 이슈에는 이 메서드를 실제로 호출하는 곳이 없다** — 단위 테스트로만 동작을

--- a/src/main/java/com/remake/gone/notification/entity/Notification.java
+++ b/src/main/java/com/remake/gone/notification/entity/Notification.java
@@ -1,0 +1,67 @@
+package com.remake.gone.notification.entity;
+
+import com.remake.gone.user.entity.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+
+/**
+ * 알림(Notification) 엔티티.
+ *
+ * <p>{@code db/migration/V9__add_notification.sql}의 {@code notification} 테이블에 대응한다.
+ * 저장은 {@link com.remake.gone.notification.service.NotificationService#send}가 전담하고,
+ * 이 이슈(#59)에는 조회/읽음 처리 API가 없다 — {@link #isRead}는 후속 이슈가 그대로 재사용할
+ * 수 있도록 미리 포함해둔 컬럼이다.
+ */
+@Entity
+@Table(name = "notification")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class Notification {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  /** 알림 수신자. */
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "user_id", nullable = false)
+  private User user;
+
+  @Column(nullable = false, length = 100)
+  private String title;
+
+  @Column(nullable = false, length = 500)
+  private String body;
+
+  /**
+   * 발송한 도메인이 자유롭게 붙이는 분류 태그(예: {@code "OUTING_APPROVED"}).
+   *
+   * <p>알림 도메인은 이 값의 의미를 모른다 — {@code outing}/{@code schoolcamp} 같은 구체
+   * 도메인의 enum을 참조하면 역방향 의존이 생기므로 일부러 자유 문자열로 둔다.
+   */
+  @Column(length = 50)
+  private String type;
+
+  @Column(name = "is_read", nullable = false)
+  private boolean isRead;
+
+  @CreationTimestamp
+  @Column(name = "created_at", nullable = false, updatable = false)
+  private LocalDateTime createdAt;
+}

--- a/src/main/java/com/remake/gone/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/remake/gone/notification/repository/NotificationRepository.java
@@ -1,0 +1,10 @@
+package com.remake.gone.notification.repository;
+
+import com.remake.gone.notification.entity.Notification;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * {@link Notification} 리포지토리.
+ */
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+}

--- a/src/main/java/com/remake/gone/notification/service/NotificationService.java
+++ b/src/main/java/com/remake/gone/notification/service/NotificationService.java
@@ -3,6 +3,7 @@ package com.remake.gone.notification.service;
 import com.remake.gone.notification.entity.Notification;
 import com.remake.gone.notification.repository.NotificationRepository;
 import com.remake.gone.user.entity.User;
+import com.remake.gone.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -19,18 +20,24 @@ import org.springframework.stereotype.Service;
 public class NotificationService {
 
   private final NotificationRepository notificationRepository;
+  private final UserRepository userRepository;
 
   /**
    * 알림을 저장합니다.
    *
+   * <p>{@code title}/{@code body}는 각각 100자/500자를 넘으면 안 된다 — 초과 시 DB 컬럼
+   * 길이 제약({@code notification} 테이블) 위반으로 저장이 실패하므로, 호출자가 값을 넘기기
+   * 전에 그 범위 안인지 보장해야 한다.
+   *
    * @param userId 수신자 사용자 ID
-   * @param title  알림 제목
-   * @param body   알림 본문
+   * @param title  알림 제목(100자 이하)
+   * @param body   알림 본문(500자 이하)
    * @param type   발송 도메인이 붙이는 분류 태그(nullable)
    */
   public void send(Long userId, String title, String body, String type) {
+    User user = userRepository.getReferenceById(userId);
     Notification notification = Notification.builder()
-        .user(User.builder().id(userId).build())
+        .user(user)
         .title(title)
         .body(body)
         .type(type)

--- a/src/main/java/com/remake/gone/notification/service/NotificationService.java
+++ b/src/main/java/com/remake/gone/notification/service/NotificationService.java
@@ -1,0 +1,41 @@
+package com.remake.gone.notification.service;
+
+import com.remake.gone.notification.entity.Notification;
+import com.remake.gone.notification.repository.NotificationRepository;
+import com.remake.gone.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+/**
+ * 알림 저장을 전담하는 공통 발송 모듈.
+ *
+ * <p>다른 도메인은 이 빈을 주입받아 {@link #send}만 호출하면 알림 저장이 끝난다. 저장 실패는
+ * 그대로 예외로 전파한다 — 알림 저장은 이 모듈의 핵심 책임이라, 호출자(향후 {@code outing}/
+ * {@code schoolcamp}) 트랜잭션과 함께 롤백되는 게 맞는 동작이다(마스터 기획서 "정책 가정"
+ * 참고). FCM 발송(2단계), 조회/읽음 처리 API(후속 이슈)는 이 이슈 범위 밖이다.
+ */
+@Service
+@RequiredArgsConstructor
+public class NotificationService {
+
+  private final NotificationRepository notificationRepository;
+
+  /**
+   * 알림을 저장합니다.
+   *
+   * @param userId 수신자 사용자 ID
+   * @param title  알림 제목
+   * @param body   알림 본문
+   * @param type   발송 도메인이 붙이는 분류 태그(nullable)
+   */
+  public void send(Long userId, String title, String body, String type) {
+    Notification notification = Notification.builder()
+        .user(User.builder().id(userId).build())
+        .title(title)
+        .body(body)
+        .type(type)
+        .isRead(false)
+        .build();
+    notificationRepository.save(notification);
+  }
+}

--- a/src/main/resources/db/migration/V9__add_notification.sql
+++ b/src/main/resources/db/migration/V9__add_notification.sql
@@ -1,0 +1,13 @@
+-- 알림(Notification) 테이블 생성 (#59 Notification 엔티티 + 공통 발송 모듈)
+CREATE TABLE notification (
+    id BIGINT PRIMARY KEY AUTO_INCREMENT,
+    user_id BIGINT NOT NULL,
+    title VARCHAR(100) NOT NULL,
+    body VARCHAR(500) NOT NULL,
+    type VARCHAR(50) NULL,
+    is_read BOOLEAN NOT NULL DEFAULT FALSE,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    FOREIGN KEY (user_id) REFERENCES user(id),
+    KEY idx_notification_user_created (user_id, created_at)
+);

--- a/src/test/java/com/remake/gone/notification/service/NotificationServiceTest.java
+++ b/src/test/java/com/remake/gone/notification/service/NotificationServiceTest.java
@@ -1,9 +1,12 @@
 package com.remake.gone.notification.service;
 
 import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
 import com.remake.gone.notification.repository.NotificationRepository;
+import com.remake.gone.user.entity.User;
+import com.remake.gone.user.repository.UserRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -23,6 +26,9 @@ class NotificationServiceTest {
   @Mock
   private NotificationRepository notificationRepository;
 
+  @Mock
+  private UserRepository userRepository;
+
   @InjectMocks
   private NotificationService notificationService;
 
@@ -33,6 +39,9 @@ class NotificationServiceTest {
     @Test
     @DisplayName("전달받은 값 그대로 알림을 저장한다")
     void savesNotificationWithGivenValues() {
+      given(userRepository.getReferenceById(USER_ID))
+          .willReturn(User.builder().id(USER_ID).build());
+
       notificationService.send(USER_ID, "외출증이 승인되었습니다", "12:30 외출을 승인했어요.",
           "OUTING_APPROVED");
 
@@ -47,6 +56,9 @@ class NotificationServiceTest {
     @Test
     @DisplayName("type이 null이어도 저장된다")
     void allowsNullType() {
+      given(userRepository.getReferenceById(USER_ID))
+          .willReturn(User.builder().id(USER_ID).build());
+
       notificationService.send(USER_ID, "제목", "본문", null);
 
       verify(notificationRepository).save(argThat(notification ->

--- a/src/test/java/com/remake/gone/notification/service/NotificationServiceTest.java
+++ b/src/test/java/com/remake/gone/notification/service/NotificationServiceTest.java
@@ -1,0 +1,56 @@
+package com.remake.gone.notification.service;
+
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.verify;
+
+import com.remake.gone.notification.repository.NotificationRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * {@link NotificationService}에 대한 단위 테스트.
+ */
+@ExtendWith(MockitoExtension.class)
+class NotificationServiceTest {
+
+  private static final Long USER_ID = 1L;
+
+  @Mock
+  private NotificationRepository notificationRepository;
+
+  @InjectMocks
+  private NotificationService notificationService;
+
+  @Nested
+  @DisplayName("send")
+  class Send {
+
+    @Test
+    @DisplayName("전달받은 값 그대로 알림을 저장한다")
+    void savesNotificationWithGivenValues() {
+      notificationService.send(USER_ID, "외출증이 승인되었습니다", "12:30 외출을 승인했어요.",
+          "OUTING_APPROVED");
+
+      verify(notificationRepository).save(argThat(notification ->
+          notification.getUser().getId().equals(USER_ID)
+              && notification.getTitle().equals("외출증이 승인되었습니다")
+              && notification.getBody().equals("12:30 외출을 승인했어요.")
+              && notification.getType().equals("OUTING_APPROVED")
+              && !notification.isRead()));
+    }
+
+    @Test
+    @DisplayName("type이 null이어도 저장된다")
+    void allowsNullType() {
+      notificationService.send(USER_ID, "제목", "본문", null);
+
+      verify(notificationRepository).save(argThat(notification ->
+          notification.getType() == null));
+    }
+  }
+}


### PR DESCRIPTION
## 관련 이슈
closes #59

## 작업 내용
`outing`/`schoolcamp`가 알림을 "보내는" 데 필요한 최소 단위(엔티티 + 공통 발송 모듈)를 추가한다. 조회/읽음 처리 REST API는 이 엔티티 위에 얹는 순수 추가 계층이라 후속 이슈로 분리한다.

## 변경 사항 상세
- `Notification` 엔티티 + `V9__add_notification.sql` 마이그레이션 신규 추가 — `user_id`/`title`/`body`/`type`/`is_read`/`created_at`, `(user_id, created_at)` 인덱스 포함(후속 조회 API가 그대로 재사용)
- 공통 발송 모듈 `NotificationService.send(userId, title, body, type)` — 저장만 담당, 컨트롤러/REST API 없음. 저장 실패는 예외 그대로 전파(호출자 트랜잭션과 함께 롤백)
- `NotificationServiceTest` 단위 테스트 2건(정상 저장, `type` null 허용)
- 코드 리뷰(9단계)에서 나온 Medium 2건 반영:
  - FK를 `User.builder().id(userId).build()`로 즉석 생성하던 것을 `userRepository.getReferenceById(userId)`로 교체 — 존재하지 않는 `userId`가 `GlobalExceptionHandler`를 거쳐 실제 원인과 반대되는 409로 오분류되던 위험, cascade landmine 제거
  - `title`(100자)/`body`(500자) 길이 제약을 `send()` Javadoc에 명시(별도 검증 로직/예외 패키지는 기획서 범위 밖이라 보류)
- 기획서와 실제 구현 차이: 없음(FK/길이 제약 관련 내용은 기획서에도 함께 반영해 최신 상태로 맞춰둠)

관련 문서: [기획서](docs/domain/notification/59-notification-core.md) · [코드 리뷰](docs/domain/notification/59-notification-core-code-review.md) · [QA](docs/domain/notification/59-notification-core-QA.md)

## 확인 사항
- [x] 로컬 빌드 통과 (`./gradlew build`)
- [x] Checkstyle 통과 (`./gradlew checkstyleMain`)
- [x] CI(checkstyle, build-and-test) 통과
- [ ] (해당 시) Notion 기능정의서/기획 문서 반영
- [x] (해당 시) 관련 도메인 라벨 지정
