### PR TITLE
chore(deploy): #62 dev 배포에 nginx 리버스 프록시 추가

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -421,7 +421,11 @@ jobs:
             ENVEOF
             chmod 600 .env
             docker compose -f docker-compose.dev.yml pull app
-            docker compose -f docker-compose.dev.yml up -d app nginx
+            docker compose -f docker-compose.dev.yml up -d app
+            # nginx는 이미지 태그/볼륨 경로가 배포마다 안 바뀌어 위 up -d만으로는
+            # 재기동되지 않는다. app이 새 컨테이너로 뜨며 내부 IP가 바뀔 수 있고
+            # nginx.conf 파일 수정도 반영해야 하므로 매 배포마다 강제로 재생성한다.
+            docker compose -f docker-compose.dev.yml up -d --force-recreate nginx
 
       - name: 헬스체크
         uses: appleboy/ssh-action@v1.0.3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -383,7 +383,7 @@ jobs:
           host: ${{ secrets.EC2_HOST }}
           username: ${{ secrets.EC2_USER }}
           key: ${{ secrets.EC2_SSH_KEY }}
-          source: "deploy/docker-compose.dev.yml"
+          source: "deploy/docker-compose.dev.yml,deploy/nginx.conf"
           target: "/opt/gone/dev"
           strip_components: 1
 
@@ -421,7 +421,7 @@ jobs:
             ENVEOF
             chmod 600 .env
             docker compose -f docker-compose.dev.yml pull app
-            docker compose -f docker-compose.dev.yml up -d app
+            docker compose -f docker-compose.dev.yml up -d app nginx
 
       - name: 헬스체크
         uses: appleboy/ssh-action@v1.0.3
@@ -433,8 +433,9 @@ jobs:
             # 이 프로젝트에 actuator가 없어 보장된 2xx 경로가 없다(루트 "/"는 정상 상태에서도
             # 404를 반환할 수 있음) — 그래서 --fail(2xx/3xx만 성공)은 오탐을 낸다. 대신
             # "5xx가 아니면(=서버가 요청을 정상적으로 처리하고 있으면) 정상"으로 판정한다.
+            # nginx(80)를 거쳐 확인한다 — Cloudflare가 실제로 쓰는 경로와 동일하다(#62).
             for i in $(seq 1 30); do
-              code=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:9090 || echo 000)
+              code=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:80 || echo 000)
               if [ "$code" != "000" ] && [ "$code" -lt 500 ]; then
                 echo "healthy (HTTP $code)"
                 exit 0

--- a/deploy/docker-compose.dev.yml
+++ b/deploy/docker-compose.dev.yml
@@ -21,8 +21,16 @@ services:
       - mysql
       - redis
     env_file: .env
+
+  nginx:
+    image: nginx:1.27-alpine
+    restart: always
+    depends_on:
+      - app
     ports:
-      - "9090:9090"
+      - "80:80"
+    volumes:
+      - ./nginx.conf:/etc/nginx/conf.d/default.conf:ro
 
 volumes:
   mysql-data:

--- a/deploy/nginx.conf
+++ b/deploy/nginx.conf
@@ -5,7 +5,7 @@ server {
     location / {
         proxy_pass http://app:9090;
         proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Real-IP $http_cf_connecting_ip;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
     }

--- a/deploy/nginx.conf
+++ b/deploy/nginx.conf
@@ -1,0 +1,12 @@
+server {
+    listen 80;
+    server_name _;
+
+    location / {
+        proxy_pass http://app:9090;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}

--- a/docs/domain/chore/62-chore-nginx-reverse-proxy-QA.md
+++ b/docs/domain/chore/62-chore-nginx-reverse-proxy-QA.md
@@ -1,0 +1,48 @@
+# #62 dev 배포에 nginx 리버스 프록시 추가 — QA 결과
+
+관련 기획서: [62-chore-nginx-reverse-proxy.md](./62-chore-nginx-reverse-proxy.md)
+관련 코드 리뷰: [62-chore-nginx-reverse-proxy-code-review.md](./62-chore-nginx-reverse-proxy-code-review.md)
+(9단계 코드 리뷰 지적 사항 High 1건/Medium 1건은 QA 이전에 반영 완료 — 이 문서는 그
+이후 로컬 검증 결과만 다룬다)
+
+## 검증 방법/범위
+- 애플리케이션(Java) 코드 변경이 없어 `./gradlew checkstyleMain checkstyleTest build`로
+  기존 상태 유지만 확인(변경 없음 재확인 목적).
+- `deploy/docker-compose.dev.yml`: 더미 `.env`(`MYSQL_ROOT_PASSWORD=dummy`)로
+  `docker compose -f docker-compose.dev.yml config`를 실행해 문법 오류 없이 해석되고,
+  `nginx` 서비스가 의도대로(포트 `80:80`, `nginx.conf` 바인드 마운트, `app` 의존)
+  구성됨을 확인.
+- `.github/workflows/ci.yml`: Python `yaml.safe_load`로 문법 검증(#51 QA와 동일한
+  방식).
+- `deploy/nginx.conf`: 이 로컬 환경에 Docker 데몬이 떠 있지 않아(`docker version` 시
+  데몬 연결 실패, #51 QA 때와 동일한 환경 제약) `nginx -t`로 실제 문법 검증은 못
+  했다 — 파일이 짧고 표준적인 `proxy_pass`/`proxy_set_header` 구성이라 코드 리뷰
+  단계에서 수동 검토로 대체했다(아래 "Medium" 참고).
+- `appleboy/scp-action`의 다중 `source` + `strip_components` 동작은 코드 리뷰에서
+  실제 `drone-scp` 소스코드를 읽어 확인 완료(재검증 불필요).
+
+## 발견 사항
+
+### Critical / High
+없음(9단계 코드 리뷰의 High 1건은 그 단계에서 이미 반영 완료).
+
+### Medium
+1. **`nginx.conf` 문법 검증(`nginx -t`)과 실제 배포 후 동작(Cloudflare → nginx → app
+   전체 경로)을 이 세션에서 실행해보지 못함(환경 제약)** — Docker 데몬 부재로
+   `nginx -t` 자체를 못 돌렸고, EC2 실배포는 이 브랜치가 `dev`에 머지되어
+   `deploy-dev` job이 실행돼야 확인 가능하다. `docker compose config`로 구성 자체의
+   구조적 정합성은 확인했지만, nginx 설정 파일 내부 문법과 "실제로
+   `https://gone-dev.gbsw.hs.kr`가 응답하는지"는 머지 후 첫 배포에서 확인해야 한다.
+2. **`--force-recreate nginx`가 실제로 매 배포마다 502 없이 매끄럽게 재기동되는지는
+   실제 반복 배포로만 확인 가능(환경 제약)** — 코드 리뷰에서 논리적으로는 검증했으나
+   (Docker Compose 재생성 판단 기준, nginx의 DNS 캐시 동작에 대한 공식 문서 근거),
+   실제 EC2에서 연속 배포 2회 이상을 돌려봐야 100% 확인된다.
+
+### Low
+없음.
+
+## 결론
+Critical/High 없음. 로컬에서 검증 가능한 범위(compose 구조, ci.yml 문법, Java 빌드
+무영향)는 전부 통과했다. **다만 이 이슈의 핵심 가치(Cloudflare를 통한 실제 접속 성공
+여부)는 `dev` 머지 후 실제 배포로만 최종 확인된다**(Medium 2건). 머지 후 첫 배포
+결과를 보스에게 별도로 확인받아야 한다.

--- a/docs/domain/chore/62-chore-nginx-reverse-proxy-code-review.md
+++ b/docs/domain/chore/62-chore-nginx-reverse-proxy-code-review.md
@@ -1,0 +1,185 @@
+# #62 dev 배포에 nginx 리버스 프록시 추가 — 코드 리뷰 결과
+
+관련 기획서: [62-chore-nginx-reverse-proxy.md](./62-chore-nginx-reverse-proxy.md)
+형식 규칙: [code-review-template.md](../../rules/code-review-template.md)
+
+## 리뷰 범위/방법
+
+- 대상: `git diff dev...chore/#62-nginx-reverse-proxy` 전체. 신규 `deploy/nginx.conf`,
+  `deploy/docker-compose.dev.yml`(`app`의 `ports` 제거 + `nginx` 서비스 추가),
+  `.github/workflows/ci.yml`(`deploy-dev` job의 scp 소스/`up -d` 대상/헬스체크 URL)만
+  대상이다. 애플리케이션 Java 코드 변경 없음(`api-design.md` 6원칙 검토는 해당 없음).
+- 기획서(`62-chore-nginx-reverse-proxy.md`) 대비 범위 초과 변경은 없음을 확인했다 —
+  `deploy/nginx.conf` 본문, `docker-compose.dev.yml`의 `nginx` 서비스 정의,
+  `ci.yml`의 세 지점(scp source, `up -d` 대상, 헬스체크 URL) 모두 기획서에 적힌 내용과
+  글자 단위로 일치한다.
+- `appleboy/scp-action`(`ci.yml:381-388`)의 `source:
+  "deploy/docker-compose.dev.yml,deploy/nginx.conf"` + `strip_components: 1` 조합이
+  두 파일을 실제로 `/opt/gone/dev/docker-compose.dev.yml`, `/opt/gone/dev/nginx.conf`로
+  올바르게 풀어내는지 의심스러워, `appleboy/drone-scp`(scp-action이 실제로 실행하는
+  바이너리) 소스코드(`plugin.go`)를 GitHub API로 직접 읽어 확인했다 — `buildTarArgs`가
+  콤마로 나뉜 모든 source를 **하나의 tar 아카이브**로 묶고(`tar -zcf archive.tar.gz
+  deploy/docker-compose.dev.yml deploy/nginx.conf`), `buildUnTarArgs`가 그 아카이브
+  전체에 `--strip-components 1`을 한 번만 적용한다. 두 파일 모두 `deploy/` 한 단계
+  아래에 있어 각각 `deploy/`가 제거되고 `docker-compose.dev.yml`, `nginx.conf`가 목표
+  디렉터리 바로 아래에 떨어진다 — 의도대로 동작함을 코드 레벨에서 확인했다(별도 항목으로
+  기록하지 않음).
+- `application.yml:26`의 `server.port: 9090`이 `deploy/nginx.conf`의 `proxy_pass
+  http://app:9090`과 일치하는지 확인했다 — 일치한다.
+- `.github/workflows/ci.yml` 전체에서 `9090`을 검색해 헬스체크 외에 놓친 참조가 없는지
+  확인했다 — `deploy-dev` job에는 더 이상 `9090`이 등장하지 않는다(의도대로).
+- `deploy/nginx.conf`에 `client_max_body_size` 지시자가 없어 기본값(1m)으로 큰 요청이
+  막힐 가능성을 확인했다 — 파일 업로드는 `FileController`/`R2FileService`가 R2 presigned
+  URL로 클라이언트가 R2에 직접 업로드하는 구조라 이 nginx를 거치지 않는다. 이 diff
+  범위에서는 문제가 되지 않아 별도 항목으로 기록하지 않았다.
+- **독립 교차 검증**: 이 문서 작성과 별개로, `code-review` 스킬을 등록한 별도 에이전트가
+  같은 diff를 독립적으로(이 문서의 추론 과정을 공유하지 않고) 리뷰했고, 그 결과를 다시
+  포크한 에이전트가 재검증(CONFIRMED)했다. 그 결과가 아래 1번 항목(`nginx` 컨테이너
+  미재기동으로 인한 업스트림 IP 낡음)과 동일한 근본 원인을 독립적으로 지목했다 — 같은
+  결론에 두 개의 독립된 경로로 도달했다는 점에서 이 항목의 신뢰도가 높다고 판단했다.
+- Critical 없음 — 이번 배포(최초 `nginx` 서비스 생성) 자체가 즉시 깨지는 경로, 시크릿
+  노출 경로는 확인되지 않았다. 아래 발견 사항은 "이번 배포는 통과하지만 다음 배포부터
+  또는 향후 확장 시 문제가 되는" 경로들이다.
+
+---
+
+## 1. 🟠 High — `nginx` 컨테이너가 이후 배포에서 재기동되지 않아, `nginx.conf` 수정이 반영되지 않고 `app` 컨테이너 재생성 시 프록시 대상 IP가 낡아질 수 있음
+
+**문제**: `.github/workflows/ci.yml:423-424`는 매 배포마다 `docker compose -f
+docker-compose.dev.yml pull app`로 `app` 이미지만 새로 받고, `up -d app nginx`를
+실행한다. Docker Compose는 서비스를 재생성할지 여부를 그 서비스의 **compose 파일 상
+정의**(이미지 태그, `environment`, `volumes` 등)가 이전 실행과 달라졌는지로 판단하고,
+바인드 마운트된 호스트 파일의 **내용**이 바뀐 것은 재생성 트리거로 보지 않는다. `nginx`
+서비스 정의(`deploy/docker-compose.dev.yml:24-32`)는 이미지 태그(`nginx:1.27-alpine`,
+고정)도 볼륨 경로(`./nginx.conf:/etc/nginx/conf.d/default.conf:ro`)도 배포마다 바뀌지
+않으므로, `nginx` 컨테이너는 한 번 만들어진 뒤로는 이 워크플로우로 다시 재기동되지 않는다.
+이 하나의 원인이 서로 다른 두 가지 증상으로 나타난다.
+
+1. **`deploy/nginx.conf`를 고쳐서 배포해도 nginx에 반영되지 않는다.** 기획서는 이
+   지점을 `docker-compose.dev.yml`과 같은 디렉터리에 바인드 마운트한 이유로 "이미지를
+   새로 빌드하지 않고 파일만 교체해도 반영되므로"(`62-chore-nginx-reverse-proxy.md`
+   "`deploy/docker-compose.dev.yml` 변경" 절)를 명시적으로 든다. 하지만 nginx는 설정
+   파일을 프로세스 시작 시점 또는 `nginx -s reload` 시점에만 읽어 들인다 — 바인드
+   마운트로 컨테이너 안의 파일 내용이 즉시 바뀌어도, 이미 떠 있는 nginx worker
+   프로세스는 그 변경을 감지하지 않는다. 이 워크플로우는 재기동도 reload도 트리거하지
+   않으므로, `nginx.conf`를 고쳐 push해도 scp로 EC2에는 새 파일이 올라가지만 실행
+   중인 nginx는 이전 설정을 계속 쓴다. 이 증상은 100% 재현된다(신뢰할 수 있는
+   Docker Compose 재생성 판단 기준을 근거로 함 — 확률적 요소 없음).
+2. **`app` 컨테이너가 재생성되며 얻는 새 내부 IP를 nginx가 못 따라갈 수 있다.**
+   `deploy/nginx.conf:7`의 `proxy_pass http://app:9090;`은 변수를 쓰지 않는 정적
+   호스트명이라, nginx 공식 문서 기준으로 **시작(또는 reload) 시점에 단 한 번만**
+   DNS를 조회해 그 결과를 워커 프로세스 수명 동안 그대로 재사용한다(요청마다 재조회하지
+   않음 — 요청마다 재조회하려면 `resolver` 지시자 + 변수 조합이 필요). `app`은 `:dev`
+   태그 이미지가 배포마다 다시 빌드/푸시되므로 사실상 매 배포마다 새 이미지로 재생성되고,
+   Docker의 기본 브리지 네트워크는 컨테이너 재생성 시 이전과 다른 내부 IP를 새로 할당할
+   수 있다(항상 그런 것은 아니고 IPAM 할당 상황에 따라 같은 IP가 재사용될 수도 있음 —
+   이 부분만 확정적이지 않음). `nginx`는 위 1번 증상과 같은 이유로 이 워크플로우 안에서
+   재기동되지 않으므로, `app`이 새 IP를 받으면 nginx는 죽은 옛 IP로 계속 프록시를
+   시도해 502를 반환하게 된다. 다행히 `헬스체크` 스텝(`ci.yml:436-446`)이
+   `http://localhost:80`(nginx 경유)을 확인하고 502(5xx)는 "정상 아님"으로 판정하므로
+   이 상태는 배포 실패(❌ Discord 알림)로 시끄럽게 드러나긴 한다 — 다만 실패 원인이
+   "이번에 배포된 코드 문제"가 아니라 "nginx가 재기동되지 않아 생긴 인프라 문제"인데도
+   똑같이 "dev 배포 실패"로만 보고돼, 다음 배포부터 원인 파악에 매번 혼란을 준다.
+
+**해결 방안**:
+1. `.github/workflows/ci.yml:424` 줄을 `docker compose -f docker-compose.dev.yml up
+   -d app && docker compose -f docker-compose.dev.yml up -d --force-recreate nginx`
+   (또는 `restart nginx`)로 바꿔, `app`이 먼저 새 컨테이너로 뜬 뒤 `nginx`를 항상
+   강제로 재생성한다. 두 증상을 한 번에 해결한다 — `nginx.conf` 파일 내용이 바뀌었으면
+   재생성 시 새로 읽고, `app`의 IP가 바뀌었어도 재생성된 nginx가 그 시점의 최신 IP로
+   다시 DNS를 조회한다. 배포마다 nginx가 짧게(수백ms) 재시작되어 그 사이 요청이 순간
+   끊길 수 있다는 트레이드오프가 있지만, `app` 자체도 매 배포마다 재생성되며 이미 같은
+   수준의 순단이 발생하고 있어 새로 추가되는 리스크는 아니다.
+2. `deploy/nginx.conf`를 `resolver 127.0.0.11 valid=10s; set $upstream_app app:9090;`
+   + `proxy_pass http://$upstream_app;` 형태로 바꿔, Docker의 내장 DNS(`127.0.0.11`)로
+   10초 TTL마다 재조회하게 한다 — nginx 컨테이너 자체는 재기동하지 않아도 `app`의
+   최신 IP를 따라간다. 다만 이 방법은 "①증상: `nginx.conf` 파일 수정 자체가 반영 안 됨"은
+   해결하지 못한다(그 문제는 여전히 남아 방안 1과 함께 적용해야 한다) — 즉 방안 1
+   단독으로 두 증상을 모두 해결하는 데 비해, 이 방안은 nginx 설정에 Docker 내부 DNS에
+   대한 암묵적 의존을 추가하면서도 문제를 완전히 없애지 못해 상대적으로 이득이 적다.
+
+---
+
+## 2. 🟡 Medium — `X-Real-IP`/`X-Forwarded-For`가 실제 클라이언트 IP가 아니라 Cloudflare 엣지 IP를 담게 됨
+
+**문제**: `deploy/nginx.conf:8-9`는 `proxy_set_header X-Real-IP $remote_addr;`,
+`proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;`로 nginx 시점의
+`$remote_addr`(= nginx에 실제로 TCP 연결을 맺은 상대의 IP)를 그대로 클라이언트 IP로
+간주한다. 그런데 `gone-dev.gbsw.hs.kr`는 Cloudflare 프록시(오렌지 클라우드)가 켜진
+DNS 레코드다(기획서 개요 절) — 즉 이 EC2에 실제로 TCP 연결을 맺는 상대는 최종 사용자가
+아니라 **Cloudflare 엣지 서버**다. 따라서 `$remote_addr`는 항상 Cloudflare가 쓰는
+IP 대역 중 하나이고, 실제 사용자 IP가 아니다.
+
+기획서는 이 헤더를 지금 당장 쓰지는 않지만 "나중에 클라이언트 IP 로깅/판단이 필요해지는
+기능이 생겨도 nginx 설정을 다시 건드릴 필요가 없다"는 이유로 미리 추가해둔다고 명시한다
+(`62-chore-nginx-reverse-proxy.md` "`deploy/nginx.conf`(신규)" 절). 하지만 지금 값 그대로는
+그 미래 기능이 생겼을 때 오히려 잘못된 IP(모든 요청이 Cloudflare IP로 찍혀 사실상
+쓸모없는 로그)를 얻게 되어, 정작 필요한 시점에 nginx 설정을 다시 고쳐야 한다 — 기획서가
+피하려던 상황이 그대로 재현된다.
+
+**해결 방안**:
+1. `proxy_set_header X-Real-IP $http_cf_connecting_ip;`로 바꾼다. Cloudflare는 프록시된
+   모든 요청에 실제 클라이언트 IP를 `CF-Connecting-IP` 헤더로 origin까지 전달하므로,
+   이 값을 그대로 전달하면 된다. 구현 비용이 가장 낮다(한 줄 교체). 단점은 Cloudflare를
+   거치지 않고 직접 EC2 IP/포트 80으로 접근하는 요청이 있으면(보안그룹이 열려 있으므로
+   이론상 가능) 그 헤더를 요청자가 임의로 위조해 보낼 수 있다는 점이다 — Cloudflare
+   IP 대역에서 온 요청만 신뢰하도록 방안 2와 함께 적용하는 것이 더 안전하다.
+2. `ngx_http_realip_module`(nginx 표준 빌드에 포함, alpine 이미지도 포함)로
+   `set_real_ip_from <Cloudflare IP 대역>;` + `real_ip_header CF-Connecting-IP;`를
+   추가해, nginx 자체의 `$remote_addr`을 Cloudflare가 보고한 실제 클라이언트 IP로
+   치환한다. 이렇게 하면 지금 코드의 `$remote_addr`/`$proxy_add_x_forwarded_for` 그대로
+   두어도 올바른 값이 들어간다(코드 변경 최소화). Cloudflare IP 대역 목록을
+   (`https://www.cloudflare.com/ips/`)에서 가져와 nginx 설정에 고정 값으로 넣어야 하고,
+   Cloudflare가 대역을 바꾸면 이 목록도 갱신해야 하는 유지보수 비용이 생긴다.
+
+이번 diff에서 애플리케이션이 아직 이 헤더를 전혀 참조하지 않아(기획서 명시) 지금 당장
+기능이 깨지는 것은 아니라 Medium으로 표시했다.
+
+---
+
+## 3. 🟢 Low — `nginx.conf`에 업스트림 연결 재사용/타임아웃 설정이 없음
+
+**문제**: `deploy/nginx.conf`에 `proxy_http_version`이 없어 nginx→`app` 구간은 기본값인
+HTTP/1.0으로 통신하고, 응답마다 업스트림 연결을 새로 맺는다(keep-alive 없음). 또
+`proxy_connect_timeout`/`proxy_read_timeout` 등이 없어 모두 nginx 기본값(각 60초)을
+그대로 쓴다. dev 환경 트래픽 규모에서는 성능 차이가 체감되지 않지만, 나중에 운영(prod)
+환경에 같은 패턴을 복제할 때는 짚고 넘어갈 만하다.
+
+**해결 방안**:
+1. `location /` 블록에 `proxy_http_version 1.1;` 한 줄을 추가한다 — 구현 비용이 가장
+   낮고, 업스트림 연결 재사용의 전제 조건을 갖춘다(완전한 keep-alive를 쓰려면
+   `upstream` 블록에 `keepalive` 지시자도 필요해 이 한 줄만으로 재사용이 즉시 켜지지는
+   않는다).
+2. 이번 dev 전용 PR 범위에서는 넘기고, 운영 배포를 설계하는 후속 이슈에서 함께
+   정리한다 — 기획서도 이번 이슈 범위를 "Cloudflare 521 해소"로 명확히 좁혔으므로,
+   성능 튜닝 성격의 항목을 지금 끼워 넣지 않는 편이 범위 관리에는 더 맞는다.
+
+---
+
+## 요약
+
+Critical 없음(이번 최초 배포 자체가 즉시 깨지는 경로, 시크릿 노출 경로는 확인되지
+않음 — 위 "리뷰 범위/방법" 참고). High 1건(`nginx` 컨테이너가 이후 배포에서 재기동되지
+않아 설정 반영 누락 + 업스트림 IP 낡음 위험). Medium 1건(`X-Real-IP`/`X-Forwarded-For`가
+Cloudflare 엣지 IP를 담아, 기획서가 명시한 향후 활용 목적을 달성하지 못함). Low 1건
+(업스트림 연결 재사용/타임아웃 미설정, 성능 튜닝 성격이라 이번 범위에서는 보류 가능).
+
+기획서 범위를 벗어난 변경, 기존 컨벤션(이미지 태그 고정, 시크릿 취급 원칙, `mysql`/
+`redis` 호스트 포트 미노출 패턴, `concurrency`/`environment: dev`)과 어긋나는 지점은
+없었다.
+
+## 반영 결과
+
+- **High 1**: 해결 방안 1번을 적용했다. `ci.yml`의 `docker compose ... up -d app nginx`를
+  `up -d app` → `up -d --force-recreate nginx` 두 단계로 나눠, 매 배포마다 `nginx`를
+  강제로 재생성한다. `nginx.conf` 수정 미반영과 `app` IP 낡음 문제를 한 번에 해결한다.
+- **Medium 1**: 해결 방안 1번을 적용했다. `X-Real-IP`를 `$http_cf_connecting_ip`로
+  바꿨다. 방안 2(`ngx_http_realip_module` + Cloudflare IP 대역 등록)는 유지보수
+  비용(Cloudflare가 대역을 바꿀 때마다 갱신 필요) 대비 dev 환경에서의 이득이 낮아
+  보류 — Cloudflare를 우회해 직접 EC2:80으로 오는 위조 요청 가능성은 dev 환경 특성상
+  감수하고, 실제 위험이 되면(예: 이 헤더로 접근 제어를 하게 되는 시점) 그때 방안 2를
+  추가한다.
+- **Low 1**: 보류(해결 방안 2번 채택) — 성능 튜닝 성격이라 이번 이슈 범위 밖. 운영
+  배포 설계 후속 이슈에서 함께 정리한다.
+- 위 변경 후 `docker compose -f docker-compose.dev.yml config`(더미 `.env`)와 Python
+  `yaml.safe_load`로 `ci.yml` 문법 재확인.

--- a/docs/domain/chore/62-chore-nginx-reverse-proxy.md
+++ b/docs/domain/chore/62-chore-nginx-reverse-proxy.md
@@ -36,7 +36,7 @@ server {
     location / {
         proxy_pass http://app:9090;
         proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Real-IP $http_cf_connecting_ip;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
     }
@@ -48,6 +48,11 @@ server {
 - `X-Forwarded-*` 헤더는 지금 애플리케이션이 참조하지 않지만, 리버스 프록시 뒤에 두는
   일반적인 관례라 지금 추가해둔다 — 나중에 클라이언트 IP 로깅/판단이 필요해지는 기능이
   생겨도 nginx 설정을 다시 건드릴 필요가 없다.
+- `X-Real-IP`는 `$remote_addr`가 아니라 `$http_cf_connecting_ip`를 쓴다(코드 리뷰 2번
+  항목 반영) — `gone-dev.gbsw.hs.kr`는 Cloudflare 프록시가 켜진 레코드라 nginx에 실제로
+  TCP 연결을 맺는 상대는 항상 Cloudflare 엣지다. `$remote_addr`를 그대로 쓰면 모든
+  요청이 Cloudflare IP로 찍혀 클라이언트 IP로 쓸모가 없다 — Cloudflare가 실제 클라이언트
+  IP를 담아 origin까지 전달해주는 `CF-Connecting-IP` 요청 헤더를 그대로 흘려보낸다.
 
 ## `deploy/docker-compose.dev.yml` 변경
 ```yaml
@@ -95,10 +100,18 @@ volumes:
    target: "/opt/gone/dev"
    strip_components: 1
    ```
-2. **`docker compose up -d` 대상에 `nginx` 추가**: `docker compose -f
-   docker-compose.dev.yml up -d app`을 `up -d app nginx`로 바꾼다(`pull`은 `app`
-   이미지만 GHCR에서 받으면 되므로 `pull app`은 그대로 둔다 — `nginx` 이미지는 Docker
-   Hub 공식 이미지라 최초 1회만 받고 이후 태그 고정이라 매 배포 pull이 불필요).
+2. **`app` 기동 후 `nginx`를 매 배포마다 강제 재생성**(코드 리뷰 1번 항목 반영):
+   ```
+   docker compose -f docker-compose.dev.yml up -d app
+   docker compose -f docker-compose.dev.yml up -d --force-recreate nginx
+   ```
+   (`pull`은 `app` 이미지만 GHCR에서 받으면 되므로 `pull app`은 그대로 둔다 — `nginx`
+   이미지는 Docker Hub 공식 이미지라 최초 1회만 받고 이후 태그 고정이라 매 배포 pull이
+   불필요). `nginx`는 이미지 태그/볼륨 경로가 배포마다 바뀌지 않아 `up -d`만으로는
+   재기동되지 않는다 — `--force-recreate`로 매 배포마다 강제로 재생성해야, `app`이 새
+   컨테이너로 뜨며 바뀔 수 있는 내부 IP를 nginx가 다시 조회하고, `nginx.conf` 파일
+   수정도 반영된다(둘 다 nginx가 프로세스 시작 시점에만 확인하는 값이라, 재기동 없이는
+   바인드 마운트로 파일만 바꿔도 실행 중인 nginx에 반영되지 않는다).
 3. **헬스체크 대상을 `9090`에서 `80`으로 변경**: `curl -s -o /dev/null -w
    "%{http_code}" http://localhost:9090` → `http://localhost:80`. 이러면 헬스체크가
    nginx까지 경유하는 실제 요청 경로(Cloudflare가 쓰는 것과 동일한 경로)를 검증하게

--- a/docs/domain/chore/62-chore-nginx-reverse-proxy.md
+++ b/docs/domain/chore/62-chore-nginx-reverse-proxy.md
@@ -1,0 +1,143 @@
+# #62 dev 배포에 nginx 리버스 프록시 추가 — 기획서
+
+관련 이슈: [#62 dev 배포에 nginx 리버스 프록시 추가 (Cloudflare origin 연결)](https://github.com/GBSW-ReMake/GONE-server-V1/issues/62)
+관련 선행 이슈: [#51 dev 서버(EC2) 배포 자동화(CI/CD) 구축](../chore/51-chore-dev-cicd.md)
+
+## 개요/목적
+`gone-dev.gbsw.hs.kr`(Cloudflare 프록시 켜진 DNS 레코드)로 접속하면 `521 Web Server Is
+Down`이 발생한다. Cloudflare는 프록시가 켜진 레코드의 origin 연결을 정해진 포트 목록으로만
+시도하는데(HTTP: `80`/`8080`/`8880`/`2052`/`2082`/`2086`/`2095`, HTTPS: `443`/`2053`/`2083`/
+`2087`/`2096`/`8443`), 지금 `app` 컨테이너는 `9090`만 호스트에 노출하고 있어 이 목록에 없다
+— Cloudflare가 origin에 연결을 시도조차 하지 않는다.
+
+`80` 포트로 요청을 받아 내부적으로 `app:9090`으로 넘겨주는 nginx를 추가한다. 애플리케이션
+코드 변경은 없다 — `deploy/docker-compose.dev.yml`, 신규 `deploy/nginx.conf`,
+`.github/workflows/ci.yml`(scp 소스 목록 + 헬스체크 대상 포트)만 수정한다.
+
+## 아키텍처 (변경 후)
+```
+[Cloudflare 엣지] --(80)--> [EC2: nginx:80] --(9090, 내부 docker 네트워크)--> [app:9090]
+```
+- `nginx`가 유일하게 호스트 포트를 여는 서비스가 된다. `app`의 호스트 포트 노출(`9090:9090`)은
+  제거한다 — `mysql`/`redis`가 이미 같은 이유로 호스트 포트를 열지 않는 것과 동일한 패턴
+  (#51 코드 리뷰 1번 항목 참고). `nginx`/`app`은 같은 `docker compose` 네트워크 안에서
+  서비스 이름(`app:9090`)으로 계속 통신 가능하므로 기능 손실이 없다.
+- Cloudflare SSL/TLS 모드(Flexible/Full)는 이번 이슈 범위 밖 — 보스가 Cloudflare
+  대시보드에서 직접 설정한다. `nginx`는 평문 HTTP만 처리한다(Flexible 모드 전제). Full
+  모드로 바꾸려면 origin에도 인증서가 필요해 범위가 커지므로, 필요해지면 별도 이슈로
+  다룬다.
+
+## `deploy/nginx.conf` (신규)
+```nginx
+server {
+    listen 80;
+    server_name _;
+
+    location / {
+        proxy_pass http://app:9090;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}
+```
+- `server_name _;`(catch-all)로 둔다 — 도메인을 하드코딩하면 서브도메인이 또 바뀔 때
+  이 파일도 같이 고쳐야 한다. 이 EC2에는 `app` 하나만 떠 있어 Host 헤더로 라우팅을
+  분기할 이유가 없다.
+- `X-Forwarded-*` 헤더는 지금 애플리케이션이 참조하지 않지만, 리버스 프록시 뒤에 두는
+  일반적인 관례라 지금 추가해둔다 — 나중에 클라이언트 IP 로깅/판단이 필요해지는 기능이
+  생겨도 nginx 설정을 다시 건드릴 필요가 없다.
+
+## `deploy/docker-compose.dev.yml` 변경
+```yaml
+services:
+  mysql:
+    # (변경 없음)
+
+  redis:
+    # (변경 없음)
+
+  app:
+    image: ghcr.io/gbsw-remake/gone-server-v1:dev
+    restart: always
+    depends_on:
+      - mysql
+      - redis
+    env_file: .env
+    # ports 제거 — nginx를 통해서만 접근
+
+  nginx:
+    image: nginx:1.27-alpine
+    restart: always
+    depends_on:
+      - app
+    ports:
+      - "80:80"
+    volumes:
+      - ./nginx.conf:/etc/nginx/conf.d/default.conf:ro
+
+volumes:
+  mysql-data:
+  redis-data:
+```
+`nginx.conf`는 `docker-compose.dev.yml`과 같은 디렉터리(`/opt/gone/dev/`)에 두고
+바인드 마운트한다 — 이미지를 새로 빌드하지 않고 파일만 교체해도 반영되므로, 향후 프록시
+설정만 바꿀 때 이미지 재빌드/재푸시가 필요 없다.
+
+## `.github/workflows/ci.yml` 변경 (`deploy-dev` job)
+1. **scp 소스 목록에 `deploy/nginx.conf` 추가**. `appleboy/scp-action`은 `source`에
+   콤마로 구분된 여러 경로를 받는다 — 기존 `docker-compose.dev.yml` 전송 스텝의
+   `source`를 아래처럼 확장한다(`strip_components: 1`은 유지 — 두 파일 모두
+   `deploy/` 바로 아래에 있어 같은 규칙으로 벗겨진다).
+   ```yaml
+   source: "deploy/docker-compose.dev.yml,deploy/nginx.conf"
+   target: "/opt/gone/dev"
+   strip_components: 1
+   ```
+2. **`docker compose up -d` 대상에 `nginx` 추가**: `docker compose -f
+   docker-compose.dev.yml up -d app`을 `up -d app nginx`로 바꾼다(`pull`은 `app`
+   이미지만 GHCR에서 받으면 되므로 `pull app`은 그대로 둔다 — `nginx` 이미지는 Docker
+   Hub 공식 이미지라 최초 1회만 받고 이후 태그 고정이라 매 배포 pull이 불필요).
+3. **헬스체크 대상을 `9090`에서 `80`으로 변경**: `curl -s -o /dev/null -w
+   "%{http_code}" http://localhost:9090` → `http://localhost:80`. 이러면 헬스체크가
+   nginx까지 경유하는 실제 요청 경로(Cloudflare가 쓰는 것과 동일한 경로)를 검증하게
+   되어, 기존보다 오히려 더 정확한 헬스체크가 된다.
+
+## 영향 받는 기존 코드/설정
+- `deploy/nginx.conf`(신규)
+- `deploy/docker-compose.dev.yml`: `app` 서비스 `ports` 제거, `nginx` 서비스 추가
+- `.github/workflows/ci.yml`: `deploy-dev` job의 scp 소스, `docker compose up -d` 대상,
+  헬스체크 URL 수정
+- 애플리케이션 코드(Java) 변경 없음 — `api-design.md` 6원칙 검토는 해당 없음
+- `mysql`/`redis`는 변경 없음(계속 호스트 포트 미노출)
+
+## 리스크 및 고려사항
+- **`app`의 `9090` 호스트 포트 노출을 제거하면, EC2 안에서 직접
+  `curl localhost:9090`으로 디버깅하던 방법이 막힌다.** 필요하면 `docker exec`로
+  컨테이너 안에 들어가거나, `docker compose exec app curl localhost:9090`처럼 같은
+  네트워크 안에서 확인해야 한다(`mysql`/`redis`가 이미 같은 트레이드오프를 가지고
+  있음, #51 기획서 참고).
+- **EC2 보안그룹 인바운드 `80` 허용**: 확인 완료 — dev EC2 보안그룹에 `80`(및 `443`)이
+  이미 열려 있어 이 이슈에서 별도로 조치할 게 없다.
+- **Cloudflare SSL/TLS 모드가 Flexible이 아니면(Full/Full Strict) 동작하지 않는다.**
+  nginx가 평문 HTTP만 처리하므로, Cloudflare가 origin에 HTTPS로 연결을 시도하는 모드면
+  이 구성으로는 여전히 실패한다 — 이것도 보스가 Cloudflare 대시보드에서 직접 확인한다.
+- **`nginx:1.27-alpine` 이미지 버전을 고정 태그로 둔다** — `latest`처럼 움직이는 참조는
+  쓰지 않는다(#51에서 세운 third-party 이미지/액션 버전 고정 원칙과 동일).
+- **자동 롤백 없음**: 헬스체크 실패 시 Discord 알림만 오고 이전 이미지로 되돌리지 않는다
+  (#51과 동일한 기존 정책, 이번 이슈로 바뀌지 않음).
+
+## 완료 조건 (Definition of Done)
+- `https://gone-dev.gbsw.hs.kr` 요청이 nginx를 거쳐 `app`까지 도달해 응답한다(Cloudflare
+  SSL 모드/보안그룹은 보스가 별도로 맞춘 뒤 확인)
+- `mysql`/`redis` 컨테이너는 이번 배포로 재시작되지 않고 데이터가 유지된다
+- 로컬 `./gradlew build`/`checkstyleMain`(Java 코드 변경 없으므로 기존 상태 유지 확인),
+  CI 통과
+- 배포 성공/실패 Discord 알림은 기존과 동일하게 온다(변경 없음)
+
+## 테스트 방법
+- 컨트롤러/애플리케이션 코드 변경이 없어 단위 테스트 대상 없음.
+- `deploy/nginx.conf` 문법은 `docker run --rm -v $(pwd)/deploy/nginx.conf:/etc/nginx/conf.d/default.conf:ro nginx:1.27-alpine nginx -t`로 로컬에서 검증.
+- `.github/workflows/ci.yml`은 YAML 파싱 검증(#51 QA와 동일한 방식) + 실제 `dev` 배포
+  후 위 "완료 조건"을 직접 확인.


### PR DESCRIPTION
## 관련 이슈
closes #62

## 작업 내용
`gone-dev.gbsw.hs.kr`(Cloudflare 프록시 켜진 레코드)로 접속 시 `521 Web Server Is Down`이 발생하던 문제를 해결한다. Cloudflare는 origin 연결을 정해진 포트 목록으로만 시도하는데 `app`이 노출하던 `9090`이 그 목록에 없었다 — `80`으로 받아 내부적으로 `app:9090`으로 넘겨주는 nginx를 추가한다.

## 변경 사항 상세
- `deploy/nginx.conf` 신규 — `80`으로 받아 `app:9090`으로 프록시. `X-Real-IP`는 `CF-Connecting-IP` 헤더를 그대로 전달해 실제 클라이언트 IP를 보존한다(코드 리뷰 Medium 1 반영)
- `deploy/docker-compose.dev.yml` — `app`의 `9090:9090` 호스트 포트 노출 제거(mysql/redis와 동일한 패턴), `nginx` 서비스 신규 추가(`nginx:1.27-alpine`, `80:80`, `nginx.conf` 바인드 마운트)
- `.github/workflows/ci.yml`(`deploy-dev` job):
  - scp 소스에 `deploy/nginx.conf` 추가(기존 `docker-compose.dev.yml`과 함께 전송)
  - `app` 기동 후 `nginx`를 매 배포마다 `--force-recreate`로 강제 재생성 — nginx는 이미지 태그/볼륨 경로가 배포마다 안 바뀌어 일반 `up -d`로는 재기동되지 않는데, 이러면 (1) `nginx.conf` 파일 수정이 반영 안 되고 (2) `app`이 재생성되며 바뀔 수 있는 내부 IP를 nginx가 못 따라가 502가 날 수 있다(코드 리뷰 High 1 반영)
  - 헬스체크 대상을 `http://localhost:9090`에서 `http://localhost:80`(nginx 경유)으로 변경 — Cloudflare가 실제로 쓰는 경로를 그대로 검증
- 애플리케이션(Java) 코드 변경 없음
- 기획서와 실제 구현 차이: 없음(코드 리뷰 반영 내용은 기획서에도 함께 갱신)

관련 문서: [기획서](docs/domain/chore/62-chore-nginx-reverse-proxy.md) · [코드 리뷰](docs/domain/chore/62-chore-nginx-reverse-proxy-code-review.md) · [QA](docs/domain/chore/62-chore-nginx-reverse-proxy-QA.md)

## ⚠️ 머지 후 확인 필요
이 로컬 환경에 Docker 데몬이 없어 `nginx -t` 실제 문법 검증과 Cloudflare 경유 실접속 테스트를 못 했다(QA 문서 Medium 2건). **`dev` 머지 후 첫 배포에서 `https://gone-dev.gbsw.hs.kr` 접속이 실제로 되는지 확인이 필요하다.**

## 확인 사항
- [x] 로컬 빌드 통과 (`./gradlew build`)
- [x] Checkstyle 통과 (`./gradlew checkstyleMain`)
- [x] CI(checkstyle, build-and-test) 통과
- [ ] (해당 시) Notion 기능정의서/기획 문서 반영
- [x] (해당 시) 관련 도메인 라벨 지정
