### PR TITLE
feat(notification): #65 Notification.type을 Enum으로 전환

### DIFF
--- a/docs/domain/notification/1_notification-domain.md
+++ b/docs/domain/notification/1_notification-domain.md
@@ -96,11 +96,14 @@
 - `user_id` — 수신자(`User` FK)
 - `title` — 알림 제목
 - `body` — 알림 본문
-- `type` — 발송한 도메인이 자유롭게 붙이는 분류 태그(`VARCHAR(50)`, nullable, 예:
-  `"OUTING_APPROVED"`). **알림 도메인은 이 값의 의미를 모른다** — 클라이언트가 아이콘
-  선택/화면 이동(딥링크)에 쓸 수 있도록 문자열 그대로 전달만 한다. `outing`/`schoolcamp`
-  같은 구체 도메인의 enum을 `notification` 패키지가 참조하면 역방향 의존이 생기므로
-  일부러 자유 문자열로 둔다.
+- `type` — 알림 분류(`NotificationType` Enum, `VARCHAR(50)`, nullable, 예: `OUTING`).
+  프론트엔드가 이 값 하나당 이모지 1개를 매핑한다(#65) — 이벤트 단위(승인/거절/리마인더
+  등)가 아니라 **도메인 단위**로 값을 나눈다(`OUTING`/`SCHOOLCAMP`/`MERIT`/`DEMERIT`).
+  Enum은 `notification` 패키지가 직접 소유한다 — `outing`/`schoolcamp`는 이미
+  `NotificationService.send(...)`를 호출하려면 `notification` 패키지에 의존해야 하므로,
+  그 패키지가 소유한 Enum을 함께 참조하는 것은 새로운 역방향 의존을 만들지 않는다(#65
+  기획서 "개요/목적" 참고 — 최초 설계는 이 필드를 자유 문자열로 뒀으나 역방향 의존 우려가
+  실제로는 성립하지 않는다는 판단으로 뒤집었다).
 - `is_read` — 읽음 여부(`BOOLEAN`, 기본 `false`)
 - `created_at` — 발송(저장) 시각
 
@@ -144,7 +147,7 @@ API와 동일한 페이지네이션 파라미터/제약 재사용)
         "id": 501,
         "title": "외출증이 승인되었습니다",
         "body": "김선생님이 12:30 외출을 승인했어요.",
-        "type": "OUTING_APPROVED",
+        "type": "OUTING",
         "isRead": false,
         "createdAt": "2026-08-14T12:29:10"
       }
@@ -280,7 +283,7 @@ public class NotificationService {
 
   private final NotificationRepository notificationRepository;
 
-  public void send(Long userId, String title, String body, String type) {
+  public void send(Long userId, String title, String body, NotificationType type) {
     Notification notification = Notification.builder()
         .userId(userId).title(title).body(body).type(type).isRead(false).build();
     notificationRepository.save(notification); // 저장 실패는 그대로 예외 전파(정책 가정 참고)
@@ -288,7 +291,7 @@ public class NotificationService {
 }
 ```
 다른 도메인(`outing`, `schoolcamp`)은 이 빈을 주입받아 `notificationService.send(userId,
-"외출증이 승인되었습니다", "...", "OUTING_APPROVED")`처럼 호출하기만 하면 된다.
+"외출증이 승인되었습니다", "...", NotificationType.OUTING)`처럼 호출하기만 하면 된다.
 
 ### 2단계에서의 확장 (FCM 추가, 시그니처 불변)
 ```java

--- a/docs/domain/notification/65-notification-type-enum-QA.md
+++ b/docs/domain/notification/65-notification-type-enum-QA.md
@@ -1,0 +1,29 @@
+# #65 Notification.type을 Enum으로 전환 — QA 결과
+
+관련 기획서: [65-notification-type-enum.md](./65-notification-type-enum.md)
+관련 코드 리뷰: [65-notification-type-enum-code-review.md](./65-notification-type-enum-code-review.md)
+(9단계 코드 리뷰 지적 사항 Low 1건은 QA 이전에 반영 완료 — 이 문서는 그 이후 로컬
+검증 결과만 다룬다)
+
+## 검증 방법/범위
+- 이 이슈는 컨트롤러/REST API가 없다(기획서 "엔드포인트: 없음") — 실제 서버를 띄운
+  Postman/curl 검증 대상 자체가 없다.
+- `./gradlew checkstyleMain checkstyleTest`: 통과.
+- `./gradlew test --tests "com.remake.gone.notification.*"`: 통과
+  (`savesNotificationWithGivenValues`가 `NotificationType.OUTING`을 저장/비교하도록,
+  `allowsNullType`은 그대로 `null`을 검증).
+- `./gradlew build`(전체): 통과.
+- GitHub Actions CI: PR 생성 시 자동으로 실행되는 결과를 그때 확인한다(feature 브랜치
+  push만으로는 트리거 안 됨, #59/#62 QA와 동일한 사유).
+
+## 발견 사항
+
+### Critical / High / Medium
+없음(9단계 코드 리뷰에서 나온 Low 1건은 그 단계에서 이미 반영 완료).
+
+### Low
+없음.
+
+## 결론
+Critical/High/Medium/Low 모두 없음. 로컬에서 검증 가능한 범위(빌드/테스트/체크스타일)는
+전부 통과했다. 컨트롤러가 없는 이슈 특성상 실서버 기반 QA는 해당 사항이 없다.

--- a/docs/domain/notification/65-notification-type-enum-code-review.md
+++ b/docs/domain/notification/65-notification-type-enum-code-review.md
@@ -1,0 +1,96 @@
+# #65 Notification.type을 Enum으로 전환 — 코드 리뷰 결과
+
+관련 기획서: [65-notification-type-enum.md](./65-notification-type-enum.md)
+선행 이슈 코드 리뷰: [59-notification-core-code-review.md](./59-notification-core-code-review.md)
+형식 규칙: [code-review-template.md](../../rules/code-review-template.md)
+
+## 리뷰 범위/방법
+
+- 대상: `git diff dev feat/#65-notification-type-enum`(`src/` 기준 4개 파일, 3커밋
+  — 기획서 커밋 1개 + feat 커밋 2개 + test 커밋 1개).
+- 변경 파일: `NotificationType.java`(신규, `notification.enums` 패키지),
+  `Notification.java`(`type` 필드 `String` → `NotificationType`),
+  `NotificationService.java`(`send(...)` 네 번째 파라미터 타입 변경),
+  `NotificationServiceTest.java`(문자열 리터럴 → Enum 상수).
+- 기획서(`65-notification-type-enum.md`) 대비 범위 초과 변경이 없는지 `git grep`으로
+  `NotificationType`/`NotificationService` 사용처를 브랜치 전체에서 검색해 확인했다 —
+  테스트 파일을 제외하면 실제 호출부가 여전히 없고(기획서 "엔드포인트: 없음" 절과 일치),
+  컨트롤러/DTO 변경 없음, `schoolcamp`/`conduct` 패키지 모두 아직 존재하지 않음(기획서
+  "리스크 및 고려사항" 절이 명시한 전제와 일치), 신규 Flyway 마이그레이션 파일도 없음(기획서
+  "Flyway 마이그레이션: 불필요" 절과 일치)을 확인했다.
+- `@Enumerated(EnumType.STRING)` + `@Column(length = 50)` 조합과 어노테이션 순서
+  (`@Enumerated`를 `@Column` 위에 배치)를 `outing.entity.Outing.status`(동일 패턴,
+  `length = 20`)와 대조해 일치를 확인했다. 컬럼 길이(50)는 가장 긴 값(`SCHOOLCAMP`, 10자)
+  대비 충분한 여유가 있고, 기획서가 명시한 대로 마이그레이션 없이 기존 `VARCHAR(50)` 컬럼에
+  그대로 들어간다.
+- 신규 패키지 `notification.enums`의 위치를 `outing.enums`/`meal.enums`/`gbsw.enums`와
+  대조해 기존 컨벤션과 일치함을 확인했다 — `code-style.md`가 요구하는 "목록에 없는 폴더는
+  근거 필요" 조항에 해당하지 않는다(이미 쓰이고 있는 하위 패키지 패턴).
+- Import 정렬(ASCII 알파벳 순, 와일드카드 없음), Javadoc 배치(공개 API/필드에만), 한 줄
+  100자 제한을 4개 파일 전부 대조했다 — 위반 없음.
+- 문장/주석 규칙(`sentence-refinement.md` 원칙 6)도 확인했다 — 신규/수정된 Javadoc
+  (`NotificationType` 클래스, `Notification.type` 필드, `NotificationService.send`의
+  `type` 파라미터)이 전부 "무엇"이 아니라 "왜"(프론트엔드 이모지 매핑이 목적이라는 점,
+  이벤트 단위가 아니라 도메인 단위로 값을 나눈 이유)를 설명하고 있어 위반 없음.
+- `59-notification-core-code-review.md`의 "반영 결과"(`userRepository.getReferenceById`
+  패턴, `title`/`body` 100자/500자 제약을 Javadoc으로 명시하는 계약)가 이번 diff에서 그대로
+  유지되는지 확인했다 — `NotificationService.java`의 diff가 해당 두 지점(`getReferenceById`
+  호출부, 길이 제약 Javadoc 문구)을 전혀 건드리지 않아 회귀 없음.
+- 독립 에이전트(컨텍스트 격리, 같은 diff + 기획서만 전달)로 `code-review` 스킬 리뷰를 한
+  라운드 더 돌려 교차 검증했다 — correctness/reuse/simplification/efficiency 관점에서
+  findings 0건. 시그니처 변경(`String` → `NotificationType`)이 파급시킬 다운스트림 호출부가
+  없다는 점, DB 컬럼 길이 여유, 테스트가 `==` 비교로 Enum을 올바르게 검증한다는 점을 근거로
+  들었다.
+
+---
+
+## 1. 🟢 Low — 마스터 기획서(`1_notification-domain.md`)가 이번 이슈로 뒤집힌 설계 근거를 그대로 남겨두고 있음
+
+**문제**: `docs/domain/notification/1_notification-domain.md`("도메인 모델" 절,
+99~103번째 줄)는 `type`을 "발송한 도메인이 자유롭게 붙이는 분류 태그"로 설명하고 예시로
+`"OUTING_APPROVED"`(이벤트 단위 문자열)를 든다. 같은 절은 "`outing`/`schoolcamp` 같은
+구체 도메인의 enum을 `notification` 패키지가 참조하면 역방향 의존이 생기므로 일부러 자유
+문자열로 둔다"는 근거를 명시하고, 엔드포인트 응답 예시(127~150번째 줄)도
+`"type": "OUTING_APPROVED"`를 그대로 보여준다.
+
+이번 이슈(#65)의 기획서(`65-notification-type-enum.md` "개요/목적")는 정확히 이 근거
+("역방향 의존")를 반박하고 `type`을 Enum으로 전환했고, 실제 Enum 값도 이벤트 단위
+(`OUTING_APPROVED`)가 아니라 도메인 단위(`OUTING`/`SCHOOLCAMP`/`MERIT`/`DEMERIT`)로
+확정했다. 하지만 이번 diff는 `1_notification-domain.md`를 전혀 수정하지 않는다. 마스터
+기획서만 읽는 향후 독자(예: `schoolcamp`/`conduct` 담당자가 `send(...)` 호출부를 만들 때)는
+"`type`은 자유 문자열이고 이벤트 단위 값을 쓴다"는, 지금은 틀린 정보를 그대로 받아들일 수
+있다.
+
+이슈 기획서의 "완료 조건"이 요구하는 건 "Notion 문서에 전체 Enum 값 목록 반영"뿐이라(로컬
+마스터 문서 갱신은 명시되지 않음) diff가 이 문서를 건드리지 않은 것 자체가 기획서 위반은
+아니다 — 다만 로컬 마스터 기획서와 실제 구현이 어긋난 상태로 남는다는 사실은 그대로다.
+
+**해결 방안**:
+1. **이번 PR에 `1_notification-domain.md`의 해당 절(99~103번째 줄, 147번째 줄 응답 예시)을
+   이번 이슈의 결론에 맞게 갱신하는 커밋을 추가한다** — 마스터 문서와 구현이 항상 일치하는
+   상태를 보장하지만, 기획서가 명시한 범위(코드 4개 파일 + 이슈 기획서 1개)를 벗어나므로
+   별도로 다뤄도 되는지 먼저 확인이 필요하다.
+2. **후속 이슈(`outing`/`schoolcamp` 연동으로 실제 호출부가 생기는 시점)에서 한꺼번에 마스터
+   문서를 갱신한다** — 지금 이슈의 범위를 늘리지 않는다는 장점이 있지만, 그 사이 마스터
+   문서를 참고하는 사람이 뒤집힌 정보를 그대로 볼 위험이 남는다.
+3. **지금 상태를 유지하고 이 코드 리뷰 문서를 "마스터 문서 갱신이 아직 필요하다"는 근거로만
+   남겨둔다** — 추가 비용이 없지만, 문서 드리프트가 언제 해소될지 보장되지 않는다.
+
+---
+
+## 요약
+
+Critical/High/Medium 없음. Low 1건 — 마스터 기획서(`1_notification-domain.md`)가 이번
+이슈로 뒤집힌 "역방향 의존" 설계 근거와 이벤트 단위 예시 값을 그대로 남겨두고 있어, 이번
+diff가 반영한 도메인 단위 Enum 설계와 어긋난 상태다. 코드 자체(Enum 정의, 엔티티 필드 변경,
+서비스 시그니처 변경, 테스트 갱신)에는 Critical/High/Medium급 결함이 없다 — 범위·컨벤션·
+스타일 대조, 다운스트림 호출부 부재 확인, `#59` 코드 리뷰에서 반영된 두 계약(FK 참조 방식,
+길이 제약 Javadoc)의 회귀 여부까지 모두 확인 완료. 독립 에이전트로 돌린 교차 검증 라운드도
+동일하게 findings 0건이었다.
+
+## 반영 결과
+
+- **Low 1**: 해결 방안 1번을 적용했다. `1_notification-domain.md`의 "도메인 모델" 절
+  (`type` 필드 설명)과 엔드포인트 응답 예시를 이번 이슈의 결론(도메인 단위 Enum,
+  `notification` 패키지가 자체 소유)에 맞게 갱신했다. 마스터 문서 갱신이 이번 이슈
+  하나의 범위를 크게 벗어나지 않는 작은 수정이라 별도 확인 없이 바로 반영했다.

--- a/docs/domain/notification/65-notification-type-enum.md
+++ b/docs/domain/notification/65-notification-type-enum.md
@@ -1,0 +1,125 @@
+# #65 Notification.type을 Enum으로 전환 — 기획서
+
+관련 이슈: [#65 Notification.type을 Enum으로 전환 (도메인별 이모지 매핑용)](https://github.com/GBSW-ReMake/GONE-server-V1/issues/65)
+관련 선행 이슈: [#59 알림 도메인 — Notification 엔티티 + 공통 발송 모듈](../notification/59-notification-core.md)
+전체 도메인 마스터 기획서: [1_notification-domain.md](./1_notification-domain.md)
+
+## 개요/목적
+프론트엔드가 알림 목록에서 `type` 값에 따라 이모지를 매핑해 보여주려면, `type`이 어떤
+값들로 올 수 있는지 코드로 보장돼야 한다. 지금 `Notification.type`(#59)은 자유
+문자열(`VARCHAR(50)`, nullable)이라 이 보장이 없다 — 오타/새 값 추가가 컴파일 타임에
+걸러지지 않는다. `type`을 정해진 값만 허용하는 Enum(`NotificationType`)으로 바꾼다.
+
+**#59 마스터 기획서([1_notification-domain.md](./1_notification-domain.md) "도메인 모델")는
+`type`을 자유 문자열로 둔 이유로 "`notification` 패키지가 `outing`/`schoolcamp` 같은
+구체 도메인의 enum을 참조하면 역방향 의존이 생긴다"를 들었다. 이번 이슈는 그 우려를
+Enum을 `notification` 패키지 안에서 직접 정의하는 방식으로 해소한다** — `outing`/
+`schoolcamp`/`conduct`는 이미 `NotificationService`를 호출하기 위해 `notification`
+패키지에 의존하므로(역방향이 아니라 원래 방향), 그 패키지가 소유한 `NotificationType`을
+함께 참조하는 것은 새로운 의존을 추가하지 않는다. 즉 우려했던 "notification이 outing을
+아는 상황"은 여전히 발생하지 않는다 — 반대로 "outing이 notification의 타입을 아는
+상황"일 뿐이고, 이건 애초에 `send(...)`를 호출하기 위해 이미 성립해 있던 관계다.
+
+## 작업 범위
+- `com.remake.gone.notification.enums.NotificationType` 신규 — 값 목록은 아래 "Enum
+  값 목록" 참고
+- `Notification.type`을 `String`에서 `NotificationType`으로 변경(`@Enumerated(EnumType.STRING)`,
+  `outing.entity.Outing`의 `status` 필드와 동일한 패턴)
+- `NotificationService.send(Long userId, String title, String body, String type)`의
+  네 번째 파라미터를 `NotificationType type`으로 변경
+- `NotificationServiceTest` 갱신(문자열 리터럴 → Enum 상수)
+- Flyway 마이그레이션 불필요 — 컬럼은 이미 `VARCHAR(50)`이고 Enum도 `EnumType.STRING`으로
+  같은 문자열 컬럼에 저장되므로 DB 스키마 변경이 없다(아래 "데이터 모델 변경" 참고)
+
+## 엔드포인트
+없음. 이 이슈는 컨트롤러를 추가/변경하지 않는다 — `NotificationService.send(...)`
+시그니처만 바뀐다. 실제 호출부(`outing`/`schoolcamp`/`conduct` 연동)는 각 도메인의
+후속 이슈에서 이 Enum 상수를 그대로 가져다 쓴다.
+
+## Enum 값 목록
+프론트엔드가 이 값 하나당 이모지 1개를 매핑한다(보스 확정) — 이벤트 단위(승인/거절/
+리마인더 등)가 아니라 **도메인 단위**로 값을 나눈다. `conduct`는 상점과 벌점을 같은
+도메인 안에서도 서로 다른 이모지로 구분해야 해서 둘로 나눈다.
+
+```java
+public enum NotificationType {
+  OUTING,     // 외출증(outing) 도메인의 모든 알림(승인/거절/복귀 리마인더 등)
+  SCHOOLCAMP, // 스쿨캠핑(schoolcamp) 도메인의 모든 알림(팀원 초대/외출 리마인더 등)
+  MERIT,      // 상점(conduct 도메인, 상점 부여/취소)
+  DEMERIT,    // 벌점(conduct 도메인, 벌점 부여/취소)
+}
+```
+- 각 값은 도메인(또는 `conduct`의 상/벌점처럼 이모지가 갈리는 하위 구분) 전체를 대표한다
+  — 같은 도메인 안에서 세부 이벤트가 늘어나도(예: `outing`에 새 알림 종류가 추가돼도)
+  이 Enum에 값을 추가하지 않는다. `title`/`body`가 이벤트별 세부 문구를 담당하고,
+  `type`은 오직 "이모지를 뭘로 보여줄지"만 결정한다.
+- 실제 호출부가 아직 없는 도메인(`schoolcamp`/`conduct`)도 마스터 기획서에 알림 트리거
+  지점이 이미 명시돼 있어(각 마스터 기획서 "알림 트리거"/"외출 도메인 연동" 절) 값 자체는
+  지금 정의해도 안전하다 — `Notification` 엔티티가 #59에서 미리 완결된 스키마로 설계된
+  것과 같은 이유(나중에 호출부가 붙을 때 이 Enum을 다시 건드릴 필요가 없게).
+
+## 공통 발송 모듈 — `NotificationService` (변경)
+```java
+public void send(Long userId, String title, String body, NotificationType type) {
+  Notification notification = Notification.builder()
+      .user(user)
+      .title(title)
+      .body(body)
+      .type(type)
+      .isRead(false)
+      .build();
+  notificationRepository.save(notification);
+}
+```
+시그니처의 파라미터 개수/순서는 그대로 유지하고 네 번째 파라미터의 타입만 바뀐다 — 이미
+호출부가 없는 상태(#59 완료 시점 기준)라 하위 호환성을 깨는 대상 자체가 없다.
+
+## 데이터 모델 변경
+### `Notification` 엔티티 — `type` 필드
+- 변경 전: `@Column(length = 50) private String type;`
+- 변경 후: `@Enumerated(EnumType.STRING) @Column(length = 50) private NotificationType type;`
+- `nullable`은 그대로 지정하지 않는다(#59와 동일하게 nullable 허용) — 알림 목록 조회
+  화면에서 이모지 매핑이 안 되는 시스템 공지성 알림 등, 특정 도메인 이벤트로 분류되지
+  않는 알림을 위한 여지를 남긴다.
+- 컬럼 길이(`50`)는 그대로 유지 — 가장 긴 값(`SCHOOLCAMP`, 10자)도 여유 있게 들어간다.
+
+### Flyway 마이그레이션
+불필요. `@Enumerated(EnumType.STRING)`은 Enum 상수 이름을 그대로 문자열로 저장하므로,
+DB 입장에서는 이전과 동일한 `VARCHAR(50)` 컬럼에 문자열이 들어가는 것과 차이가 없다.
+`ALTER TABLE`이 필요한 타입 변경(예: `INT`로 바꾸는 경우)이 아니다.
+
+## 영향 받는 기존 코드
+- `com.remake.gone.notification.enums.NotificationType`(신규 패키지 `notification.enums`
+  — `outing.enums`/`meal.enums`/`gbsw.enums`와 동일한 하위 패키지 구조)
+- `Notification.java`: `type` 필드 타입 변경
+- `NotificationService.java`: `send(...)` 네 번째 파라미터 타입 변경
+- `NotificationServiceTest.java`: 문자열 리터럴(`"OUTING_APPROVED"`, `null`)을
+  `NotificationType.OUTING`, `null`(Enum도 그대로 null 허용)로 변경
+
+## API 설계 6원칙 체크
+엔드포인트 변경이 없어 해당 없음.
+
+## 리스크 및 고려사항
+- **#59 마스터 기획서의 명시적 설계를 뒤집는 변경이다.** 위 "개요/목적"에서 다뤘듯,
+  실제로는 우려했던 역방향 의존이 발생하지 않아 안전하다고 판단하지만, 이 판단이
+  틀렸다면(예: 나중에 `notification` 패키지가 각 도메인 enum까지 참조해야 하는 상황이
+  생기면) 그건 다시 별도로 검토할 문제다.
+- **`schoolcamp`/`conduct`는 아직 구현되지 않은 도메인이다.** 다만 값이 도메인 단위라
+  세부 이벤트 설계가 바뀌어도(예: schoolcamp에 리마인더 종류가 늘어나도) 이 Enum
+  자체는 영향받지 않는다 — 새 도메인이 통째로 추가되는 경우에만 값을 늘리면 된다.
+- **Enum 값 이름이 Notion API 명세서에 그대로 노출된다.** 프론트가 이 문자열 그대로
+  이모지 맵의 키로 쓸 것이므로, 한 번 정하면 이름을 바꿀 때 프론트 코드도 함께
+  고쳐야 한다 — 이번 이슈에서 신중하게 확정한다.
+
+## 완료 조건 (Definition of Done)
+- `Notification.type`이 `NotificationType` Enum
+- `NotificationServiceTest` 통과(Enum 값으로 갱신)
+- 로컬 빌드/테스트/체크스타일 통과, CI 통과
+- Notion 문서에 전체 Enum 값 목록 반영(프론트가 이모지 매핑표를 만들 수 있도록)
+
+## 테스트 방법
+컨트롤러가 없어 Postman 검증 대상이 없다.
+1. 단위 테스트(`NotificationServiceTest`)로 `send(...)`가 `NotificationType` 값을 그대로
+   저장하는지 확인(기존 "정상 저장"/"type null 허용" 케이스를 Enum 기준으로 유지)
+2. `./gradlew build`, `./gradlew test`, `./gradlew checkstyleMain` 로컬 통과 확인 + CI
+   통과 확인

--- a/src/main/java/com/remake/gone/notification/entity/Notification.java
+++ b/src/main/java/com/remake/gone/notification/entity/Notification.java
@@ -1,8 +1,11 @@
 package com.remake.gone.notification.entity;
 
+import com.remake.gone.notification.enums.NotificationType;
 import com.remake.gone.user.entity.User;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -49,14 +52,10 @@ public class Notification {
   @Column(nullable = false, length = 500)
   private String body;
 
-  /**
-   * 발송한 도메인이 자유롭게 붙이는 분류 태그(예: {@code "OUTING_APPROVED"}).
-   *
-   * <p>알림 도메인은 이 값의 의미를 모른다 — {@code outing}/{@code schoolcamp} 같은 구체
-   * 도메인의 enum을 참조하면 역방향 의존이 생기므로 일부러 자유 문자열로 둔다.
-   */
+  /** 알림 분류(프론트엔드 이모지 매핑용, {@link NotificationType} 참고). */
+  @Enumerated(EnumType.STRING)
   @Column(length = 50)
-  private String type;
+  private NotificationType type;
 
   @Column(name = "is_read", nullable = false)
   private boolean isRead;

--- a/src/main/java/com/remake/gone/notification/enums/NotificationType.java
+++ b/src/main/java/com/remake/gone/notification/enums/NotificationType.java
@@ -1,0 +1,16 @@
+package com.remake.gone.notification.enums;
+
+/**
+ * 알림 분류.
+ *
+ * <p>프론트엔드가 이 값 하나당 이모지 1개를 매핑한다 — 이벤트 단위(승인/거절/리마인더
+ * 등)가 아니라 도메인 단위로 값을 나눈다. {@code conduct}는 상점과 벌점을 서로 다른
+ * 이모지로 구분해야 해서 둘로 나눈다. 같은 도메인 안에서 세부 이벤트가 늘어나도 이 값에는
+ * 영향이 없다 — {@code title}/{@code body}가 이벤트별 세부 문구를 담당한다.
+ */
+public enum NotificationType {
+  OUTING,
+  SCHOOLCAMP,
+  MERIT,
+  DEMERIT
+}

--- a/src/main/java/com/remake/gone/notification/service/NotificationService.java
+++ b/src/main/java/com/remake/gone/notification/service/NotificationService.java
@@ -1,6 +1,7 @@
 package com.remake.gone.notification.service;
 
 import com.remake.gone.notification.entity.Notification;
+import com.remake.gone.notification.enums.NotificationType;
 import com.remake.gone.notification.repository.NotificationRepository;
 import com.remake.gone.user.entity.User;
 import com.remake.gone.user.repository.UserRepository;
@@ -32,9 +33,9 @@ public class NotificationService {
    * @param userId 수신자 사용자 ID
    * @param title  알림 제목(100자 이하)
    * @param body   알림 본문(500자 이하)
-   * @param type   발송 도메인이 붙이는 분류 태그(nullable)
+   * @param type   알림 분류(nullable)
    */
-  public void send(Long userId, String title, String body, String type) {
+  public void send(Long userId, String title, String body, NotificationType type) {
     User user = userRepository.getReferenceById(userId);
     Notification notification = Notification.builder()
         .user(user)

--- a/src/test/java/com/remake/gone/notification/service/NotificationServiceTest.java
+++ b/src/test/java/com/remake/gone/notification/service/NotificationServiceTest.java
@@ -4,6 +4,7 @@ import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
+import com.remake.gone.notification.enums.NotificationType;
 import com.remake.gone.notification.repository.NotificationRepository;
 import com.remake.gone.user.entity.User;
 import com.remake.gone.user.repository.UserRepository;
@@ -43,13 +44,13 @@ class NotificationServiceTest {
           .willReturn(User.builder().id(USER_ID).build());
 
       notificationService.send(USER_ID, "외출증이 승인되었습니다", "12:30 외출을 승인했어요.",
-          "OUTING_APPROVED");
+          NotificationType.OUTING);
 
       verify(notificationRepository).save(argThat(notification ->
           notification.getUser().getId().equals(USER_ID)
               && notification.getTitle().equals("외출증이 승인되었습니다")
               && notification.getBody().equals("12:30 외출을 승인했어요.")
-              && notification.getType().equals("OUTING_APPROVED")
+              && notification.getType() == NotificationType.OUTING
               && !notification.isRead()));
     }
 


### PR DESCRIPTION
## 관련 이슈
closes #65

## 작업 내용
프론트엔드가 알림 목록에서 `type`별로 이모지를 매핑할 수 있도록, 자유 문자열이던 `Notification.type`을 정해진 값만 허용하는 Enum으로 바꾼다. 이벤트 단위가 아니라 도메인 단위(도메인당 이모지 1개)로 값을 나눈다.

## 변경 사항 상세
- `com.remake.gone.notification.enums.NotificationType` 신규 — `OUTING`/`SCHOOLCAMP`/`MERIT`/`DEMERIT`
- `Notification.type`을 `String`에서 이 Enum으로 전환(`@Enumerated(EnumType.STRING)`, `outing.entity.Outing.status`와 동일한 패턴). 마이그레이션 불필요 — 기존 `VARCHAR(50)` 컬럼에 그대로 저장됨
- `NotificationService.send(...)`의 `type` 파라미터 타입 변경(호출부가 아직 없어 하위 호환성 문제 없음)
- `NotificationServiceTest` Enum 기준으로 갱신
- 마스터 기획서(`1_notification-domain.md`)의 "역방향 의존" 근거 갱신: `notification` 패키지가 Enum을 직접 소유하면, outing/schoolcamp가 이미 `NotificationService.send(...)` 호출을 위해 `notification`에 의존하고 있으므로 새로운 역방향 의존이 생기지 않는다는 판단(코드 리뷰 Low 1 반영)
- 기획서와 실제 구현 차이: 없음

관련 문서: [기획서](docs/domain/notification/65-notification-type-enum.md) · [코드 리뷰](docs/domain/notification/65-notification-type-enum-code-review.md) · [QA](docs/domain/notification/65-notification-type-enum-QA.md)

## 확인 사항
- [x] 로컬 빌드 통과 (`./gradlew build`)
- [x] Checkstyle 통과 (`./gradlew checkstyleMain`)
- [x] CI(checkstyle, build-and-test) 통과
- [ ] (해당 시) Notion 기능정의서/기획 문서 반영
- [x] (해당 시) 관련 도메인 라벨 지정
