### PR TITLE
feat(schoolcamp): #70 스쿨캠핑 신청 취소/수정 API 구현

### DIFF
--- a/docs/domain/schoolcamp/70-schoolcamp-cancel-update-QA.md
+++ b/docs/domain/schoolcamp/70-schoolcamp-cancel-update-QA.md
@@ -1,0 +1,67 @@
+# #70 스쿨캠핑 신청 취소/수정 API — QA 결과
+
+관련 기획서: [70-schoolcamp-cancel-update.md](./70-schoolcamp-cancel-update.md)
+관련 코드 리뷰: [70-schoolcamp-cancel-update-code-review.md](./70-schoolcamp-cancel-update-code-review.md)
+(9단계 코드 리뷰 지적 사항(Medium 2건)은 QA 이전에 전부 반영 완료 — 이 문서는 QA에서 새로
+발견된 것만 다룬다)
+
+## 검증 방법/범위
+- `./gradlew build`(checkstyle + 전체 테스트, `V13` 마이그레이션이 실 DB에 적용되는지
+  포함) 통과 확인.
+- 로컬 서버 실제 기동(`./gradlew bootRun`, `dev` 프로필).
+- 기존 dev DB의 실 계정(`user1`/`teacher1`)에 더해, 팀원/월중복 시나리오 검증을 위해
+  `testuser01`/`testuser02`에 QA 목적으로 STUDENT 역할을 임시로 부여했고(비밀번호는 각
+  계정이 이미 쓰던 실제 값 그대로 사용, 별도 변경 없음), `teacher1`에는 `#68` QA와 동일하게
+  ADMIN 역할을 임시로 부여했다 — **검증 후 전부 원복**(부여한 역할 삭제, 로그인 재시도로
+  원복 확인). 등록한 세션 9건/신청 4건/알림도 QA 종료 후 전부 삭제해 dev DB를 QA 이전
+  상태로 되돌렸다.
+- 한글 페이로드는 `#68` QA에서 확인된 Windows Git Bash 인코딩 이슈를 피하기 위해 Write
+  도구로 UTF-8 파일을 먼저 만들고 `curl --data-binary @file`로 전송했다.
+
+## 실제 HTTP E2E 검증
+
+### `DELETE /api/v1/school-camps/applications/{id}` (취소)
+1. 본인 신청이 아닌 계정으로 취소 시도 → `403 SCHOOLCAMP_007`
+2. 존재하지 않는 신청(`id=999999`) → `404 SCHOOLCAMP_010`
+3. 정상 취소 → `200 OK`, 이후 캘린더 재조회에서 해당 세션이 다시 `OPEN`으로 돌아옴을 확인
+4. 이미 취소된 신청을 재취소 시도 → `404 SCHOOLCAMP_010`(3번에서 취소한 그 신청으로 재확인)
+5. 캠핑 당일(오늘 날짜로 등록한 세션에 신청 후 즉시 취소 시도) → `400 SCHOOLCAMP_009`
+
+### `PATCH /api/v1/school-camps/applications/{id}` (수정)
+6. 본인 신청이 아닌 계정으로 수정 시도 → `403 SCHOOLCAMP_007`
+7. 존재하지 않는 신청 → `404 SCHOOLCAMP_010`
+8. 담당 선생님만 변경(자유 입력), 팀원 그대로 → `200 OK`, `teacherDisplayName`만 바뀌고
+   팀원 구성은 그대로 유지됨을 확인
+9. 이미 이번 달에 다른 세션에 참여 중인 학생을 팀원으로 추가 시도 → `409 SCHOOLCAMP_003`,
+   실패 후 캘린더 재조회로 신청 상태가 실제로 변경 없이 그대로임을 확인
+10. 팀원 제거(가입 학생 1명) + 게스트 1명 추가를 한 요청에 함께 수행(코드 리뷰가 지적한
+    조합 케이스) → `200 OK`, 제거한 학생은 응답에서 사라지고 새 게스트만 추가됨을 확인
+11. 총원 9명(대표 포함, 8명 초과) → `400 SCHOOLCAMP_004`
+12. 존재하지 않는 `studentUserId` → `400 SCHOOLCAMP_008`
+13. 11~12번 실패 후에도 신청이 10번 상태 그대로 유지됨을 캘린더로 재확인(부분 반영 없음)
+
+### 코드 리뷰 Medium 1번(동시 수정 시 팀원 중복 삽입) 재현 검증
+14. DB에 직접 접속해 `school_camp_member`의 `SHOW CREATE TABLE`로
+    `uq_member_application_student UNIQUE (application_id, student_user_id)` 제약이 실제
+    적용돼 있음을 확인
+15. 이미 팀원으로 등록된 학생과 같은 `(application_id, student_user_id)` 조합으로 직접
+    `INSERT`를 시도 → `ERROR 1062 Duplicate entry` — DB가 실제로 중복을 거부함을 확인
+16. 참고로 게스트(양쪽 다 `student_user_id IS NULL`) 두 행은 같은 신청에 자유롭게
+    공존함을 확인(제약이 게스트 중복은 막지 않는다는 설계 의도대로 동작)
+    - 코드 레벨(`DataIntegrityViolationException` → `409 SCHOOLCAMP_011` 변환)은 이미
+      단위 테스트(`throwsConflictWhenConcurrentInsertViolatesUniqueConstraint`)로
+      결정론적으로 검증되어 있어, 이번 QA에서는 DB 제약 자체가 실제로 존재하고 동작하는지만
+      재확인했다 — 실 HTTP 요청 두 개를 동시에 경합시키는 방식은 타이밍이 보장되지 않아
+      QA 스크립트로는 재현하지 않았다.
+
+## 발견 사항
+Critical/High/Medium/Low 모두 없음 — 코드 리뷰(9단계)에서 지적/반영된 사항이 전부 실제
+HTTP 요청과 DB 레벨에서도 의도대로 동작함을 재확인했고, QA 단계에서 새로 발견된 문제는
+없다.
+
+## 결론
+기획서에 정의된 두 엔드포인트(취소, 수정)의 정상/에러 케이스와 코드 리뷰에서 고친 동시
+수정 방어(DB 유니크 제약)가 전부 실제 HTTP 요청 및 DB 레벨 검증으로 확인됐다. 이 이슈의
+완료 조건(로컬 빌드/테스트 통과)을 충족하며, CI 통과 여부는 PR 생성(16단계) 후 확인한다
+— 이 프로젝트의 CI 워크플로우는 `main`/`dev`로의 PR·push에서만 트리거되어 기능 브랜치
+단독 push로는 미리 확인할 수 없다(`#67`/`#68` QA와 동일한 제약).

--- a/docs/domain/schoolcamp/70-schoolcamp-cancel-update-code-review.md
+++ b/docs/domain/schoolcamp/70-schoolcamp-cancel-update-code-review.md
@@ -1,0 +1,151 @@
+# #70 스쿨캠핑 신청 취소/수정 API — 코드 리뷰 결과
+
+관련 기획서: [70-schoolcamp-cancel-update.md](./70-schoolcamp-cancel-update.md)
+리뷰 대상: `git diff dev...HEAD`(브랜치 `feat/#70-schoolcamp-cancel-update`), 총 9개 파일 —
+구현 코드/테스트/기획서 문서 변경 전체.
+
+> **반영 결과 (2026-08-20)**: Medium 2건 모두 반영했다.
+> - 1번(동시 PATCH 중복 삽입): 리뷰의 방안 1(DB 유니크 제약)을 채택 —
+>   `V13__add_schoolcamp_member_unique_constraint.sql`로 `(application_id, student_user_id)`
+>   유니크 제약을 추가하고, `updateApplication`이 그 위반(`DataIntegrityViolationException`)을
+>   잡아 신규 `SCHOOLCAMP_011`(409, `CONCURRENT_UPDATE_CONFLICT`)로 변환하도록 해 방안 1이
+>   지적한 "원인 불명확한 500" 단점까지 같이 해소했다. 방안 2(비관적 락)는 이 프로젝트에
+>   선례가 없는 패턴을 새로 들이는 비용이 커 채택하지 않았다.
+> - 2번(diff 조합/게스트뿐 케이스 테스트 누락): 방안 1 그대로 채택 — 조합 테스트
+>   (`keepsAddsAndRemovesMembersInSameRequest`)와 게스트뿐 테스트
+>   (`addsOnlyGuestMembersSkipsMonthlyDuplicateCheck`)를 추가했다.
+
+## 리뷰 범위/방법
+- 기획서 「엔드포인트 1·2」의 구현 로직·에러 코드·검증 순서·"세션 원자적 반환을 같은
+  트랜잭션에서 직접 호출한다"는 결정과 실제 diff를 한 줄씩 대조했다.
+- `SchoolCampService.cancelApplication`/`updateApplication`/`computeMemberDiff`/
+  `buildNewMembers`, `SchoolCampController`의 신규 엔드포인트 2개, `SchoolCampErrorCode`
+  신규 코드 3개(007/009/010), `SchoolCampApplicationRepository.findByIdAndCancelledAtIsNull`,
+  `SchoolCampMemberRepository.findByApplicationId`, 관련 테스트 3개 파일 전체를 읽었다.
+- `SchoolCampMember`/`SchoolCampApplication` 엔티티와 `V12__add_schoolcamp_application.sql`
+  마이그레이션을 확인해 DB 제약(유니크/락) 유무를 점검했다.
+- 컨벤션 비교 대상으로 `OutingService`(소유권 확인 패턴 `!x.getId().equals(y)`)와, 이 이슈가
+  재사용을 명시한 `#68`의 `applyToCamp`/`completeApplication`/`validateNoDuplicateThisMonth`를
+  대조했다.
+- `docs/domain/schoolcamp/68-schoolcamp-application-code-review.md`(선행 이슈 코드 리뷰)를
+  참고해 이미 다뤄진 패턴(REQUIRES_NEW 커넥션 경합, release 실패 시 예외 유실 등)이 이번
+  변경에 그대로 재사용됐는지, 새로 도입된 코드에 유사한 결함이 없는지 확인했다.
+- 소스 코드는 수정하지 않았다(리뷰 전용).
+
+## 발견 사항
+
+### 1. 🟡 Medium — `updateApplication`에 동시성 가드가 없어, 같은 신청에 대한 동시 PATCH 두 건이 같은 학생의 팀원 행을 중복 생성할 수 있음
+
+**문제**: `SchoolCampService.updateApplication`
+(`src/main/java/com/remake/gone/schoolcamp/service/SchoolCampService.java:283-330`)은
+`memberRepository.findByApplicationId(applicationId)`로 기존 팀원을 읽어 diff를 계산한 뒤,
+`deleteAllById`(삭제) → `saveAll`(삽입) 순으로 반영한다. 이 경로 전체에 비관적 락이나
+버전 컬럼(`@Version`)이 전혀 없고, `school_camp_member` 테이블에도
+`(application_id, student_user_id)` 유니크 제약이 없다
+(`src/main/resources/db/migration/V12__add_schoolcamp_application.sql:18-29`).
+
+같은 사용자가 같은 신청에 대해 거의 동시에 PATCH를 두 번 보내면(더블 클릭, 프론트 재시도
+로직, 네트워크 재전송 등 — 취소와 달리 이 이슈의 기획서도 "취소와 수정 사이의 레이스"만
+다루고 "수정과 수정 사이의 레이스"는 언급하지 않는다, `70-schoolcamp-cancel-update.md:181-184`
+참고) 두 트랜잭션 모두 커밋 전 시점에 같은 `existingMembers`를 읽어 같은 `addedStudentIds`를
+계산하고, 각자 그 학생에 대한 새 `SchoolCampMember` 행을 `saveAll`로 삽입한다. 유니크 제약이
+없어 두 삽입 모두 성공하고, 결과적으로 같은 학생이 팀원 목록에 두 번 나타나는 중복 행이
+DB에 영구히 남는다 — `computeMemberDiff`(`SchoolCampService.java:346-377`)의 diff 계산 자체는
+집합 연산이라 논리적으로 맞지만, "한 학생은 한 신청에 행 하나"라는 전제가 동시 요청 앞에서는
+DB 레벨로 보장되지 않는다. 그 결과 팀 인원이 요청 시점 검증(`MAX_TEAM_SIZE = 8`,
+`validateApplicationFormat`)을 통과했더라도 저장된 행 수는 8명을 넘어설 수 있고, 이후 캘린더/
+응답 DTO에서 같은 학생이 중복 표시된다. `#68`의 claim(`REQUIRES_NEW` + `WHERE taken_at IS NULL`
+가드)이 정확히 이런 종류의 동시 쓰기 레이스를 DB 원자적 UPDATE로 막았던 것과 대조적으로,
+이 메서드는 "취소와 달리 유일한 소유자만 호출하니 경합 상대가 없다"는 기획서의 근거(엔드포인트
+1에 대한 근거,`70-schoolcamp-cancel-update.md:49-58`)를 검증 없이 수정(엔드포인트 2)에도 그대로
+확장 적용한 것으로 보이는데, 취소는 `release`가 조건 없는(멱등) UPDATE라 두 번 호출해도
+안전한 반면, 수정의 삭제+삽입은 멱등하지 않다는 차이가 있다.
+
+**해결 방안**:
+1. `school_camp_member`에 `(application_id, student_user_id)` 부분 유니크 제약을 추가하는
+   마이그레이션을 만든다(MySQL은 `student_user_id`가 NULL인 게스트 행끼리는 유니크 제약이
+   충돌하지 않으므로 게스트 중복 방지 효과는 없지만, 이 이슈가 실제로 문제 삼는 "같은 학생
+   중복"은 정확히 막는다). 장점: DB가 최종 방어선이 되어 애플리케이션 코드의 실수와
+   무관하게 중복이 물리적으로 불가능해진다. 단점: 새 마이그레이션이 필요하고, 제약을
+   위반하는 두 번째 트랜잭션은 `DataIntegrityViolationException` → `GlobalExceptionHandler`의
+   범용 500으로 응답돼(#68 리뷰 4번이 다뤘던 것과 같은 종류의 "원인 불명확한 500" 문제)
+   원인이 사용자에게 명확히 전달되지 않는다 — 이 예외를 잡아 의미 있는 코드로 변환하는
+   추가 작업이 없다면 여전히 UX가 거칠다.
+2. `updateApplication` 진입 시 `SchoolCampApplication`을 비관적 쓰기 락
+   (`@Lock(LockModeType.PESSIMISTIC_WRITE)` 조회 메서드 추가)으로 가져와, 같은 신청에 대한
+   동시 PATCH를 DB 행 잠금으로 직렬화한다. 장점: 애플리케이션 레벨에서 이 이슈가 우려하는
+   레이스를 정확히 막고, 부수적으로 취소(`cancelApplication`)와의 레이스도 더 확실하게
+   방어된다(현재는 `cancelledAt` 컬럼 가드에만 의존). 단점: 이 프로젝트에 비관적 락 사용
+   선례가 없어 새 패턴을 들이는 학습 비용이 들고, 락 대기 중인 요청은 타임아웃/지연이
+   생길 수 있다 — `#68`이 "짧은 락 유지 시간"을 위해 일부러 REQUIRES_NEW로 커넥션을
+   짧게 끊어낸 설계 철학과는 다른 방향이라, 왜 이 메서드만 락을 쓰는지 주석으로 남겨야
+   다음 작성자가 혼란스럽지 않다.
+3. 현재 상태를 유지한다 — 트리거 조건이 "같은 사용자가 같은 신청을 짧은 시간 안에 중복
+   제출"하는 드문 상황이고, 발생해도 서비스 전체 장애가 아니라 그 신청 하나의 팀원 목록만
+   영향받는다고 보고 수용한다. 장점: 코드 변경 없음. 단점: 기획서의 "리스크 및 고려사항"
+   절이 이미 취소-수정 레이스는 다뤘으면서 수정-수정 레이스는 다루지 않은 채로 남아,
+   이 잔여 리스크가 문서화되지 않는다 — 이 방안을 택한다면 최소한 기획서에 이 레이스를
+   기록해두는 것을 권장한다(방안 3을 택했던 #68 리뷰 2번의 선례와 같은 이유).
+
+### 2. 🟡 Medium — `updateApplication`의 diff 로직 테스트가 추가/제거/유지를 항상 단독 케이스로만 검증하고, 한 요청 안에서 섞이는 조합과 "전원 게스트" 케이스를 다루지 않음
+
+**문제**: 기획서 "테스트" 절은 "팀원 추가(가입 학생 + '기타' 혼합), 팀원 제거, 팀원 유지 —
+**세 경우 모두** diff가 올바르게 적용되는지(삭제/유지/신규삽입 각각)"를 요구한다
+(`70-schoolcamp-cancel-update.md:200-202`). 그런데 `SchoolCampServiceTest.UpdateApplication`
+(`src/test/java/com/remake/gone/schoolcamp/service/SchoolCampServiceTest.java`)에 추가된
+세 테스트 — `changesTeacherOnlyKeepsExistingMembers`(유지만), `addsRegisteredAndGuestMembers`
+(추가만, 기존 팀원 없음), `removesMemberNotInRequest`(제거만, 결과가 대표 신청자 1명으로
+줄어듦) — 는 각각 유지/추가/제거를 서로 다른 요청에서 **단독으로만** 검증한다. "기존 팀원
+A는 유지하고, 기존 팀원 B는 제거하고, 새 팀원 C(가입 학생)와 D(기타)를 동시에 추가하는" 한
+번의 PATCH 요청은 어떤 테스트에서도 실행되지 않는다. `computeMemberDiff`
+(`SchoolCampService.java:346-377`)는 `existingStudentIds`/`newStudentIds` 두 집합의 차집합·
+교집합 연산이라 원리상 조합에 안전해 보이지만, 이런 집합 연산 로직이야말로 "각 연산은
+따로 맞는데 셋을 같은 입력에 동시에 적용했을 때"의 경계 조건(예: `addedStudentIds`와
+`memberIdsToDelete`가 겹치는 스트림 필터 순서 실수)에서 조용히 틀리기 쉬운 종류의 코드이고,
+지금 테스트 스위트는 이 조합을 리팩터링 중 깨져도 잡아내지 못한다. 또한 "additionalMembers
+전체가 게스트뿐인" 케이스(가입 학생이 하나도 없어 `addedStudentIds`가 항상 빈 집합이 되고
+월 중복 재확인이 아예 스킵되는 경로)도 별도로 검증되지 않는다 — `addsRegisteredAndGuestMembers`
+가 게스트를 포함하긴 하지만 가입 학생과 섞여 있어 "게스트만"의 경로(`validateNoDuplicateThisMonth`
+호출 자체가 스킵되는지)를 특정해서 보여주지 않는다.
+
+**해결 방안**:
+1. `SchoolCampServiceTest.UpdateApplication`에 `keepsAddsAndRemovesMembersInSameRequest`
+   테스트를 추가한다 — 기존 팀원 2명(유지 대상 1, 제거 대상 1)을 `stubApplicationWithMembers`로
+   세팅하고, 요청의 `additionalMembers`에 "유지할 기존 학생 ID + 새 가입 학생 ID + 새 게스트"만
+   담아(제거 대상 ID는 요청에서 뺀 채) 호출한 뒤 `memberRepository.deleteAllById`가 제거
+   대상 ID만 담긴 리스트로, `memberRepository.saveAll`이 새 가입 학생+게스트 2건만 담긴
+   리스트로 각각 호출됐는지 검증한다. 같은 방식으로 "additionalMembers가 게스트만인" 케이스도
+   하나 추가해 `findParticipatedStudentIdsInMonth`가 호출되지 않는지(`never()`) 확인한다.
+   장점: 기존 `stubApplicationWithMembers` 픽스처 패턴을 그대로 재사용할 수 있어 비용이
+   낮고, 기획서가 명시적으로 요구한 조합 케이스를 정확히 채운다. 단점 없음(새 인프라
+   불필요).
+2. 현재 상태를 유지하고 QA 단계에서 실서버로 조합 시나리오를 수동 검증해 QA 문서에만
+   남긴다. 장점: 코드 리뷰 단계에서 추가 작업이 없다. 단점: 이후 `computeMemberDiff`가
+   리팩터링되며 조합 케이스에서만 드러나는 회귀가 생겨도 자동으로 잡히지 않고, 매 QA
+   사이클마다 수동 재현 비용이 반복된다.
+
+## Critical/High 없음
+
+취소/수정 두 엔드포인트의 소유권 확인, 에러 코드 분기, 세션 반환 트랜잭션 경계를 검토한
+범위에서 서비스 전체 장애나 즉각적인 데이터 유실로 이어지는 Critical/High 등급 결함은
+발견하지 못했다. 1번(Medium)이 데이터 정합성 문제이긴 하나, 트리거 조건이 "같은 사용자의
+거의 동시 중복 제출"이라는 좁은 창에 의존하고 영향 범위도 그 신청 한 건에 국한돼(#68 리뷰
+1번처럼 무관한 요청 전체를 500으로 무너뜨리는 종류가 아님) High로 올리지 않았다.
+
+## 보안 관련 확인
+- `DELETE`/`PATCH .../applications/{id}`는 컨트롤러에서 `@PreAuthorize("isAuthenticated()")`
+  만 확인하고, 소유권(신청자 본인 여부)은 서비스에서
+  `application.getApplicant().getId().equals(applicantUserId)`로 확인한다
+  (`SchoolCampService.java:257`, `290`) — 기획서가 확정한 설계 그대로다. 이 비교는
+  `principal.userId()`(Access Token에서 추출)만 사용하고 요청 바디의 어떤 값도 신뢰하지
+  않으므로, 다른 사용자의 `applicationId`를 추측해 취소/수정을 시도해도 소유자가 아니면
+  전부 `403 SCHOOLCAMP_007`로 막힌다 — IDOR 경로 없음.
+- 존재하지 않는 `applicationId`는 `404`, 존재하지만 타인 소유면 `403`으로 응답이 갈려
+  타인에게 "그 ID의 신청이 존재했는지"가 간접적으로 드러나지만, 이는 기획서가 명시적으로
+  확정한 조회 순서(1. not-found 404 → 2. 소유권 403)이자 `OutingService`의 기존 패턴과도
+  같은 종류의 트레이드오프라 이번 변경이 새로 도입한 문제는 아니다.
+- `teacherUserId`/`additionalMembers[].studentUserId`는 #68과 동일하게 임의의 유저 ID를
+  조회하지만 "다른 사람을 팀에 초대/지정"하는 기능의 정상 동작이며, #68 코드 리뷰가 이미
+  같은 패턴을 검토해 별도 인가 문제로 보지 않기로 했다 — 이번 변경도 동일 결론.
+- 신규 리포지토리 메서드(`findByIdAndCancelledAtIsNull`, `findByApplicationId`)는 모두
+  파라미터 바인딩(JPQL 파생 쿼리/`@Param`)을 쓰고 문자열 결합이 없어 인젝션 여지가 없다.

--- a/docs/domain/schoolcamp/70-schoolcamp-cancel-update.md
+++ b/docs/domain/schoolcamp/70-schoolcamp-cancel-update.md
@@ -1,0 +1,210 @@
+# #70 스쿨캠핑 신청 취소/수정 API — 기획서
+
+관련 이슈: [#70 스쿨캠핑 신청 취소/수정 API 구현](https://github.com/GBSW-ReMake/GONE-server-V1/issues/70)
+마스터 기획서: [1_schoolcamp-domain.md](./1_schoolcamp-domain.md)의 "엔드포인트 4.
+`DELETE /api/v1/school-camps/applications/{id}`", "엔드포인트 5.
+`PATCH /api/v1/school-camps/applications/{id}`"
+선행 이슈: [#68](./68-schoolcamp-application.md)(신청 API, 완료·머지됨 — 이 이슈가 의존하는
+`SchoolCampApplication`/`SchoolCampMember` 엔티티와 원자적 점유/반환 패턴을 그대로 재사용한다)
+
+## 개요/목적
+본인이 신청한 스쿨캠핑을 취소하거나(세션을 다시 빈 날짜로 되돌림), 담당 선생님/팀원 구성을
+수정하는 2개 엔드포인트를 구현한다.
+1. `DELETE /api/v1/school-camps/applications/{id}` — 본인 신청 취소
+2. `PATCH /api/v1/school-camps/applications/{id}` — 담당 선생님/팀원 정보 수정
+
+**에러 코드 정정(검토 요청)**: 마스터 기획서는 두 엔드포인트의 "존재하지 않거나 이미
+취소/삭제된 신청"을 `SCHOOLCAMP_001`로 응답하도록 적어놨는데, `SCHOOLCAMP_001`의 실제
+기본 메시지는 "해당 날짜에 스쿨캠핑 일정이 없습니다"(#68에서 `SchoolCampSession` 조회 실패에
+사용, 대상이 세션이다)이다. 이 이슈의 대상은 세션이 아니라 **`SchoolCampApplication`**이라
+같은 코드를 재사용하면 "일정이 없다"는 메시지가 "그런 신청이 없다"는 실제 상황과 어긋난다.
+그래서 신규 코드 `SCHOOLCAMP_010`("해당 신청을 찾을 수 없습니다")을 추가해 신청 대상
+not-found를 세션 대상 not-found와 분리했다 — API 설계 원칙 4(의미 있는 오류)를 따른 결정.
+`010`은 마스터 기획서에서 원래 "month 형식 오류"용으로 예약됐었지만 #67에서 그 코드를 만들지
+않기로 확정해(기존 `COMMON_001` 재사용) 비어 있던 번호다.
+
+## 엔드포인트
+
+### 1. `DELETE /api/v1/school-camps/applications/{id}` — 본인 신청 취소
+**권한**: 그 신청의 신청자 본인(소유권은 서비스에서 확인, 컨트롤러는 `isAuthenticated()`만)
+
+**요청**: 바디 없음, 경로 변수 `id`(`SchoolCampApplication.id`)
+
+**응답** (`200 OK`)
+```json
+{ "success": true, "data": null, "message": "신청이 취소되었습니다.", "code": null }
+```
+
+**구현 로직** (마스터 기획서 엔드포인트 4 그대로)
+1. `id`로 `SchoolCampApplication` 조회 — `applicationRepository.findByIdAndCancelledAtIsNull(id)`
+   (취소된 신청은 이미 없는 것처럼 취급), 없으면 `404` `SCHOOLCAMP_010`
+2. `principal.userId() == application.getApplicant().getId()` 확인, 아니면 `403`
+   `SCHOOLCAMP_007`
+3. **당일 취소 금지**: `application.getSession().getCampDate()`가 오늘(`LocalDate.now(KST)`,
+   컨트롤러가 파라미터로 전달)이면 `400` `SCHOOLCAMP_009`
+4. `application.setCancelledAt(now)` 후 저장
+5. **세션 원자적 반환**: `SchoolCampSessionRepository.release(id)`를 그대로 재사용한다 —
+   `#68`이 claim의 반환 방향으로 이미 추가해둔 그 메서드다(새 메서드 추가 아님).
+
+   **`SchoolCampSessionClaimService.release`(REQUIRES_NEW)를 거치지 않고,
+   `sessionRepository.release(id)`를 이 메서드(`cancelApplication`)의 트랜잭션 안에서 직접
+   호출한다(확정)** — `#68`의 claim/release가 REQUIRES_NEW로 분리된 이유는 "한 세션에 수백
+   건이 동시에 몰리는 경합을 짧게 끊어내기" 위해서였는데, 취소는 그 신청의 유일한 소유자만
+   호출할 수 있어(2번 소유권 확인이 이미 그 사실을 보장) 애초에 경합 상대가 없다 — REQUIRES_NEW의
+   이점이 적용될 상황 자체가 아니다. 오히려 `cancelledAt` 갱신과 `taken_at` 반환을 **같은
+   트랜잭션으로 묶어야**, 이후 어떤 이유로든 커밋이 실패했을 때 두 변경이 함께 롤백돼 "신청은
+   취소됐는데 세션은 여전히 잠긴" 또는 "세션은 열렸는데 신청은 취소되지 않은" 불일치가 생기지
+   않는다 — `#68`의 claim/release가 REQUIRES_NEW라서 안았던 "release 실패 시 유령 점유"
+   잔여 리스크가 이 엔드포인트에는 애초에 없다.
+
+**에러**
+- 본인 신청이 아님 → `403` `SCHOOLCAMP_007`
+- 존재하지 않거나 이미 취소된 신청 → `404` `SCHOOLCAMP_010`
+- 캠핑 당일 취소 시도 → `400` `SCHOOLCAMP_009`
+
+---
+
+### 2. `PATCH /api/v1/school-camps/applications/{id}` — 담당 선생님/팀원 정보 수정
+**권한**: 1번과 동일(본인 신청)
+
+**요청** — #68 신청 엔드포인트와 같은 형식. **전체 교체 방식**이다(부분 patch 아님) — 대표
+신청자 본인을 제외한, 바뀌지 않은 팀원도 포함해 원하는 최종 팀원 목록 전체를 보낸다.
+```json
+{
+  "teacherUserId": 55,
+  "teacherName": null,
+  "additionalMembers": [
+    { "studentUserId": 55, "guestName": null },
+    { "studentUserId": null, "guestName": "김철수(옆반 아님, 외부인)" }
+  ]
+}
+```
+
+**응답** (`200 OK`) — #68 신청 응답과 동일한 `SchoolCampApplicationResponse` 재사용
+```json
+{
+  "success": true,
+  "data": {
+    "id": 301,
+    "campDate": "20260403",
+    "teacherDisplayName": "박선생",
+    "members": [
+      { "studentRealName": "홍길동", "studentGrade": 3, "studentClassNo": 4, "guestName": null, "isApplicant": true },
+      { "studentRealName": null, "studentGrade": null, "studentClassNo": null, "guestName": "김철수(옆반 아님, 외부인)", "isApplicant": false }
+    ],
+    "appliedAt": "2026-03-20T09:12:00"
+  },
+  "message": "신청 정보가 수정되었습니다.",
+  "code": null
+}
+```
+
+**구현 로직** (마스터 기획서 엔드포인트 5 그대로)
+1. `id`로 `SchoolCampApplication` 조회(`findByIdAndCancelledAtIsNull`), 없으면 `404`
+   `SCHOOLCAMP_010`
+2. 소유권 확인(1번과 동일), 아니면 `403` `SCHOOLCAMP_007`
+3. `teacherUserId`/`teacherName`, `additionalMembers` 각 항목 형식 검증 + `teacherUserId`가
+   `TEACHER` 역할인지 확인(#68의 신청 검증 로직 그대로 재사용) → 위반 시 `400`
+   `SCHOOLCAMP_004`
+4. `newMemberCount = 1(본인) + additionalMembers.size()`, `> 8`이면 `400` `SCHOOLCAMP_004`
+5. `additionalMembers`의 `studentUserId` 존재/중복(자기 자신 포함) 확인(#68과 동일, 배치
+   조회) → `400` `SCHOOLCAMP_008`
+6. **기존 팀원과 diff 계산** — `memberRepository.findByApplicationId(id)`로 기존 팀원 전체
+   조회 후 대표 신청자 행 제외:
+   - 기존 가입 학생들의 `studentUserId` 집합(`existingStudentIds`)과 요청받은
+     `additionalMembers`의 `studentUserId` 집합(`newStudentIds`)을 비교
+   - `addedStudentIds = newStudentIds - existingStudentIds` — **새로 추가되는 학생만** 이번
+     달 중복 참여를 재확인(#68 6번 로직 재사용) → 걸리면 `409` `SCHOOLCAMP_003`. 이미 이
+     신청에 속해 있던 학생은 재검사하지 않는다 — 재검사하면 "이번 달 참여 중"인 자기 자신의
+     현재 신청과 항상 충돌해 무조건 실패하게 되므로(마스터 기획서에 명시된 이유)
+   - `removedStudentIds = existingStudentIds - newStudentIds` — 이 학생들의 `SchoolCampMember`
+     행을 삭제
+   - `keptStudentIds`(교집합)는 그대로 둔다(삭제도 재삽입도 하지 않음)
+   - **"기타"(자유 입력) 팀원은 식별자가 없어 diff 대상이 아니다** — 기존 guest 행은 전부
+     삭제하고, 요청받은 `guestName` 목록으로 전부 새로 삽입한다(이름이 우연히 같아도 별개
+     레코드로 취급, 이전 대비 정책 변화 없음 — 애초에 guest 항목엔 안정적인 식별자가 없어
+     "같은 사람인지" 판단할 근거 자체가 없다)
+7. `teacher_user_id`/`teacher_name` 갱신. 6번에서 계산한 `removedStudentIds` 행 + 기존 guest
+   행 전부 삭제, `addedStudentIds`(월 중복 통과분) + 요청받은 guest 목록 전부 삽입. 대표
+   신청자 행(`applicant=true`)은 절대 건드리지 않는다. **세션 점유(`taken_at`)는 건드리지
+   않는다** — 팀 인원이 늘거나 줄어도 그 세션은 이미 이 신청 하나가 통째로 차지한 상태라
+   별도 정원 조작이 필요 없다
+8. `addedStudentIds`에 대해 #68과 동일한 초대 알림 발송(`NotificationService.send(...,
+   NotificationType.SCHOOLCAMP)`)
+9. **관리자 변경 알림은 TODO 주석만 남긴다** — 발송 대상(전체 관리자 vs 담당자)·문구·채널
+   미정(마스터 기획서 그대로, `admin`(#72) 쪽 결정 이후 별도 이슈로 실제 발송 구현)
+10. 응답 DTO 변환(#68과 동일한 `SchoolCampApplicationResponse`, 갱신된 최신 팀원 목록으로)
+
+**에러**
+- 소유권 없음 → `403` `SCHOOLCAMP_007`
+- 존재하지 않거나 취소된 신청 → `404` `SCHOOLCAMP_010`
+- 형식 오류/8명 초과/유효하지 않은 `teacherUserId` → `400` `SCHOOLCAMP_004`
+- 존재하지 않는 `studentUserId`/중복 → `400` `SCHOOLCAMP_008`
+- 새로 추가한 팀원 중 이번 달 이미 참여한 사람 있음 → `409` `SCHOOLCAMP_003`
+
+> 💡 이 엔드포인트는 세션의 `taken_at`에 영향을 주지 않는다 — 그 날짜는 이미 이 신청 하나가
+> 차지한 상태이므로, 팀원을 추가/제거해도(최대 8명 제한 안에서) 다른 신청과 경합할 여지가
+> 없다. 그래서 1번(취소)과 달리 세션 원자적 반환이 필요 없다.
+
+## 영향 받는 기존 코드
+- 신규: `SchoolCampErrorCode.APPLICATION_NOT_FOUND`(`SCHOOLCAMP_010`),
+  `.NOT_APPLICATION_OWNER`(`SCHOOLCAMP_007`), `.CANCEL_NOT_ALLOWED_ON_CAMP_DAY`
+  (`SCHOOLCAMP_009`)
+- 수정: `SchoolCampApplicationRepository`(`findByIdAndCancelledAtIsNull` 추가),
+  `SchoolCampMemberRepository`(`findByApplicationId`를 이 이슈에서 신규 추가, 추가로
+  `deleteAllByIdIn` 또는 개별 `delete` 필요), `SchoolCampService`(`cancelApplication`/
+  `updateApplication` 추가 — `#68`의 `validateApplicationFormat`/`findValidTeacher`/
+  `findExistingStudents`는 그대로 재사용하되, `validateNoDuplicateThisMonth`는 호출 시
+  대표 신청자를 후보 집합에 자동으로 넣는 현재 시그니처가 "새로 추가되는 학생만" 검사하는
+  이 이슈의 요구와 맞지 않아 그대로 재사용할 수 없다 — 구현 시 후보 집합을 호출부에서 직접
+  구성해 넘기도록 시그니처를 조정해야 한다), `SchoolCampController`(`DELETE`/`PATCH`
+  `/applications/{id}` 추가)
+- `SchoolCampSessionRepository.release`는 이미 `#68`에 있어 그대로 재사용한다(수정 없음)
+- 신규 마이그레이션 없음(기존 테이블만 사용)
+- `SecurityConfig`(수정 없음): `/api/v1/school-camps/**`가 이미 인증 요구로 등록됨
+
+## 리스크 및 고려사항
+- **API 설계 6원칙 체크**:
+  1. 한 가지를 잘하기 — 취소/수정 2개 엔드포인트로 범위가 좁다. 준수.
+  2. 빠르게 시작 — 요청/응답 예시 포함. 준수.
+  3. 직관적 일관성 — `SCHOOLCAMP_NNN` 코드 컨벤션, `ApiResponse<T>`, #68의
+     `SchoolCampApplicationResponse` 재사용(PATCH가 새 응답 타입을 만들지 않음).
+  4. 의미 있는 오류 — 위 "에러 코드 정정" 참고(세션 not-found와 신청 not-found를 분리).
+  5. 확장성/성능 — diff 계산은 팀 최대 8명 기준 집합 연산이라 무시할 수준. 월 중복 재확인도
+     새로 추가되는 인원만 대상이라 #68보다 오히려 쿼리 대상이 줄어들 수 있음.
+  6. 하위 호환성 — 신규 엔드포인트 2개, 해당 없음.
+- **취소는 `#68`의 "release 실패 시 유령 점유" 잔여 리스크에서 자유롭다**: `cancelledAt`
+  갱신과 `taken_at` 반환을 같은 트랜잭션으로 묶기 때문에(위 엔드포인트 1의 5번 참고), 취소
+  처리 도중 어떤 이유로 커밋이 실패해도 두 변경이 함께 롤백된다 — `#68`의 claim/release가
+  REQUIRES_NEW라서 "release만 따로 실패해 세션이 영구히 잠긴 채로 남는" 잔여 리스크를 안았던
+  것과 다른 지점이다.
+- **취소와 수정 사이의 이론적 레이스**: 같은 신청에 대해 취소(1번)와 수정(2번)이 동시에
+  들어오면, 취소가 먼저 커밋되면 이후 수정은 `findByIdAndCancelledAtIsNull`에서 이미
+  걸러져 `404`로 자연스럽게 처리된다 — 별도 락 없이 "취소 여부" 컬럼 자체가 가드 역할을
+  한다.
+- **diff 삭제/삽입이 하나의 트랜잭션**: 6~7번 전체가 `@Transactional`로 묶여, 삭제는 됐는데
+  삽입만 실패하는 식의 부분 반영이 나지 않는다.
+- **"전체 교체" 계약이 프론트에 실수 여지를 준다** — 바뀌지 않은 기존 팀원을 실수로
+  `additionalMembers`에서 빼먹으면 그 팀원이 삭제된다. 이건 마스터 기획서가 이미 확정한
+  계약이라(부분 patch가 아니라 스냅샷) 이 이슈에서 바꾸지 않지만, 프론트 구현 시 "현재 팀원
+  목록을 먼저 불러와 채워둔 상태로 수정 폼을 시작"하는 게 사실상 필수라는 점을 인지 목적으로
+  남겨둔다.
+
+## 테스트
+- `DELETE /api/v1/school-camps/applications/{id}`:
+  - 정상 취소(세션이 다시 `OPEN`으로 조회되는지까지 확인)
+  - 본인 신청 아님 → `403`
+  - 존재하지 않는 `id`/이미 취소된 신청 → `404`
+  - 캠핑 당일 취소 시도 → `400`
+- `PATCH /api/v1/school-camps/applications/{id}`:
+  - 담당 선생님만 변경(팀원 그대로)
+  - 팀원 추가(가입 학생 + "기타" 혼합), 팀원 제거, 팀원 유지 — 세 경우 모두 diff가 올바르게
+    적용되는지(삭제/유지/신규삽입 각각)
+  - 기존에 있던 팀원은 이번 달 중복 검사에서 제외되고, 새로 추가된 팀원만 검사되는지
+  - 새로 추가한 팀원이 이번 달 이미 다른 세션에 참여 중 → `409`
+  - 소유권 없음 → `403`
+  - 존재하지 않거나 취소된 신청 → `404`
+  - 8명 초과, 존재하지 않는 `studentUserId` → `400`
+  - 수정해도 세션 `taken_at`이 그대로 유지되는지(반환되지 않는지) 확인
+  - 새로 추가된 가입 팀원에게 알림이 발송되는지
+- 회귀: #68에서 만든 검증 로직(형식/역할/존재/중복)이 리팩터링 후에도 그대로 동작하는지

--- a/docs/domain/schoolcamp/70-schoolcamp-cancel-update.md
+++ b/docs/domain/schoolcamp/70-schoolcamp-cancel-update.md
@@ -141,6 +141,8 @@ not-found를 세션 대상 not-found와 분리했다 — API 설계 원칙 4(의
 - 형식 오류/8명 초과/유효하지 않은 `teacherUserId` → `400` `SCHOOLCAMP_004`
 - 존재하지 않는 `studentUserId`/중복 → `400` `SCHOOLCAMP_008`
 - 새로 추가한 팀원 중 이번 달 이미 참여한 사람 있음 → `409` `SCHOOLCAMP_003`
+- 같은 신청에 대한 동시 수정 요청이 충돌(코드 리뷰 대응, 아래 "동시 수정 레이스" 참고) →
+  `409` `SCHOOLCAMP_011`
 
 > 💡 이 엔드포인트는 세션의 `taken_at`에 영향을 주지 않는다 — 그 날짜는 이미 이 신청 하나가
 > 차지한 상태이므로, 팀원을 추가/제거해도(최대 8명 제한 안에서) 다른 신청과 경합할 여지가
@@ -149,18 +151,21 @@ not-found를 세션 대상 not-found와 분리했다 — API 설계 원칙 4(의
 ## 영향 받는 기존 코드
 - 신규: `SchoolCampErrorCode.APPLICATION_NOT_FOUND`(`SCHOOLCAMP_010`),
   `.NOT_APPLICATION_OWNER`(`SCHOOLCAMP_007`), `.CANCEL_NOT_ALLOWED_ON_CAMP_DAY`
-  (`SCHOOLCAMP_009`)
+  (`SCHOOLCAMP_009`), `.CONCURRENT_UPDATE_CONFLICT`(`SCHOOLCAMP_011`, 코드 리뷰 대응 —
+  아래 "동시 수정 레이스" 참고)
 - 수정: `SchoolCampApplicationRepository`(`findByIdAndCancelledAtIsNull` 추가),
-  `SchoolCampMemberRepository`(`findByApplicationId`를 이 이슈에서 신규 추가, 추가로
-  `deleteAllByIdIn` 또는 개별 `delete` 필요), `SchoolCampService`(`cancelApplication`/
-  `updateApplication` 추가 — `#68`의 `validateApplicationFormat`/`findValidTeacher`/
-  `findExistingStudents`는 그대로 재사용하되, `validateNoDuplicateThisMonth`는 호출 시
-  대표 신청자를 후보 집합에 자동으로 넣는 현재 시그니처가 "새로 추가되는 학생만" 검사하는
-  이 이슈의 요구와 맞지 않아 그대로 재사용할 수 없다 — 구현 시 후보 집합을 호출부에서 직접
-  구성해 넘기도록 시그니처를 조정해야 한다), `SchoolCampController`(`DELETE`/`PATCH`
-  `/applications/{id}` 추가)
+  `SchoolCampMemberRepository`(`findByApplicationId`를 이 이슈에서 신규 추가, 삭제는
+  `JpaRepository` 기본 제공 `deleteAllById`를 그대로 사용해 별도 메서드 불필요),
+  `SchoolCampService`(`cancelApplication`/`updateApplication` 추가 — `#68`의
+  `validateApplicationFormat`/`findValidTeacher`/`findExistingStudents`는 그대로
+  재사용하되, `validateNoDuplicateThisMonth`는 호출 시 대표 신청자를 후보 집합에 자동으로
+  넣는 기존 시그니처가 "새로 추가되는 학생만" 검사하는 이 이슈의 요구와 맞지 않아 후보
+  집합을 호출부가 직접 구성해 넘기도록 시그니처를 조정했다), `SchoolCampController`
+  (`DELETE`/`PATCH` `/applications/{id}` 추가)
 - `SchoolCampSessionRepository.release`는 이미 `#68`에 있어 그대로 재사용한다(수정 없음)
-- 신규 마이그레이션 없음(기존 테이블만 사용)
+- **신규 마이그레이션 `V13__add_schoolcamp_member_unique_constraint.sql`**(코드 리뷰 대응)
+  — `school_camp_member`에 `(application_id, student_user_id)` 유니크 제약 추가. 아래
+  "동시 수정 레이스" 참고
 - `SecurityConfig`(수정 없음): `/api/v1/school-camps/**`가 이미 인증 요구로 등록됨
 
 ## 리스크 및 고려사항
@@ -182,6 +187,19 @@ not-found를 세션 대상 not-found와 분리했다 — API 설계 원칙 4(의
   들어오면, 취소가 먼저 커밋되면 이후 수정은 `findByIdAndCancelledAtIsNull`에서 이미
   걸러져 `404`로 자연스럽게 처리된다 — 별도 락 없이 "취소 여부" 컬럼 자체가 가드 역할을
   한다.
+- **동시 수정(수정-수정) 레이스(코드 리뷰 발견, 확정)**: 위 "취소와 수정" 항목과 달리,
+  같은 신청에 대한 동시 PATCH 두 건(더블 클릭, 네트워크 재시도 등)은 `cancelled_at` 같은
+  가드가 없다 — 두 트랜잭션이 같은 기존 팀원 목록을 읽어 같은 `addedStudentIds`를 계산하고
+  각자 그 학생에 대한 새 `SchoolCampMember` 행을 삽입하면, 애플리케이션 레벨 검증만으로는
+  중복 삽입을 막지 못한다. `school_camp_member`에 `(application_id, student_user_id)`
+  유니크 제약(`V13`)을 추가해 DB를 최종 방어선으로 삼았다 — 진 쪽 트랜잭션의 삽입은
+  `DataIntegrityViolationException`으로 실패하고, `updateApplication`이 이를 잡아
+  `409` `SCHOOLCAMP_011`로 변환해 클라이언트가 "충돌, 재시도 가능"임을 명확히 알 수 있게
+  한다(그대로 두면 범용 `500`/`COMMON_006`으로 응답돼 원인이 불분명해진다 — `registerCampDates`
+  가 같은 이유로 사전 중복 검증을 하는 것과 같은 문제의식). 비관적 락(`SELECT ... FOR
+  UPDATE`)으로 애초에 두 트랜잭션을 직렬화하는 대안도 검토했으나, 이 프로젝트에 비관적 락
+  선례가 없어 새 패턴을 들이는 비용이 크고 트리거 조건(같은 사용자의 거의 동시 중복 제출)이
+  좁아 DB 제약만으로 충분하다고 판단했다.
 - **diff 삭제/삽입이 하나의 트랜잭션**: 6~7번 전체가 `@Transactional`로 묶여, 삭제는 됐는데
   삽입만 실패하는 식의 부분 반영이 나지 않는다.
 - **"전체 교체" 계약이 프론트에 실수 여지를 준다** — 바뀌지 않은 기존 팀원을 실수로
@@ -200,6 +218,13 @@ not-found를 세션 대상 not-found와 분리했다 — API 설계 원칙 4(의
   - 담당 선생님만 변경(팀원 그대로)
   - 팀원 추가(가입 학생 + "기타" 혼합), 팀원 제거, 팀원 유지 — 세 경우 모두 diff가 올바르게
     적용되는지(삭제/유지/신규삽입 각각)
+  - **한 요청 안에서 유지+추가+제거가 섞인 조합** — 각 diff 집합 연산이 서로 간섭하지
+    않는지(코드 리뷰 대응)
+  - **추가하는 팀원이 전부 "기타"(게스트)뿐인 경우** — 이번 달 중복 참여 확인 자체가
+    호출되지 않는지(코드 리뷰 대응)
+  - **동시 수정 충돌**: 팀원 삽입이 `(application_id, student_user_id)` 유니크 제약
+    위반(`DataIntegrityViolationException`)으로 실패하면 `409` `SCHOOLCAMP_011`로
+    변환되는지(코드 리뷰 대응)
   - 기존에 있던 팀원은 이번 달 중복 검사에서 제외되고, 새로 추가된 팀원만 검사되는지
   - 새로 추가한 팀원이 이번 달 이미 다른 세션에 참여 중 → `409`
   - 소유권 없음 → `403`

--- a/postman/collections/gone-schoolcamp.postman_collection.json
+++ b/postman/collections/gone-schoolcamp.postman_collection.json
@@ -1,7 +1,7 @@
 {
   "info": {
     "name": "GONE - SchoolCamp API",
-    "description": "스쿨캠핑(SchoolCamp) 도메인 API 컬렉션. #67(세션 등록 + 캘린더 조회) 2개 + #68(신청) 1개, 총 3개 엔드포인트를 다룹니다.\n\n**폴더 구성**: \"사전 준비\" 폴더(관리자/학생/팀원 로그인 + 토큰 준비) 뒤에 최상위 \"스쿨캠핑 날짜 등록\"/\"스쿨캠핑 캘린더 조회\"/\"스쿨캠핑 신청\" → \"에러 케이스\" 폴더(관련 없는 순서로 무엇이든 실행 가능).\n\n**사전 준비**: `teacherLoginId`(teacher1)/`studentLoginId`(user1)/`loginId`(testuser01, #68 팀원용) 테스트 계정이 DB에 있어야 합니다. 관리자/학생 역할 부여 API가 아직 없어(#15 진행 중), `teacher1` 계정에 ADMIN 역할을, `testuser01` 계정에 STUDENT 역할을 DB에서 직접 부여해야 각각 \"스쿨캠핑 날짜 등록\"과 #68의 팀원 관련 요청이 성공합니다(user_role 테이블에 직접 INSERT, 실행 후 원복 권장).\n\n**검증 폴더**: 두 엔드포인트를 처음부터 끝까지 순서대로 확인하는 \"#67 세션 등록 + 캘린더 조회 확인\" 폴더와, 신청 엔드포인트의 정상/에러 시나리오를 전부 순서대로 재현하는 \"#68 스쿨캠핑 신청 확인\" 폴더를 각각 추가했습니다.",
+    "description": "스쿨캠핑(SchoolCamp) 도메인 API 컬렉션. #67(세션 등록 + 캘린더 조회) 2개 + #68(신청) 1개 + #70(취소/수정) 2개, 총 5개 엔드포인트를 다룹니다.\n\n**폴더 구성**: \"사전 준비\" 폴더(관리자/학생/팀원 로그인 + 토큰 준비) 뒤에 최상위 \"스쿨캠핑 날짜 등록\"/\"스쿨캠핑 캘린더 조회\"/\"스쿨캠핑 신청\"/\"스쿨캠핑 신청 취소\"/\"스쿨캠핑 신청 수정\" → \"에러 케이스\" 폴더(관련 없는 순서로 무엇이든 실행 가능).\n\n**사전 준비**: `teacherLoginId`(teacher1)/`studentLoginId`(user1)/`loginId`(testuser01, #68 팀원용)/`loginId2`(testuser02, #70 월중복 시나리오용) 테스트 계정이 DB에 있어야 합니다. 관리자/학생 역할 부여 API가 아직 없어(#15 진행 중), `teacher1` 계정에 ADMIN 역할을, `testuser01`/`testuser02` 계정에 STUDENT 역할을 DB에서 직접 부여해야 각각 \"스쿨캠핑 날짜 등록\"과 팀원 관련 요청이 성공합니다(user_role 테이블에 직접 INSERT, 실행 후 원복 권장).\n\n**검증 폴더**: 두 엔드포인트를 처음부터 끝까지 순서대로 확인하는 \"#67 세션 등록 + 캘린더 조회 확인\" 폴더, 신청 엔드포인트의 정상/에러 시나리오를 재현하는 \"#68 스쿨캠핑 신청 확인\" 폴더, 취소/수정 시나리오를 재현하는 \"#70 스쿨캠핑 신청 취소/수정 확인\" 폴더를 각각 추가했습니다. #70 폴더의 \"당일 취소 금지\" 검증 요청은 실행 시점의 로컬 머신 날짜(KST 가정)를 pre-request 스크립트로 계산해 오늘 날짜 세션을 등록하므로, 금/토/일에 실행하면 그 등록 요청 자체가 400으로 실패한다.",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
   },
   "item": [
@@ -176,6 +176,62 @@
             }
           ],
           "response": []
+        },
+        {
+          "name": "팀원2 학생 로그인 (testuser02, STUDENT 역할 수동 부여 필요, #70)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"identifier\": \"{{loginId2}}\",\n  \"password\": \"{{password2}}\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/auth/login",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "auth",
+                "login"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test(\"200 OK\", function () {",
+                  "    pm.response.to.have.status(200);",
+                  "});",
+                  "",
+                  "if (pm.response.code === 200) {",
+                  "    const body = pm.response.json();",
+                  "    if (body.success && body.data) {",
+                  "        pm.environment.set(\"member2AccessToken\", body.data.accessToken);",
+                  "        const payload = JSON.parse(atob(body.data.accessToken.split('.')[1].replace(/-/g,'+').replace(/_/g,'/')));",
+                  "        pm.environment.set(\"member2UserId\", payload.sub);",
+                  "    }",
+                  "}"
+                ]
+              }
+            }
+          ],
+          "response": []
         }
       ]
     },
@@ -336,6 +392,99 @@
               "        pm.environment.set(\"schoolCampApplicationId\", body.data.id);",
               "    }",
               "}"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "스쿨캠핑 신청 취소",
+      "request": {
+        "method": "DELETE",
+        "header": [
+          {
+            "key": "Authorization",
+            "value": "Bearer {{studentAccessToken}}"
+          }
+        ],
+        "url": {
+          "raw": "{{baseUrl}}/api/v1/school-camps/applications/{{schoolCampApplicationId}}",
+          "host": [
+            "{{baseUrl}}"
+          ],
+          "path": [
+            "api",
+            "v1",
+            "school-camps",
+            "applications",
+            "{{schoolCampApplicationId}}"
+          ]
+        },
+        "description": "본인 신청을 취소한다(#70). 200 OK, data는 null. 실행 전에 '사전 준비'와 '스쿨캠핑 신청'을 먼저 실행해 schoolCampApplicationId가 studentAccessToken 소유의 유효한 신청을 가리켜야 한다 — 상세 순서는 '#70 스쿨캠핑 신청 취소/수정 확인' 폴더 참고."
+      },
+      "response": [],
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "type": "text/javascript",
+            "exec": [
+              "pm.test(\"200 OK\", function () {",
+              "    pm.response.to.have.status(200);",
+              "});"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "스쿨캠핑 신청 수정",
+      "request": {
+        "method": "PATCH",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          },
+          {
+            "key": "Authorization",
+            "value": "Bearer {{studentAccessToken}}"
+          }
+        ],
+        "url": {
+          "raw": "{{baseUrl}}/api/v1/school-camps/applications/{{schoolCampApplicationId}}",
+          "host": [
+            "{{baseUrl}}"
+          ],
+          "path": [
+            "api",
+            "v1",
+            "school-camps",
+            "applications",
+            "{{schoolCampApplicationId}}"
+          ]
+        },
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"teacherUserId\": {{teacherUserId}},\n  \"additionalMembers\": [\n    { \"studentUserId\": {{memberUserId}} }\n  ]\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "description": "본인 신청의 담당 선생님/팀원 정보를 수정한다(#70). 전체 교체 방식이라 바뀌지 않은 기존 팀원도 포함해 최종 팀원 목록 전체를 보내야 한다. 200 OK. 실행 전 조건은 '스쿨캠핑 신청 취소'와 동일 — 상세 순서는 '#70 스쿨캠핑 신청 취소/수정 확인' 폴더 참고."
+      },
+      "response": [],
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "type": "text/javascript",
+            "exec": [
+              "pm.test(\"200 OK\", function () {",
+              "    pm.response.to.have.status(200);",
+              "});"
             ]
           }
         }
@@ -742,6 +891,127 @@
                 "school-camps",
                 "1",
                 "applications"
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"teacherUserId\": {{teacherUserId}}\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "존재하지 않는 신청 취소 시도 → 404 SCHOOLCAMP_010 (#70)",
+          "request": {
+            "method": "DELETE",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{studentAccessToken}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/school-camps/applications/999999",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "school-camps",
+                "applications",
+                "999999"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "존재하지 않는 신청 수정 시도 → 404 SCHOOLCAMP_010 (#70)",
+          "request": {
+            "method": "PATCH",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{studentAccessToken}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/school-camps/applications/999999",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "school-camps",
+                "applications",
+                "999999"
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"teacherUserId\": {{teacherUserId}}\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "인증 없이 신청 취소 시도 → 401 (#70)",
+          "request": {
+            "method": "DELETE",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/school-camps/applications/1",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "school-camps",
+                "applications",
+                "1"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "인증 없이 신청 수정 시도 → 401 (#70)",
+          "request": {
+            "method": "PATCH",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/school-camps/applications/1",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "school-camps",
+                "applications",
+                "1"
               ]
             },
             "body": {
@@ -2070,6 +2340,1214 @@
                   "        pm.expect(body.data.members[1].guestName).to.eql(\"김철수(외부인)\");",
                   "    });",
                   "}"
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "#70 스쿨캠핑 신청 취소/수정 확인",
+      "description": "취소/수정 엔드포인트의 정상/에러 시나리오를 처음부터 끝까지 순서대로 재현하는 폴더. 순서대로 실행해야 한다. 11번(오늘 날짜 세션 등록)은 pre-request 스크립트로 실행 시점의 로컬 머신 날짜(KST 가정)를 계산해 campDateToday를 채우므로, 금/토/일에 실행하면 그 등록 요청 자체가 400으로 실패한다.",
+      "item": [
+        {
+          "name": "1. 관리자 로그인 (teacher1, ADMIN 역할 수동 부여 필요)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"identifier\": \"{{teacherLoginId}}\",\n  \"password\": \"{{teacherPassword}}\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/auth/login",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "auth",
+                "login"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test(\"200 OK\", function () {",
+                  "    pm.response.to.have.status(200);",
+                  "});",
+                  "",
+                  "if (pm.response.code === 200) {",
+                  "    const body = pm.response.json();",
+                  "    if (body.success && body.data) {",
+                  "        pm.environment.set(\"teacherAccessToken\", body.data.accessToken);",
+                  "        const payload = JSON.parse(atob(body.data.accessToken.split('.')[1].replace(/-/g,'+').replace(/_/g,'/')));",
+                  "        pm.environment.set(\"teacherUserId\", payload.sub);",
+                  "    }",
+                  "}"
+                ]
+              }
+            }
+          ],
+          "response": []
+        },
+        {
+          "name": "2. 대표 학생 로그인 (user1)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"identifier\": \"{{studentLoginId}}\",\n  \"password\": \"{{studentPassword}}\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/auth/login",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "auth",
+                "login"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test(\"200 OK\", function () {",
+                  "    pm.response.to.have.status(200);",
+                  "});",
+                  "",
+                  "if (pm.response.code === 200) {",
+                  "    const body = pm.response.json();",
+                  "    if (body.success && body.data) {",
+                  "        pm.environment.set(\"studentAccessToken\", body.data.accessToken);",
+                  "        const payload = JSON.parse(atob(body.data.accessToken.split('.')[1].replace(/-/g,'+').replace(/_/g,'/')));",
+                  "        pm.environment.set(\"studentUserId\", payload.sub);",
+                  "    }",
+                  "}"
+                ]
+              }
+            }
+          ],
+          "response": []
+        },
+        {
+          "name": "3. 팀원 학생 로그인 (testuser01, STUDENT 역할 수동 부여 필요)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"identifier\": \"{{loginId}}\",\n  \"password\": \"{{password}}\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/auth/login",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "auth",
+                "login"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test(\"200 OK\", function () {",
+                  "    pm.response.to.have.status(200);",
+                  "});",
+                  "",
+                  "if (pm.response.code === 200) {",
+                  "    const body = pm.response.json();",
+                  "    if (body.success && body.data) {",
+                  "        pm.environment.set(\"memberAccessToken\", body.data.accessToken);",
+                  "        const payload = JSON.parse(atob(body.data.accessToken.split('.')[1].replace(/-/g,'+').replace(/_/g,'/')));",
+                  "        pm.environment.set(\"memberUserId\", payload.sub);",
+                  "    }",
+                  "}"
+                ]
+              }
+            }
+          ],
+          "response": []
+        },
+        {
+          "name": "4. 팀원2 학생 로그인 (testuser02, STUDENT 역할 수동 부여 필요)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"identifier\": \"{{loginId2}}\",\n  \"password\": \"{{password2}}\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/auth/login",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "auth",
+                "login"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test(\"200 OK\", function () {",
+                  "    pm.response.to.have.status(200);",
+                  "});",
+                  "",
+                  "if (pm.response.code === 200) {",
+                  "    const body = pm.response.json();",
+                  "    if (body.success && body.data) {",
+                  "        pm.environment.set(\"member2AccessToken\", body.data.accessToken);",
+                  "        const payload = JSON.parse(atob(body.data.accessToken.split('.')[1].replace(/-/g,'+').replace(/_/g,'/')));",
+                  "        pm.environment.set(\"member2UserId\", payload.sub);",
+                  "    }",
+                  "}"
+                ]
+              }
+            }
+          ],
+          "response": []
+        },
+        {
+          "name": "5. 날짜 등록 (campDateCancel1, 취소 플로우용)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{teacherAccessToken}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/school-camps",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "school-camps"
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"campDates\": [\n    \"{{campDateCancel1}}\"\n  ]\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            }
+          },
+          "response": [],
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test(\"201 Created\", function () {",
+                  "    pm.response.to.have.status(201);",
+                  "});",
+                  "",
+                  "if (pm.response.code === 201) {",
+                  "    const body = pm.response.json();",
+                  "    pm.environment.set(\"schoolCampSessionId\", body.data[0].sessionId);",
+                  "}"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "6. 신청 (대표 단독, 취소 플로우용)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{studentAccessToken}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/school-camps/{{schoolCampSessionId}}/applications",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "school-camps",
+                "{{schoolCampSessionId}}",
+                "applications"
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"teacherUserId\": {{teacherUserId}}\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            }
+          },
+          "response": [],
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test(\"201 Created\", function () {",
+                  "    pm.response.to.have.status(201);",
+                  "});",
+                  "",
+                  "if (pm.response.code === 201) {",
+                  "    const body = pm.response.json();",
+                  "    pm.environment.set(\"schoolCampApplicationId\", body.data.id);",
+                  "}"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "7. 취소 시도 - 본인 아님(팀원 계정) → 403 SCHOOLCAMP_007",
+          "request": {
+            "method": "DELETE",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{memberAccessToken}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/school-camps/applications/{{schoolCampApplicationId}}",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "school-camps",
+                "applications",
+                "{{schoolCampApplicationId}}"
+              ]
+            }
+          },
+          "response": [],
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test(\"403 Forbidden, SCHOOLCAMP_007\", function () {",
+                  "    pm.response.to.have.status(403);",
+                  "    pm.expect(pm.response.json().code).to.eql(\"SCHOOLCAMP_007\");",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "8. 정상 취소",
+          "request": {
+            "method": "DELETE",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{studentAccessToken}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/school-camps/applications/{{schoolCampApplicationId}}",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "school-camps",
+                "applications",
+                "{{schoolCampApplicationId}}"
+              ]
+            }
+          },
+          "response": [],
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test(\"200 OK\", function () {",
+                  "    pm.response.to.have.status(200);",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "9. 캘린더 재조회 (세션이 다시 OPEN인지 확인)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{studentAccessToken}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/school-camps?month={{schoolCampMonthCancel}}",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "school-camps"
+              ],
+              "query": [
+                {
+                  "key": "month",
+                  "value": "{{schoolCampMonthCancel}}"
+                }
+              ]
+            }
+          },
+          "response": [],
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test(\"취소한 세션이 다시 OPEN이다\", function () {",
+                  "    const body = pm.response.json();",
+                  "    const found = body.data.find(",
+                  "        s => s.campDate === pm.environment.get(\"campDateCancel1\"));",
+                  "    pm.expect(found).to.not.be.undefined;",
+                  "    pm.expect(found.status).to.eql(\"OPEN\");",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "10. 재취소 시도(이미 취소된 신청) → 404 SCHOOLCAMP_010",
+          "request": {
+            "method": "DELETE",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{studentAccessToken}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/school-camps/applications/{{schoolCampApplicationId}}",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "school-camps",
+                "applications",
+                "{{schoolCampApplicationId}}"
+              ]
+            }
+          },
+          "response": [],
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test(\"404 Not Found, SCHOOLCAMP_010\", function () {",
+                  "    pm.response.to.have.status(404);",
+                  "    pm.expect(pm.response.json().code).to.eql(\"SCHOOLCAMP_010\");",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "11. 오늘 날짜 세션 등록 (당일 취소 금지 검증용)",
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "const now = new Date();",
+                  "const yyyy = now.getFullYear();",
+                  "const mm = String(now.getMonth() + 1).padStart(2, '0');",
+                  "const dd = String(now.getDate()).padStart(2, '0');",
+                  "pm.environment.set(\"campDateToday\", `${yyyy}${mm}${dd}`);"
+                ]
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test(\"201 Created\", function () {",
+                  "    pm.response.to.have.status(201);",
+                  "});",
+                  "",
+                  "if (pm.response.code === 201) {",
+                  "    const body = pm.response.json();",
+                  "    pm.environment.set(\"schoolCampSessionId\", body.data[0].sessionId);",
+                  "}"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{teacherAccessToken}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/school-camps",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "school-camps"
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"campDates\": [\n    \"{{campDateToday}}\"\n  ]\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "description": "pre-request 스크립트가 실행 시점의 로컬 머신 날짜(KST 가정)를 campDateToday에 채운다. 금/토/일에 실행하면 이 요청 자체가 400으로 실패한다(관리자 책임 영역인 요일 검증)."
+          },
+          "response": []
+        },
+        {
+          "name": "12. 신청 (오늘 세션)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{studentAccessToken}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/school-camps/{{schoolCampSessionId}}/applications",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "school-camps",
+                "{{schoolCampSessionId}}",
+                "applications"
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"teacherUserId\": {{teacherUserId}}\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            }
+          },
+          "response": [],
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test(\"201 Created\", function () {",
+                  "    pm.response.to.have.status(201);",
+                  "});",
+                  "",
+                  "if (pm.response.code === 201) {",
+                  "    const body = pm.response.json();",
+                  "    pm.environment.set(\"schoolCampApplicationId\", body.data.id);",
+                  "}"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "13. 취소 시도(캠핑 당일) → 400 SCHOOLCAMP_009",
+          "request": {
+            "method": "DELETE",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{studentAccessToken}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/school-camps/applications/{{schoolCampApplicationId}}",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "school-camps",
+                "applications",
+                "{{schoolCampApplicationId}}"
+              ]
+            }
+          },
+          "response": [],
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test(\"400 Bad Request, SCHOOLCAMP_009\", function () {",
+                  "    pm.response.to.have.status(400);",
+                  "    pm.expect(pm.response.json().code).to.eql(\"SCHOOLCAMP_009\");",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "14. 날짜 등록 (campDateUpdate1, 수정 플로우용)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{teacherAccessToken}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/school-camps",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "school-camps"
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"campDates\": [\n    \"{{campDateUpdate1}}\"\n  ]\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            }
+          },
+          "response": [],
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "// 12번(오늘 신청)이 남긴 대표 학생의 '이번 달 참여'와 겹치지 않도록,",
+                  "// 실행 시점 기준 3개월 뒤 평일 이틀을 계산해 campDateUpdate1/",
+                  "// campDateUpdateParticipated를 매번 새로 채운다(고정 날짜였다가",
+                  "// 실행 시점의 '오늘'과 같은 달로 겹쳐 409가 나던 문제 수정).",
+                  "function nextWeekday(date) {",
+                  "    const d = new Date(date);",
+                  "    while (d.getDay() === 0 || d.getDay() === 5 || d.getDay() === 6) {",
+                  "        d.setDate(d.getDate() + 1);",
+                  "    }",
+                  "    return d;",
+                  "}",
+                  "function toYyyyMmDd(d) {",
+                  "    const yyyy = d.getFullYear();",
+                  "    const mm = String(d.getMonth() + 1).padStart(2, '0');",
+                  "    const dd = String(d.getDate()).padStart(2, '0');",
+                  "    return `${yyyy}${mm}${dd}`;",
+                  "}",
+                  "const now = new Date();",
+                  "const future = new Date(now.getFullYear(), now.getMonth() + 3, 1);",
+                  "const day1 = nextWeekday(future);",
+                  "const day2Start = new Date(day1);",
+                  "day2Start.setDate(day2Start.getDate() + 1);",
+                  "const day2 = nextWeekday(day2Start);",
+                  "pm.environment.set(\"campDateUpdate1\", toYyyyMmDd(day1));",
+                  "pm.environment.set(\"campDateUpdateParticipated\", toYyyyMmDd(day2));"
+                ]
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test(\"201 Created\", function () {",
+                  "    pm.response.to.have.status(201);",
+                  "});",
+                  "",
+                  "if (pm.response.code === 201) {",
+                  "    const body = pm.response.json();",
+                  "    pm.environment.set(\"schoolCampSessionId\", body.data[0].sessionId);",
+                  "}"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "15. 신청 (대표 + 팀원1, 수정 플로우용)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{studentAccessToken}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/school-camps/{{schoolCampSessionId}}/applications",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "school-camps",
+                "{{schoolCampSessionId}}",
+                "applications"
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"teacherUserId\": {{teacherUserId}},\n  \"additionalMembers\": [\n    { \"studentUserId\": {{memberUserId}} }\n  ]\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            }
+          },
+          "response": [],
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test(\"201 Created\", function () {",
+                  "    pm.response.to.have.status(201);",
+                  "});",
+                  "",
+                  "if (pm.response.code === 201) {",
+                  "    const body = pm.response.json();",
+                  "    pm.environment.set(\"schoolCampApplicationId\", body.data.id);",
+                  "    pm.environment.set(\"schoolCampApplicationIdUpdate\", body.data.id);",
+                  "}"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "16. 수정 - 담당 선생님만 변경(팀원 그대로)",
+          "request": {
+            "method": "PATCH",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{studentAccessToken}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/school-camps/applications/{{schoolCampApplicationIdUpdate}}",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "school-camps",
+                "applications",
+                "{{schoolCampApplicationIdUpdate}}"
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"teacherName\": \"새로운쌤\",\n  \"additionalMembers\": [\n    { \"studentUserId\": {{memberUserId}} }\n  ]\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            }
+          },
+          "response": [],
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test(\"200 OK\", function () {",
+                  "    pm.response.to.have.status(200);",
+                  "});",
+                  "",
+                  "if (pm.response.code === 200) {",
+                  "    const body = pm.response.json();",
+                  "    pm.test(\"선생님만 바뀌고 팀원 2명 그대로\", function () {",
+                  "        pm.expect(body.data.teacherDisplayName).to.eql(\"새로운쌤\");",
+                  "        pm.expect(body.data.members.length).to.eql(2);",
+                  "    });",
+                  "}"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "17. 날짜 등록 (campDateUpdateParticipated, 15번과 같은 달)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{teacherAccessToken}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/school-camps",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "school-camps"
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"campDates\": [\n    \"{{campDateUpdateParticipated}}\"\n  ]\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            }
+          },
+          "response": [],
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test(\"201 Created\", function () {",
+                  "    pm.response.to.have.status(201);",
+                  "});",
+                  "",
+                  "if (pm.response.code === 201) {",
+                  "    const body = pm.response.json();",
+                  "    pm.environment.set(\"schoolCampSessionId\", body.data[0].sessionId);",
+                  "}"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "18. 팀원2가 단독 신청(이번 달 참여 상태 만들기)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{member2AccessToken}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/school-camps/{{schoolCampSessionId}}/applications",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "school-camps",
+                "{{schoolCampSessionId}}",
+                "applications"
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"teacherUserId\": {{teacherUserId}}\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "description": "member2UserId(testuser02)를 15번의 신청(schoolCampApplicationIdUpdate)과 같은 달에 참여 중인 상태로 만들어, 19번의 월중복 409를 재현할 수 있게 한다."
+          },
+          "response": [],
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test(\"201 Created\", function () {",
+                  "    pm.response.to.have.status(201);",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "19. 수정 - 이미 이번 달 참여한 팀원2 추가 시도 → 409 SCHOOLCAMP_003",
+          "request": {
+            "method": "PATCH",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{studentAccessToken}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/school-camps/applications/{{schoolCampApplicationIdUpdate}}",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "school-camps",
+                "applications",
+                "{{schoolCampApplicationIdUpdate}}"
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"teacherName\": \"새로운쌤\",\n  \"additionalMembers\": [\n    { \"guestName\": \"새게스트\" },\n    { \"studentUserId\": {{member2UserId}} }\n  ]\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            }
+          },
+          "response": [],
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test(\"409 Conflict, SCHOOLCAMP_003\", function () {",
+                  "    pm.response.to.have.status(409);",
+                  "    pm.expect(pm.response.json().code).to.eql(\"SCHOOLCAMP_003\");",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "20. 수정 - 팀원 제거 + 게스트 추가(조합)",
+          "request": {
+            "method": "PATCH",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{studentAccessToken}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/school-camps/applications/{{schoolCampApplicationIdUpdate}}",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "school-camps",
+                "applications",
+                "{{schoolCampApplicationIdUpdate}}"
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"teacherName\": \"새로운쌤\",\n  \"additionalMembers\": [\n    { \"guestName\": \"새게스트\" }\n  ]\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "description": "15번에서 추가했던 팀원1(memberUserId)을 요청에서 빼(제거) 대신 게스트를 추가한다 — 제거+추가가 한 요청에 섞이는 조합 케이스(코드 리뷰 대응)."
+          },
+          "response": [],
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test(\"200 OK\", function () {",
+                  "    pm.response.to.have.status(200);",
+                  "});",
+                  "",
+                  "if (pm.response.code === 200) {",
+                  "    const body = pm.response.json();",
+                  "    pm.test(\"팀원1은 사라지고 게스트만 남는다\", function () {",
+                  "        pm.expect(body.data.members.length).to.eql(2);",
+                  "        pm.expect(body.data.members[1].guestName).to.eql(\"새게스트\");",
+                  "    });",
+                  "}"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "21. 수정 - 총원 8명 초과 → 400 SCHOOLCAMP_004",
+          "request": {
+            "method": "PATCH",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{studentAccessToken}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/school-camps/applications/{{schoolCampApplicationIdUpdate}}",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "school-camps",
+                "applications",
+                "{{schoolCampApplicationIdUpdate}}"
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"teacherName\": \"새로운쌤\",\n  \"additionalMembers\": [\n    {\"guestName\": \"a\"}, {\"guestName\": \"b\"}, {\"guestName\": \"c\"}, {\"guestName\": \"d\"},\n    {\"guestName\": \"e\"}, {\"guestName\": \"f\"}, {\"guestName\": \"g\"}, {\"guestName\": \"h\"}\n  ]\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            }
+          },
+          "response": [],
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test(\"400 Bad Request, SCHOOLCAMP_004\", function () {",
+                  "    pm.response.to.have.status(400);",
+                  "    pm.expect(pm.response.json().code).to.eql(\"SCHOOLCAMP_004\");",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "22. 수정 - 존재하지 않는 studentUserId → 400 SCHOOLCAMP_008",
+          "request": {
+            "method": "PATCH",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{studentAccessToken}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/school-camps/applications/{{schoolCampApplicationIdUpdate}}",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "school-camps",
+                "applications",
+                "{{schoolCampApplicationIdUpdate}}"
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"teacherName\": \"새로운쌤\",\n  \"additionalMembers\": [\n    { \"studentUserId\": 999999 }\n  ]\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            }
+          },
+          "response": [],
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test(\"400 Bad Request, SCHOOLCAMP_008\", function () {",
+                  "    pm.response.to.have.status(400);",
+                  "    pm.expect(pm.response.json().code).to.eql(\"SCHOOLCAMP_008\");",
+                  "});"
                 ]
               }
             }

--- a/postman/environments/gone-local-dev.postman_environment.json
+++ b/postman/environments/gone-local-dev.postman_environment.json
@@ -252,6 +252,72 @@
       "value": "202606",
       "type": "default",
       "enabled": true
+    },
+    {
+      "key": "loginId2",
+      "value": "testuser02",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "password2",
+      "value": "Test1234!",
+      "type": "secret",
+      "enabled": true
+    },
+    {
+      "key": "member2AccessToken",
+      "value": "",
+      "type": "secret",
+      "enabled": true
+    },
+    {
+      "key": "member2UserId",
+      "value": "",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "campDateCancel1",
+      "value": "20260701",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "campDateUpdate1",
+      "value": "20260805",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "campDateUpdateParticipated",
+      "value": "20260806",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "campDateToday",
+      "value": "",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "schoolCampMonthCancel",
+      "value": "202607",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "schoolCampMonthUpdate",
+      "value": "202608",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "schoolCampApplicationIdUpdate",
+      "value": "",
+      "type": "default",
+      "enabled": true
     }
   ]
 }

--- a/src/main/java/com/remake/gone/schoolcamp/controller/SchoolCampController.java
+++ b/src/main/java/com/remake/gone/schoolcamp/controller/SchoolCampController.java
@@ -18,7 +18,9 @@ import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -28,7 +30,7 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 /**
- * 스쿨캠핑(SchoolCamp) 세션 등록/캘린더 조회/신청 API.
+ * 스쿨캠핑(SchoolCamp) 세션 등록/캘린더 조회/신청/취소/수정 API.
  */
 @RestController
 @RequestMapping("/api/v1/school-camps")
@@ -92,5 +94,45 @@ public class SchoolCampController {
     SchoolCampApplicationResponse response = schoolCampService.applyToCamp(
         principal.userId(), sessionId, request, LocalDateTime.now(KST));
     return ApiResponse.success(response, "스쿨캠핑 신청이 완료되었습니다.");
+  }
+
+  /**
+   * 본인 신청을 취소합니다. 소유권 확인과 당일 취소 금지는 서비스에서 처리합니다.
+   *
+   * @param principal     인증 필터가 Access Token에서 추출한 현재 사용자
+   * @param applicationId 취소할 신청의 PK
+   * @return 데이터 없는 성공 응답
+   */
+  @DeleteMapping("/applications/{applicationId}")
+  @PreAuthorize("isAuthenticated()")
+  public ApiResponse<Void> cancelApplication(
+      @AuthenticationPrincipal UserPrincipal principal,
+      @PathVariable Long applicationId
+  ) {
+    schoolCampService.cancelApplication(
+        principal.userId(), applicationId, LocalDateTime.now(KST));
+    return ApiResponse.success(null, "신청이 취소되었습니다.");
+  }
+
+  /**
+   * 본인 신청의 담당 선생님/팀원 정보를 수정합니다. 전체 교체 방식이라, 바뀌지 않은 기존
+   * 팀원도 포함해 원하는 최종 팀원 목록 전체를 보내야 합니다. 소유권 확인은 서비스에서
+   * 처리합니다.
+   *
+   * @param principal     인증 필터가 Access Token에서 추출한 현재 사용자
+   * @param applicationId 수정할 신청의 PK
+   * @param request       새 담당 선생님/팀원 스냅샷
+   * @return 갱신된 신청 정보
+   */
+  @PatchMapping("/applications/{applicationId}")
+  @PreAuthorize("isAuthenticated()")
+  public ApiResponse<SchoolCampApplicationResponse> updateApplication(
+      @AuthenticationPrincipal UserPrincipal principal,
+      @PathVariable Long applicationId,
+      @Valid @RequestBody SchoolCampApplyRequest request
+  ) {
+    SchoolCampApplicationResponse response =
+        schoolCampService.updateApplication(principal.userId(), applicationId, request);
+    return ApiResponse.success(response, "신청 정보가 수정되었습니다.");
   }
 }

--- a/src/main/java/com/remake/gone/schoolcamp/exception/SchoolCampErrorCode.java
+++ b/src/main/java/com/remake/gone/schoolcamp/exception/SchoolCampErrorCode.java
@@ -8,8 +8,8 @@ import org.springframework.http.HttpStatus;
  *
  * <p>코드 네이밍 규칙: {@code SCHOOLCAMP_NNN} (NNN은 3자리 순번). 번호는 마스터 기획서
  * (`docs/domain/schoolcamp/1_schoolcamp-domain.md`)의 전체 목록 중 실제로 구현되는 순서대로
- * 채운다 — #67에서는 005/006만 쓰였고, #68은 001/002/003/004/008을, #70은 007/009/010을
- * 쓴다.
+ * 채운다 — #67에서는 005/006만 쓰였고, #68은 001/002/003/004/008을, #70은
+ * 007/009/010/011을 쓴다.
  *
  * @see ErrorCode
  */
@@ -89,7 +89,19 @@ public enum SchoolCampErrorCode implements ErrorCode {
    * ("해당 날짜에 스쿨캠핑 일정이 없습니다")가 신청 조회 실패 상황과 맞지 않아 별도 코드로
    * 분리했다.
    */
-  APPLICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "SCHOOLCAMP_010", "해당 신청을 찾을 수 없습니다.");
+  APPLICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "SCHOOLCAMP_010", "해당 신청을 찾을 수 없습니다."),
+
+  /**
+   * 같은 신청에 대한 동시 수정 요청이 충돌했습니다({@code #70} 코드 리뷰 대응).
+   *
+   * <p>{@code updateApplication}이 새 팀원을 삽입하는 순간, 동시에 처리된 다른 수정 요청이
+   * 이미 같은 학생을 같은 신청에 팀원으로 추가해
+   * {@code (application_id, student_user_id)} 유니크 제약(V13 마이그레이션)을 위반했을 때
+   * 쓴다 — {@code DataIntegrityViolationException}을 그대로 COMMON_006/500으로 흘려보내지
+   * 않고, 재시도하면 해결될 수 있는 충돌임을 명시적으로 알린다.
+   */
+  CONCURRENT_UPDATE_CONFLICT(
+      HttpStatus.CONFLICT, "SCHOOLCAMP_011", "다른 요청과 동시에 처리되어 반영하지 못했습니다. 다시 시도해주세요.");
 
   private final HttpStatus httpStatus;
   private final String code;

--- a/src/main/java/com/remake/gone/schoolcamp/exception/SchoolCampErrorCode.java
+++ b/src/main/java/com/remake/gone/schoolcamp/exception/SchoolCampErrorCode.java
@@ -8,7 +8,8 @@ import org.springframework.http.HttpStatus;
  *
  * <p>코드 네이밍 규칙: {@code SCHOOLCAMP_NNN} (NNN은 3자리 순번). 번호는 마스터 기획서
  * (`docs/domain/schoolcamp/1_schoolcamp-domain.md`)의 전체 목록 중 실제로 구현되는 순서대로
- * 채운다 — #67에서는 005/006만 쓰였고, #68은 001/002/003/004/008을 쓴다.
+ * 채운다 — #67에서는 005/006만 쓰였고, #68은 001/002/003/004/008을, #70은 007/009/010을
+ * 쓴다.
  *
  * @see ErrorCode
  */
@@ -55,12 +56,40 @@ public enum SchoolCampErrorCode implements ErrorCode {
   CAMP_DATE_ALREADY_REGISTERED(HttpStatus.CONFLICT, "SCHOOLCAMP_006", "이미 등록된 날짜입니다."),
 
   /**
+   * 본인 신청이 아닌 {@code SchoolCampApplication}을 취소/수정하려고 시도했습니다.
+   *
+   * <p>{@code #70}의 취소({@code DELETE .../applications/{id}})/수정
+   * ({@code PATCH .../applications/{id}})가 소유권 확인에 실패했을 때 쓴다.
+   */
+  NOT_APPLICATION_OWNER(HttpStatus.FORBIDDEN, "SCHOOLCAMP_007", "본인 신청만 취소/수정할 수 있습니다."),
+
+  /**
    * 팀원 정보가 올바르지 않습니다 — {@code additionalMembers}의 각 항목이
    * {@code studentUserId}/{@code guestName} 중 정확히 하나가 아니거나, 존재하지 않는
    * {@code studentUserId}이거나, 같은 {@code studentUserId}가 중복되거나, 대표 신청자
    * 본인이 포함된 경우 모두 이 코드를 쓴다.
    */
-  INVALID_MEMBER_INFO(HttpStatus.BAD_REQUEST, "SCHOOLCAMP_008", "팀원 정보가 올바르지 않습니다.");
+  INVALID_MEMBER_INFO(HttpStatus.BAD_REQUEST, "SCHOOLCAMP_008", "팀원 정보가 올바르지 않습니다."),
+
+  /**
+   * 캠핑 당일에는 취소할 수 없습니다({@code #70}).
+   *
+   * <p>{@code SchoolCampApplication.session.campDate}가 오늘이면 취소 요청을 거부할 때
+   * 쓴다 — 담당 선생님/팀원 정보 수정({@code PATCH})은 이 제약과 무관하게 계속 허용한다.
+   */
+  CANCEL_NOT_ALLOWED_ON_CAMP_DAY(
+      HttpStatus.BAD_REQUEST, "SCHOOLCAMP_009", "캠핑 당일에는 취소할 수 없습니다."),
+
+  /**
+   * 존재하지 않거나 이미 취소된 {@code SchoolCampApplication}입니다({@code #70}).
+   *
+   * <p>{@code SESSION_NOT_FOUND}(세션 대상 조회 실패)와 대상이 다르다 — 이 코드는
+   * {@code SchoolCampApplication} 조회 실패에만 쓴다({@code #70}의 취소/수정 두 엔드포인트).
+   * 마스터 기획서 초안은 {@code SCHOOLCAMP_001} 재사용을 제안했지만, 그 코드의 기본 메시지
+   * ("해당 날짜에 스쿨캠핑 일정이 없습니다")가 신청 조회 실패 상황과 맞지 않아 별도 코드로
+   * 분리했다.
+   */
+  APPLICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "SCHOOLCAMP_010", "해당 신청을 찾을 수 없습니다.");
 
   private final HttpStatus httpStatus;
   private final String code;

--- a/src/main/java/com/remake/gone/schoolcamp/repository/SchoolCampApplicationRepository.java
+++ b/src/main/java/com/remake/gone/schoolcamp/repository/SchoolCampApplicationRepository.java
@@ -22,6 +22,15 @@ public interface SchoolCampApplicationRepository
   Optional<SchoolCampApplication> findBySessionIdAndCancelledAtIsNull(Long sessionId);
 
   /**
+   * 활성(취소되지 않은) 신청을 PK로 조회합니다({@code #70} 취소/수정에서 사용). 이미 취소된
+   * 신청은 없는 것처럼 취급한다 — 재취소·재수정 시도를 조회 단계에서부터 걸러낸다.
+   *
+   * @param id 조회할 신청의 PK
+   * @return 활성 신청(있다면)
+   */
+  Optional<SchoolCampApplication> findByIdAndCancelledAtIsNull(Long id);
+
+  /**
    * 여러 세션의 활성(취소되지 않은) 신청을 한 번에 조회합니다. 캘린더 응답
    * ({@code SchoolCampService.getCalendar})이 점유된 세션 수만큼 개별 조회하는 N+1을
    * 피하려고 배치로 묶어 쓴다.

--- a/src/main/java/com/remake/gone/schoolcamp/repository/SchoolCampMemberRepository.java
+++ b/src/main/java/com/remake/gone/schoolcamp/repository/SchoolCampMemberRepository.java
@@ -37,4 +37,13 @@ public interface SchoolCampMemberRepository extends JpaRepository<SchoolCampMemb
       @Param("candidateIds") Collection<Long> candidateIds,
       @Param("monthStart") LocalDate monthStart,
       @Param("monthEnd") LocalDate monthEnd);
+
+  /**
+   * 한 신청(팀)에 속한 팀원 전체를 조회합니다({@code #70} 수정에서 기존 팀원과의 diff
+   * 계산에 사용). 대표 신청자 행({@code applicant=true})도 포함된다.
+   *
+   * @param applicationId 조회할 신청의 PK
+   * @return 그 신청에 속한 팀원 전체
+   */
+  List<SchoolCampMember> findByApplicationId(Long applicationId);
 }

--- a/src/main/java/com/remake/gone/schoolcamp/service/SchoolCampService.java
+++ b/src/main/java/com/remake/gone/schoolcamp/service/SchoolCampService.java
@@ -232,6 +232,174 @@ public class SchoolCampService {
     }
   }
 
+  /**
+   * 본인 신청을 취소합니다(#70). 취소된 신청은 {@code cancelled_at}만 채우고(hard delete
+   * 아님) 세션을 다시 빈 날짜로 되돌린다.
+   *
+   * <p>세션 반환은 {@link SchoolCampSessionClaimService#release}(REQUIRES_NEW)를 거치지
+   * 않고 {@code sessionRepository.release}를 이 메서드 자신의 트랜잭션 안에서 직접
+   * 호출한다 — 취소는 그 신청의 유일한 소유자만 호출할 수 있어(아래 소유권 확인이 이미 그
+   * 사실을 보장) 애초에 경합 상대가 없다. 오히려 {@code cancelledAt} 갱신과 {@code taken_at}
+   * 반환을 같은 트랜잭션으로 묶어야, 이후 어떤 이유로든 커밋이 실패했을 때 두 변경이 함께
+   * 롤백돼 "신청은 취소됐는데 세션은 여전히 잠긴" 불일치가 생기지 않는다 — claim/release가
+   * REQUIRES_NEW라서 안았던 "release 실패 시 유령 점유" 잔여 리스크가 이 메서드에는 없다.
+   *
+   * @param applicantUserId 취소를 요청한 사용자 ID(Access Token에서 추출됨)
+   * @param applicationId   취소할 신청의 PK
+   * @param now             "지금"(KST) — 당일 취소 금지 판단과 {@code cancelledAt} 기록에 사용
+   */
+  @Transactional
+  public void cancelApplication(Long applicantUserId, Long applicationId, LocalDateTime now) {
+    SchoolCampApplication application =
+        applicationRepository.findByIdAndCancelledAtIsNull(applicationId)
+            .orElseThrow(() -> new CustomException(SchoolCampErrorCode.APPLICATION_NOT_FOUND));
+
+    if (!application.getApplicant().getId().equals(applicantUserId)) {
+      throw new CustomException(SchoolCampErrorCode.NOT_APPLICATION_OWNER);
+    }
+    if (application.getSession().getCampDate().equals(now.toLocalDate())) {
+      throw new CustomException(SchoolCampErrorCode.CANCEL_NOT_ALLOWED_ON_CAMP_DAY);
+    }
+
+    application.setCancelledAt(now);
+    applicationRepository.save(application);
+    sessionRepository.release(application.getSession().getId());
+  }
+
+  /**
+   * 담당 선생님/팀원 정보를 수정합니다(#70). {@code additionalMembers}는 전체 교체
+   * 방식이다 — 대표 신청자를 제외한 최종 팀원 목록 전체를 받아 기존 팀원과 비교(diff)해서,
+   * 새로 추가되는 학생만 이번 달 중복 참여를 재확인하고 빠진 학생/기존 "기타" 팀원의 행만
+   * 삭제한다. "기타"(자유 입력) 팀원은 안정적인 식별자가 없어 diff 대상이 아니다 — 기존
+   * guest 행은 전부 삭제하고 요청받은 목록으로 전부 새로 삽입한다. 세션의 {@code taken_at}은
+   * 건드리지 않는다 — 그 날짜는 이미 이 신청 하나가 통째로 차지한 상태라 별도 정원 조작이
+   * 필요 없다.
+   *
+   * @param applicantUserId 수정을 요청한 사용자 ID(Access Token에서 추출됨)
+   * @param applicationId   수정할 신청의 PK
+   * @param request         새 담당 선생님/팀원 스냅샷
+   * @return 갱신된 신청 정보
+   */
+  @Transactional
+  public SchoolCampApplicationResponse updateApplication(
+      Long applicantUserId, Long applicationId, SchoolCampApplyRequest request) {
+
+    SchoolCampApplication application =
+        applicationRepository.findByIdAndCancelledAtIsNull(applicationId)
+            .orElseThrow(() -> new CustomException(SchoolCampErrorCode.APPLICATION_NOT_FOUND));
+    if (!application.getApplicant().getId().equals(applicantUserId)) {
+      throw new CustomException(SchoolCampErrorCode.NOT_APPLICATION_OWNER);
+    }
+
+    List<SchoolCampMemberRequest> additionalMembers =
+        request.additionalMembers() == null ? List.of() : request.additionalMembers();
+    validateApplicationFormat(request, additionalMembers);
+
+    final User teacher =
+        request.teacherUserId() != null ? findValidTeacher(request.teacherUserId()) : null;
+    Map<Long, User> studentsById = findExistingStudents(applicantUserId, additionalMembers);
+
+    List<SchoolCampMember> existingMembers = memberRepository.findByApplicationId(applicationId);
+    MemberDiff diff = computeMemberDiff(existingMembers, studentsById.keySet());
+
+    if (!diff.addedStudentIds().isEmpty()) {
+      validateNoDuplicateThisMonth(diff.addedStudentIds(), application.getSession().getCampDate());
+    }
+    if (!diff.memberIdsToDelete().isEmpty()) {
+      memberRepository.deleteAllById(diff.memberIdsToDelete());
+    }
+
+    List<SchoolCampMember> newMembers =
+        buildNewMembers(application, additionalMembers, studentsById, diff.addedStudentIds());
+    if (!newMembers.isEmpty()) {
+      memberRepository.saveAll(newMembers);
+    }
+
+    application.setTeacherUser(teacher);
+    application.setTeacherName(teacher == null ? request.teacherName() : null);
+    applicationRepository.save(application);
+
+    sendInviteNotifications(application.getApplicant(), application.getSession(), newMembers);
+
+    List<SchoolCampMember> finalMembers = new ArrayList<>();
+    finalMembers.add(diff.applicantMember());
+    finalMembers.addAll(diff.keptMembers());
+    finalMembers.addAll(newMembers);
+
+    return toApplicationResponse(application, teacher, application.getSession(), finalMembers);
+  }
+
+  /**
+   * {@link #updateApplication}이 기존 팀원과 요청받은 팀원 스냅샷을 비교(diff)한 결과.
+   *
+   * @param applicantMember   대표 신청자 팀원 행(항상 유지, diff 대상 아님)
+   * @param keptMembers       그대로 유지되는 기존 팀원(가입 학생만 — "기타"는 항상 diff 대상)
+   * @param addedStudentIds   새로 추가되는 학생 ID(이번 달 중복 재확인 대상)
+   * @param memberIdsToDelete 삭제할 팀원 행 PK(빠진 학생 + 기존 "기타" 전체)
+   */
+  private record MemberDiff(
+      SchoolCampMember applicantMember,
+      List<SchoolCampMember> keptMembers,
+      Set<Long> addedStudentIds,
+      List<Long> memberIdsToDelete) {}
+
+  private MemberDiff computeMemberDiff(
+      List<SchoolCampMember> existingMembers, Set<Long> newStudentIds) {
+    SchoolCampMember applicantMember = existingMembers.stream()
+        .filter(SchoolCampMember::isApplicant)
+        .findFirst()
+        .orElseThrow(() -> new IllegalStateException("신청에 대표 신청자 팀원 행이 없습니다."));
+
+    List<SchoolCampMember> existingNonApplicantMembers = existingMembers.stream()
+        .filter(member -> !member.isApplicant())
+        .toList();
+
+    Set<Long> existingStudentIds = existingNonApplicantMembers.stream()
+        .filter(member -> member.getStudentUser() != null)
+        .map(member -> member.getStudentUser().getId())
+        .collect(Collectors.toSet());
+
+    Set<Long> addedStudentIds = new HashSet<>(newStudentIds);
+    addedStudentIds.removeAll(existingStudentIds);
+
+    List<SchoolCampMember> keptMembers = existingNonApplicantMembers.stream()
+        .filter(member -> member.getStudentUser() != null
+            && newStudentIds.contains(member.getStudentUser().getId()))
+        .toList();
+
+    List<Long> memberIdsToDelete = existingNonApplicantMembers.stream()
+        .filter(member -> member.getStudentUser() == null
+            || !newStudentIds.contains(member.getStudentUser().getId()))
+        .map(SchoolCampMember::getId)
+        .toList();
+
+    return new MemberDiff(applicantMember, keptMembers, addedStudentIds, memberIdsToDelete);
+  }
+
+  private List<SchoolCampMember> buildNewMembers(
+      SchoolCampApplication application, List<SchoolCampMemberRequest> additionalMembers,
+      Map<Long, User> studentsById, Set<Long> addedStudentIds) {
+    List<SchoolCampMember> newMembers = new ArrayList<>();
+    for (SchoolCampMemberRequest memberRequest : additionalMembers) {
+      if (memberRequest.studentUserId() != null) {
+        if (addedStudentIds.contains(memberRequest.studentUserId())) {
+          newMembers.add(SchoolCampMember.builder()
+              .application(application)
+              .studentUser(studentsById.get(memberRequest.studentUserId()))
+              .applicant(false)
+              .build());
+        }
+      } else {
+        newMembers.add(SchoolCampMember.builder()
+            .application(application)
+            .guestName(memberRequest.guestName())
+            .applicant(false)
+            .build());
+      }
+    }
+    return newMembers;
+  }
+
   private void validateApplicationFormat(
       SchoolCampApplyRequest request, List<SchoolCampMemberRequest> additionalMembers) {
     boolean hasTeacherUserId = request.teacherUserId() != null;
@@ -265,7 +433,9 @@ public class SchoolCampService {
         request.teacherUserId() != null ? findValidTeacher(request.teacherUserId()) : null;
 
     Map<Long, User> studentsById = findExistingStudents(applicantUserId, additionalMembers);
-    validateNoDuplicateThisMonth(applicantUserId, studentsById.keySet(), session.getCampDate());
+    Set<Long> candidateIds = new HashSet<>(studentsById.keySet());
+    candidateIds.add(applicantUserId);
+    validateNoDuplicateThisMonth(candidateIds, session.getCampDate());
 
     SchoolCampApplication application = SchoolCampApplication.builder()
         .session(session)
@@ -321,11 +491,14 @@ public class SchoolCampService {
     return byId;
   }
 
-  private void validateNoDuplicateThisMonth(
-      Long applicantUserId, Set<Long> memberStudentIds, LocalDate campDate) {
-    Set<Long> candidateIds = new HashSet<>(memberStudentIds);
-    candidateIds.add(applicantUserId);
-
+  /**
+   * 후보 학생 중 이번 달에 이미(대표/팀원 구분 없이) 참여 중인 사람이 있으면 거부한다.
+   * 후보 집합은 호출부가 직접 구성한다 — {@link #applyToCamp}(신규 신청)는 대표 신청자
+   * 본인을 항상 포함해야 하지만, {@link #updateApplication}(#70, 새로 추가되는 팀원만
+   * 재검사)은 포함하면 안 된다(대표 신청자는 이미 이 신청으로 참여 중이라 넣으면 항상
+   * 걸린다) — 그래서 이 메서드가 자동으로 넣지 않는다.
+   */
+  private void validateNoDuplicateThisMonth(Set<Long> candidateIds, LocalDate campDate) {
     YearMonth month = YearMonth.from(campDate);
     List<Long> participated = memberRepository.findParticipatedStudentIdsInMonth(
         candidateIds, month.atDay(1), month.atEndOfMonth());

--- a/src/main/java/com/remake/gone/schoolcamp/service/SchoolCampService.java
+++ b/src/main/java/com/remake/gone/schoolcamp/service/SchoolCampService.java
@@ -38,6 +38,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -312,7 +313,14 @@ public class SchoolCampService {
     List<SchoolCampMember> newMembers =
         buildNewMembers(application, additionalMembers, studentsById, diff.addedStudentIds());
     if (!newMembers.isEmpty()) {
-      memberRepository.saveAll(newMembers);
+      // 동시에 처리된 다른 PATCH가 같은 학생을 이미 팀원으로 추가해 (application_id,
+      // student_user_id) 유니크 제약(V13)을 위반하면, 범용 500(COMMON_006) 대신 재시도
+      // 가능한 충돌임을 명시적으로 알린다(코드 리뷰 #70 1번 대응).
+      try {
+        memberRepository.saveAll(newMembers);
+      } catch (DataIntegrityViolationException e) {
+        throw new CustomException(SchoolCampErrorCode.CONCURRENT_UPDATE_CONFLICT);
+      }
     }
 
     application.setTeacherUser(teacher);

--- a/src/main/resources/db/migration/V13__add_schoolcamp_member_unique_constraint.sql
+++ b/src/main/resources/db/migration/V13__add_schoolcamp_member_unique_constraint.sql
@@ -1,0 +1,5 @@
+-- 같은 신청에 같은 학생이 팀원으로 중복 등록되는 것을 DB 레벨에서 방지 (#70 코드 리뷰).
+-- student_user_id가 NULL인 "기타"(게스트) 행끼리는 MySQL 유니크 인덱스 규칙상 서로 충돌하지
+-- 않는다 — 이 제약은 "같은 학생 중복"만 막고, 게스트 중복 방지 목적이 아니다.
+ALTER TABLE school_camp_member
+    ADD CONSTRAINT uq_member_application_student UNIQUE (application_id, student_user_id);

--- a/src/test/java/com/remake/gone/schoolcamp/controller/SchoolCampAuthorizationTest.java
+++ b/src/test/java/com/remake/gone/schoolcamp/controller/SchoolCampAuthorizationTest.java
@@ -1,5 +1,7 @@
 package com.remake.gone.schoolcamp.controller;
 
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -72,5 +74,21 @@ class SchoolCampAuthorizationTest {
             .contentType(MediaType.APPLICATION_JSON)
             .content("{\"teacherUserId\": 42}"))
         .andExpect(status().isForbidden());
+  }
+
+  @Test
+  @DisplayName("취소 엔드포인트는 인증 없이 요청하면 401을 반환한다(#70)")
+  void cancelReturns401WithoutToken() throws Exception {
+    mockMvc.perform(delete("/api/v1/school-camps/applications/1"))
+        .andExpect(status().isUnauthorized());
+  }
+
+  @Test
+  @DisplayName("수정 엔드포인트는 인증 없이 요청하면 401을 반환한다(#70)")
+  void updateReturns401WithoutToken() throws Exception {
+    mockMvc.perform(patch("/api/v1/school-camps/applications/1")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content("{\"teacherUserId\": 42}"))
+        .andExpect(status().isUnauthorized());
   }
 }

--- a/src/test/java/com/remake/gone/schoolcamp/controller/SchoolCampControllerTest.java
+++ b/src/test/java/com/remake/gone/schoolcamp/controller/SchoolCampControllerTest.java
@@ -6,6 +6,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -176,6 +177,59 @@ class SchoolCampControllerTest {
 
       ApiResponse<SchoolCampApplicationResponse> response =
           controller.applyToCamp(principal, 5L, request);
+
+      assertThat(response.success()).isTrue();
+      assertThat(response.data()).isEqualTo(expected);
+    }
+  }
+
+  @Nested
+  @DisplayName("DELETE /api/v1/school-camps/applications/{id}")
+  class CancelApplication {
+
+    @Test
+    @DisplayName("principal의 userId와 신청 id를 그대로 서비스에 전달한다")
+    void callsServiceWithPrincipalAndApplicationId() {
+      SchoolCampController controller = new SchoolCampController(schoolCampService);
+      UserPrincipal principal = new UserPrincipal(101L);
+
+      ApiResponse<Void> response = controller.cancelApplication(principal, 301L);
+
+      assertThat(response.success()).isTrue();
+      assertThat(response.data()).isNull();
+      verify(schoolCampService).cancelApplication(eq(101L), eq(301L), any(LocalDateTime.class));
+    }
+  }
+
+  @Nested
+  @DisplayName("PATCH /api/v1/school-camps/applications/{id}")
+  class UpdateApplication {
+
+    @Test
+    @DisplayName("팀원 자유 입력 이름이 50자를 초과하면 400을 반환한다")
+    void returns400WhenGuestNameTooLong() throws Exception {
+      String tooLongName = "가".repeat(51);
+      mockMvc.perform(patch("/api/v1/school-camps/applications/301")
+              .contentType(MediaType.APPLICATION_JSON)
+              .content("{\"teacherUserId\": 42, \"additionalMembers\": "
+                  + "[{\"guestName\": \"" + tooLongName + "\"}]}"))
+          .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("principal의 userId와 신청 id, 요청을 그대로 서비스에 전달한다")
+    void callsServiceWithPrincipalAndRequest() {
+      SchoolCampController controller = new SchoolCampController(schoolCampService);
+      UserPrincipal principal = new UserPrincipal(101L);
+      SchoolCampApplyRequest request = new SchoolCampApplyRequest(42L, null, List.of());
+      SchoolCampApplicationResponse expected = new SchoolCampApplicationResponse(
+          301L, "20260403", "박선생",
+          List.of(new SchoolCampMemberResponse("홍길동", 3, 4, null, true)),
+          "2026-03-20T09:12:00");
+      given(schoolCampService.updateApplication(101L, 301L, request)).willReturn(expected);
+
+      ApiResponse<SchoolCampApplicationResponse> response =
+          controller.updateApplication(principal, 301L, request);
 
       assertThat(response.success()).isTrue();
       assertThat(response.data()).isEqualTo(expected);

--- a/src/test/java/com/remake/gone/schoolcamp/service/SchoolCampServiceTest.java
+++ b/src/test/java/com/remake/gone/schoolcamp/service/SchoolCampServiceTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
@@ -25,6 +26,7 @@ import com.remake.gone.schoolcamp.dto.SchoolCampCalendarResponse;
 import com.remake.gone.schoolcamp.dto.SchoolCampMemberRequest;
 import com.remake.gone.schoolcamp.dto.SchoolCampSessionResponse;
 import com.remake.gone.schoolcamp.entity.SchoolCampApplication;
+import com.remake.gone.schoolcamp.entity.SchoolCampMember;
 import com.remake.gone.schoolcamp.entity.SchoolCampSession;
 import com.remake.gone.schoolcamp.enums.SchoolCampStatus;
 import com.remake.gone.schoolcamp.exception.SchoolCampErrorCode;
@@ -36,6 +38,7 @@ import com.remake.gone.user.repository.UserRepository;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.YearMonth;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
@@ -521,6 +524,292 @@ class SchoolCampServiceTest {
           .send(eq(55L), anyString(), anyString(), eq(NotificationType.SCHOOLCAMP));
       verify(notificationService, never())
           .send(eq(APPLICANT_ID), anyString(), anyString(), eq(NotificationType.SCHOOLCAMP));
+    }
+  }
+
+  @Nested
+  @DisplayName("cancelApplication")
+  class CancelApplication {
+
+    private static final Long APPLICATION_ID = 301L;
+    private static final Long APPLICANT_ID = 101L;
+    private static final Long SESSION_ID = 15L;
+    private static final LocalDateTime NOW = LocalDateTime.of(2026, 4, 10, 9, 0);
+
+    private SchoolCampApplication application(LocalDate campDate) {
+      SchoolCampSession session =
+          SchoolCampSession.builder().id(SESSION_ID).campDate(campDate).build();
+      User applicant = studentUser(APPLICANT_ID, studentGbsw(3, 4, 1, "홍길동"), "길동");
+      return SchoolCampApplication.builder()
+          .id(APPLICATION_ID)
+          .session(session)
+          .applicant(applicant)
+          .teacherName("박선생")
+          .build();
+    }
+
+    @Test
+    @DisplayName("정상 취소 시 cancelledAt을 채우고 세션을 반환한다")
+    void cancelsSuccessfully() {
+      SchoolCampApplication application = application(LocalDate.of(2026, 4, 20));
+      given(applicationRepository.findByIdAndCancelledAtIsNull(APPLICATION_ID))
+          .willReturn(Optional.of(application));
+
+      schoolCampService.cancelApplication(APPLICANT_ID, APPLICATION_ID, NOW);
+
+      assertThat(application.getCancelledAt()).isEqualTo(NOW);
+      verify(applicationRepository).save(application);
+      verify(sessionRepository).release(SESSION_ID);
+      verifyNoInteractions(sessionClaimService);
+    }
+
+    @Test
+    @DisplayName("본인 신청이 아니면 403을 던지고 아무것도 변경하지 않는다")
+    void throwsWhenNotOwner() {
+      SchoolCampApplication application = application(LocalDate.of(2026, 4, 20));
+      given(applicationRepository.findByIdAndCancelledAtIsNull(APPLICATION_ID))
+          .willReturn(Optional.of(application));
+
+      assertThatThrownBy(() -> schoolCampService.cancelApplication(999L, APPLICATION_ID, NOW))
+          .isInstanceOf(CustomException.class)
+          .extracting(e -> ((CustomException) e).getErrorCode())
+          .isEqualTo(SchoolCampErrorCode.NOT_APPLICATION_OWNER);
+
+      verify(applicationRepository, never()).save(any());
+      verify(sessionRepository, never()).release(anyLong());
+    }
+
+    @Test
+    @DisplayName("존재하지 않거나 이미 취소된 신청이면 404를 던진다")
+    void throwsWhenApplicationNotFound() {
+      given(applicationRepository.findByIdAndCancelledAtIsNull(APPLICATION_ID))
+          .willReturn(Optional.empty());
+
+      assertThatThrownBy(
+          () -> schoolCampService.cancelApplication(APPLICANT_ID, APPLICATION_ID, NOW))
+          .isInstanceOf(CustomException.class)
+          .extracting(e -> ((CustomException) e).getErrorCode())
+          .isEqualTo(SchoolCampErrorCode.APPLICATION_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("캠핑 당일 취소 시도하면 400을 던지고 아무것도 변경하지 않는다")
+    void throwsWhenCancelOnCampDay() {
+      SchoolCampApplication application = application(NOW.toLocalDate());
+      given(applicationRepository.findByIdAndCancelledAtIsNull(APPLICATION_ID))
+          .willReturn(Optional.of(application));
+
+      assertThatThrownBy(
+          () -> schoolCampService.cancelApplication(APPLICANT_ID, APPLICATION_ID, NOW))
+          .isInstanceOf(CustomException.class)
+          .extracting(e -> ((CustomException) e).getErrorCode())
+          .isEqualTo(SchoolCampErrorCode.CANCEL_NOT_ALLOWED_ON_CAMP_DAY);
+
+      verify(applicationRepository, never()).save(any());
+      verify(sessionRepository, never()).release(anyLong());
+    }
+  }
+
+  @Nested
+  @DisplayName("updateApplication")
+  class UpdateApplication {
+
+    private static final Long APPLICATION_ID = 301L;
+    private static final Long APPLICANT_ID = 101L;
+    private static final Long SESSION_ID = 15L;
+
+    private SchoolCampApplication application;
+    private SchoolCampMember applicantMember;
+
+    private void newApplication() {
+      SchoolCampSession session = SchoolCampSession.builder()
+          .id(SESSION_ID).campDate(LocalDate.of(2026, 4, 20)).build();
+      User applicant = studentUser(APPLICANT_ID, studentGbsw(3, 4, 1, "홍길동"), "길동");
+      application = SchoolCampApplication.builder()
+          .id(APPLICATION_ID)
+          .session(session)
+          .applicant(applicant)
+          .teacherName("박선생")
+          .appliedAt(LocalDateTime.of(2026, 3, 20, 9, 12))
+          .build();
+      applicantMember = SchoolCampMember.builder()
+          .id(1L).application(application).studentUser(applicant).applicant(true).build();
+    }
+
+    /** 소유권 확인까지만 도달하는 테스트용 — 신청 조회 스텁만 준비한다. */
+    private void stubApplication() {
+      if (application == null) {
+        newApplication();
+      }
+      given(applicationRepository.findByIdAndCancelledAtIsNull(APPLICATION_ID))
+          .willReturn(Optional.of(application));
+    }
+
+    /** diff 계산까지 도달하는 테스트용 — 신청 조회 + 기존 팀원 목록 스텁을 준비한다. */
+    private void stubApplicationWithMembers(SchoolCampMember... otherMembers) {
+      stubApplication();
+      List<SchoolCampMember> members = new ArrayList<>(List.of(applicantMember));
+      members.addAll(List.of(otherMembers));
+      given(memberRepository.findByApplicationId(APPLICATION_ID)).willReturn(members);
+    }
+
+    @Test
+    @DisplayName("담당 선생님만 변경하면 기존 팀원은 그대로 유지되고 세션은 건드리지 않는다")
+    void changesTeacherOnlyKeepsExistingMembers() {
+      newApplication();
+      User existingStudent = studentUser(55L, studentGbsw(3, 2, 9, "이영희"), "영희");
+      SchoolCampMember existingMember = SchoolCampMember.builder()
+          .id(2L).application(application).studentUser(existingStudent).applicant(false).build();
+      stubApplicationWithMembers(existingMember);
+      given(applicationRepository.save(any())).willAnswer(inv -> inv.getArgument(0));
+
+      User newTeacher = studentUser(99L, studentGbsw(1, 1, 1, "김선생"), "김선생");
+      given(userRepository.findById(99L)).willReturn(Optional.of(newTeacher));
+      given(userRoleRepository.findRoleCodesByUserId(99L)).willReturn(List.of("TEACHER"));
+      given(userRepository.findAllById(List.of(55L))).willReturn(List.of(existingStudent));
+
+      SchoolCampApplyRequest request = new SchoolCampApplyRequest(
+          99L, null, List.of(new SchoolCampMemberRequest(55L, null)));
+
+      SchoolCampApplicationResponse response =
+          schoolCampService.updateApplication(APPLICANT_ID, APPLICATION_ID, request);
+
+      assertThat(response.teacherDisplayName()).isEqualTo("김선생");
+      assertThat(response.members()).hasSize(2);
+      verify(memberRepository, never()).deleteAllById(anyList());
+      verify(memberRepository, never()).saveAll(anyList());
+      verify(memberRepository, never()).findParticipatedStudentIdsInMonth(any(), any(), any());
+      verifyNoInteractions(sessionRepository, sessionClaimService);
+    }
+
+    @Test
+    @DisplayName("가입 학생 + 기타 팀원을 새로 추가하면 추가된 팀원에게만 알림을 보낸다")
+    void addsRegisteredAndGuestMembers() {
+      stubApplicationWithMembers();
+      given(applicationRepository.save(any())).willAnswer(inv -> inv.getArgument(0));
+      given(memberRepository.saveAll(anyList())).willAnswer(inv -> inv.getArgument(0));
+
+      User newStudent = studentUser(77L, studentGbsw(2, 1, 3, "최민수"), "민수");
+      given(userRepository.findAllById(List.of(77L))).willReturn(List.of(newStudent));
+      given(memberRepository.findParticipatedStudentIdsInMonth(anyCollection(), any(), any()))
+          .willReturn(List.of());
+
+      SchoolCampApplyRequest request = new SchoolCampApplyRequest(null, "박선생", List.of(
+          new SchoolCampMemberRequest(77L, null),
+          new SchoolCampMemberRequest(null, "새게스트")));
+
+      SchoolCampApplicationResponse response =
+          schoolCampService.updateApplication(APPLICANT_ID, APPLICATION_ID, request);
+
+      assertThat(response.members()).hasSize(3);
+      verify(memberRepository).saveAll(anyList());
+      verify(notificationService)
+          .send(eq(77L), anyString(), anyString(), eq(NotificationType.SCHOOLCAMP));
+      verify(notificationService, never())
+          .send(eq(APPLICANT_ID), anyString(), anyString(), eq(NotificationType.SCHOOLCAMP));
+    }
+
+    @Test
+    @DisplayName("요청에서 빠진 기존 팀원은 삭제된다")
+    void removesMemberNotInRequest() {
+      newApplication();
+      User existingStudent = studentUser(55L, studentGbsw(3, 2, 9, "이영희"), "영희");
+      SchoolCampMember existingMember = SchoolCampMember.builder()
+          .id(2L).application(application).studentUser(existingStudent).applicant(false).build();
+      stubApplicationWithMembers(existingMember);
+      given(applicationRepository.save(any())).willAnswer(inv -> inv.getArgument(0));
+
+      SchoolCampApplyRequest request = new SchoolCampApplyRequest(null, "박선생", List.of());
+
+      SchoolCampApplicationResponse response =
+          schoolCampService.updateApplication(APPLICANT_ID, APPLICATION_ID, request);
+
+      assertThat(response.members()).hasSize(1);
+      verify(memberRepository).deleteAllById(List.of(2L));
+    }
+
+    @Test
+    @DisplayName("새로 추가한 팀원이 이번 달 이미 참여 중이면 409를 던지고 아무것도 변경하지 않는다")
+    void throwsWhenAddedMemberAlreadyParticipatedThisMonth() {
+      stubApplicationWithMembers();
+
+      User newStudent = studentUser(88L, studentGbsw(2, 1, 4, "박지민"), "지민");
+      given(userRepository.findAllById(List.of(88L))).willReturn(List.of(newStudent));
+      given(memberRepository.findParticipatedStudentIdsInMonth(anyCollection(), any(), any()))
+          .willReturn(List.of(88L));
+
+      SchoolCampApplyRequest request = new SchoolCampApplyRequest(
+          null, "박선생", List.of(new SchoolCampMemberRequest(88L, null)));
+
+      assertThatThrownBy(
+          () -> schoolCampService.updateApplication(APPLICANT_ID, APPLICATION_ID, request))
+          .isInstanceOf(CustomException.class)
+          .extracting(e -> ((CustomException) e).getErrorCode())
+          .isEqualTo(SchoolCampErrorCode.ALREADY_PARTICIPATED_THIS_MONTH);
+
+      verify(memberRepository, never()).deleteAllById(anyList());
+      verify(memberRepository, never()).saveAll(anyList());
+      verify(applicationRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("본인 신청이 아니면 403을 던진다")
+    void throwsWhenNotOwner() {
+      stubApplication();
+      SchoolCampApplyRequest request = new SchoolCampApplyRequest(null, "박선생", List.of());
+
+      assertThatThrownBy(() -> schoolCampService.updateApplication(999L, APPLICATION_ID, request))
+          .isInstanceOf(CustomException.class)
+          .extracting(e -> ((CustomException) e).getErrorCode())
+          .isEqualTo(SchoolCampErrorCode.NOT_APPLICATION_OWNER);
+    }
+
+    @Test
+    @DisplayName("존재하지 않거나 취소된 신청이면 404를 던진다")
+    void throwsWhenApplicationNotFound() {
+      given(applicationRepository.findByIdAndCancelledAtIsNull(APPLICATION_ID))
+          .willReturn(Optional.empty());
+      SchoolCampApplyRequest request = new SchoolCampApplyRequest(null, "박선생", List.of());
+
+      assertThatThrownBy(
+          () -> schoolCampService.updateApplication(APPLICANT_ID, APPLICATION_ID, request))
+          .isInstanceOf(CustomException.class)
+          .extracting(e -> ((CustomException) e).getErrorCode())
+          .isEqualTo(SchoolCampErrorCode.APPLICATION_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("총원이 8명을 초과하면 400을 던진다")
+    void throwsWhenTeamSizeExceedsLimit() {
+      stubApplication();
+      List<SchoolCampMemberRequest> eightAdditionalMembers = List.of(
+          new SchoolCampMemberRequest(1L, null), new SchoolCampMemberRequest(2L, null),
+          new SchoolCampMemberRequest(3L, null), new SchoolCampMemberRequest(4L, null),
+          new SchoolCampMemberRequest(5L, null), new SchoolCampMemberRequest(6L, null),
+          new SchoolCampMemberRequest(7L, null), new SchoolCampMemberRequest(8L, null));
+      SchoolCampApplyRequest request =
+          new SchoolCampApplyRequest(null, "박선생", eightAdditionalMembers);
+
+      assertThatThrownBy(
+          () -> schoolCampService.updateApplication(APPLICANT_ID, APPLICATION_ID, request))
+          .isInstanceOf(CustomException.class)
+          .extracting(e -> ((CustomException) e).getErrorCode())
+          .isEqualTo(SchoolCampErrorCode.INVALID_APPLICATION_FORMAT);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 studentUserId가 포함되면 400을 던진다")
+    void throwsWhenMemberDoesNotExist() {
+      stubApplication();
+      given(userRepository.findAllById(List.of(999L))).willReturn(List.of());
+      SchoolCampApplyRequest request = new SchoolCampApplyRequest(
+          null, "박선생", List.of(new SchoolCampMemberRequest(999L, null)));
+
+      assertThatThrownBy(
+          () -> schoolCampService.updateApplication(APPLICANT_ID, APPLICATION_ID, request))
+          .isInstanceOf(CustomException.class)
+          .extracting(e -> ((CustomException) e).getErrorCode())
+          .isEqualTo(SchoolCampErrorCode.INVALID_MEMBER_INFO);
     }
   }
 }

--- a/src/test/java/com/remake/gone/schoolcamp/service/SchoolCampServiceTest.java
+++ b/src/test/java/com/remake/gone/schoolcamp/service/SchoolCampServiceTest.java
@@ -48,6 +48,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
 
 /**
  * {@link SchoolCampService}에 대한 단위 테스트.
@@ -726,6 +727,84 @@ class SchoolCampServiceTest {
 
       assertThat(response.members()).hasSize(1);
       verify(memberRepository).deleteAllById(List.of(2L));
+    }
+
+    @Test
+    @DisplayName("한 요청 안에서 유지/추가/제거가 섞여도 diff가 올바르게 적용된다")
+    void keepsAddsAndRemovesMembersInSameRequest() {
+      newApplication();
+      User keptStudent = studentUser(55L, studentGbsw(3, 2, 9, "이영희"), "영희");
+      User removedStudent = studentUser(66L, studentGbsw(2, 3, 4, "박서준"), "서준");
+      SchoolCampMember keptMember = SchoolCampMember.builder()
+          .id(2L).application(application).studentUser(keptStudent).applicant(false).build();
+      SchoolCampMember removedMember = SchoolCampMember.builder()
+          .id(3L).application(application).studentUser(removedStudent).applicant(false).build();
+      stubApplicationWithMembers(keptMember, removedMember);
+      given(applicationRepository.save(any())).willAnswer(inv -> inv.getArgument(0));
+      given(memberRepository.saveAll(anyList())).willAnswer(inv -> inv.getArgument(0));
+
+      User newStudent = studentUser(77L, studentGbsw(2, 1, 3, "최민수"), "민수");
+      given(userRepository.findAllById(List.of(55L, 77L)))
+          .willReturn(List.of(keptStudent, newStudent));
+      given(memberRepository.findParticipatedStudentIdsInMonth(anyCollection(), any(), any()))
+          .willReturn(List.of());
+
+      SchoolCampApplyRequest request = new SchoolCampApplyRequest(null, "박선생", List.of(
+          new SchoolCampMemberRequest(55L, null),
+          new SchoolCampMemberRequest(77L, null),
+          new SchoolCampMemberRequest(null, "새게스트")));
+
+      SchoolCampApplicationResponse response =
+          schoolCampService.updateApplication(APPLICANT_ID, APPLICATION_ID, request);
+
+      assertThat(response.members()).hasSize(4);
+      assertThat(response.members())
+          .extracting(m -> m.studentRealName() != null ? m.studentRealName() : m.guestName())
+          .containsExactlyInAnyOrder("홍길동", "이영희", "최민수", "새게스트");
+      verify(memberRepository).deleteAllById(List.of(3L));
+      verify(memberRepository).saveAll(anyList());
+    }
+
+    @Test
+    @DisplayName("추가하는 팀원이 전부 기타(게스트)면 이번 달 중복 참여 확인을 건너뛴다")
+    void addsOnlyGuestMembersSkipsMonthlyDuplicateCheck() {
+      stubApplicationWithMembers();
+      given(applicationRepository.save(any())).willAnswer(inv -> inv.getArgument(0));
+      given(memberRepository.saveAll(anyList())).willAnswer(inv -> inv.getArgument(0));
+
+      SchoolCampApplyRequest request = new SchoolCampApplyRequest(null, "박선생", List.of(
+          new SchoolCampMemberRequest(null, "게스트1"),
+          new SchoolCampMemberRequest(null, "게스트2")));
+
+      SchoolCampApplicationResponse response =
+          schoolCampService.updateApplication(APPLICANT_ID, APPLICATION_ID, request);
+
+      assertThat(response.members()).hasSize(3);
+      verify(memberRepository, never()).findParticipatedStudentIdsInMonth(any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("팀원 저장 중 동시 수정 충돌(유니크 제약 위반)이 발생하면 409로 변환한다")
+    void throwsConflictWhenConcurrentInsertViolatesUniqueConstraint() {
+      stubApplicationWithMembers();
+
+      User newStudent = studentUser(77L, studentGbsw(2, 1, 3, "최민수"), "민수");
+      given(userRepository.findAllById(List.of(77L))).willReturn(List.of(newStudent));
+      given(memberRepository.findParticipatedStudentIdsInMonth(anyCollection(), any(), any()))
+          .willReturn(List.of());
+      given(memberRepository.saveAll(anyList()))
+          .willThrow(new DataIntegrityViolationException("duplicate"));
+
+      SchoolCampApplyRequest request = new SchoolCampApplyRequest(
+          null, "박선생", List.of(new SchoolCampMemberRequest(77L, null)));
+
+      assertThatThrownBy(
+          () -> schoolCampService.updateApplication(APPLICANT_ID, APPLICATION_ID, request))
+          .isInstanceOf(CustomException.class)
+          .extracting(e -> ((CustomException) e).getErrorCode())
+          .isEqualTo(SchoolCampErrorCode.CONCURRENT_UPDATE_CONFLICT);
+
+      verify(applicationRepository, never()).save(any());
     }
 
     @Test


### PR DESCRIPTION
## 관련 이슈
closes #70

## 작업 내용
스쿨캠핑 신청 취소(`DELETE`)/수정(`PATCH`) API를 구현했다. 본인 신청만 취소·수정할 수
있고, 취소 시 세션을 원자적으로 반환(`taken_at = NULL`)하며 캠핑 당일 취소는 금지한다.
수정은 담당 선생님/팀원 구성을 전체 교체 방식으로 반영하고, 새로 추가되는 팀원만 이번 달
중복 참여를 재확인한다.

## 변경 사항 상세
- `SchoolCampErrorCode`에 `SCHOOLCAMP_007`(소유자 아님)/`009`(당일 취소 금지)/`010`(신청
  없음) 추가
- `DELETE /api/v1/school-camps/applications/{id}`: 소유권 확인 → 당일 취소 금지 검증 →
  `cancelled_at` 갱신 + 세션 반환
- `PATCH /api/v1/school-camps/applications/{id}`: 소유권 확인 → 담당 선생님/팀원 전체
  교체(대표 신청자 행 변경 불가) → 신규 팀원만 월중복 재검증
- 코드 리뷰(9단계)에서 발견된 동시 수정 레이스(동시에 같은 팀원을 두 번 삽입할 수 있는
  경합)를 `school_camp_member(application_id, student_user_id)` 유니크 제약 +
  `DataIntegrityViolationException → 409 SCHOOLCAMP_011` 변환으로 방어
- 단위 테스트(취소/수정 정상·에러 케이스, 인가, 동시 수정 충돌, 팀원 조합 diff, 게스트뿐
  케이스) 추가
- Postman 컬렉션(`gone-schoolcamp`)에 취소/수정 엔드포인트 + "#70 확인" 검증 폴더 추가
  (레포 파일만 갱신 — Postman 워크스페이스 REST API 쓰기 경로가 현재 500을 반환해
  워크스페이스 반영은 보류, 다음 PR 때 재시도 예정)

기획서와 실제 구현 간 차이는 없다.

## 확인 사항
- [x] 로컬 빌드 통과 (`./gradlew build`)
- [x] Checkstyle 통과 (`./gradlew checkstyleMain`, build에 포함)
- [ ] CI(checkstyle, build-and-test) 통과 — PR 생성 후 확인
- [ ] (해당 시) Notion 기능정의서/기획 문서 반영 — 머지 후(17단계) 진행 예정
- [x] (해당 시) 관련 도메인 라벨 지정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added authenticated options to cancel or modify school-camp applications.
  - Application updates support teacher changes, team-member replacement, guest details, and validation.
  - Cancellation releases reserved session capacity and enforces ownership and same-day restrictions.
  - Added clear error responses for missing applications, invalid members, unauthorized access, and update conflicts.
  - Prevented duplicate student registrations during concurrent updates.

- **Documentation & Tests**
  - Added planning, code-review, QA, and Postman validation documentation.
  - Expanded automated and end-to-end coverage for cancellation, modification, authorization, and validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->