### PR TITLE
feat(schoolcamp): #71 스쿨캠핑 외출 연동 리마인더 스케줄러 구현

### DIFF
--- a/docs/domain/schoolcamp/71-schoolcamp-outing-reminder-QA.md
+++ b/docs/domain/schoolcamp/71-schoolcamp-outing-reminder-QA.md
@@ -1,0 +1,94 @@
+# #71 스쿨캠핑 외출 연동 리마인더 스케줄러 — QA 결과
+
+관련 기획서: [71-schoolcamp-outing-reminder.md](./71-schoolcamp-outing-reminder.md)
+관련 코드 리뷰: [71-schoolcamp-outing-reminder-code-review.md](./71-schoolcamp-outing-reminder-code-review.md)
+(9단계 코드 리뷰 지적 사항(High 1/Medium 1/Low 1)은 QA 이전에 전부 반영 완료 — 이 문서는
+QA에서 새로 확인/발견한 것만 다룬다)
+
+## 검증 방법/범위
+이 이슈는 HTTP 엔드포인트가 없는 배치(cron) 작업이라, `#67`/`#68`/`#70`처럼 curl로 엔드포인트를
+직접 두드리는 방식만으로는 끝까지 검증할 수 없다. 크론이 매일 08:30(KST) 1회뿐이라 `#42`
+(`fixedDelay` 1분 주기)처럼 실시간 대기로 검증하는 것도 불가능하고, 알림 조회 API 자체가
+없어(기획서 "선행 조건 공백" 참고) 결과를 API로 되짚어볼 수도 없다. 보스 승인을 받아 아래
+방식으로 진행했다.
+
+- `./gradlew build`(checkstyle + 전체 테스트) 통과 확인.
+- 로컬 서버 실제 기동(`./gradlew bootRun`, `dev` 프로필) — Flyway 마이그레이션 13개 전부
+  검증됨, `SchoolCampReminderScheduler`를 포함한 컨텍스트가 예외 없이 기동됨을 확인(잘못된
+  cron 표현식이었다면 여기서 즉시 실패했을 것).
+- **실제 데이터는 기존 엔드포인트(`POST /api/v1/school-camps`, `POST .../applications`,
+  `POST /api/v1/outings`)로 실제 HTTP 요청을 보내 준비**하고, **`sendOutingReminders`
+  자체의 실행만** 별도 `@SpringBootTest`(`SchoolCampSessionClaimServiceIntegrationTest`와
+  동일한 로컬 MySQL에 붙는 기존 통합 테스트 패턴 재사용)로 1회 직접 호출했다 — 이 테스트
+  파일은 QA 전용 임시 트리거였고 검증 후 삭제했다(커밋하지 않음, 저장소에 남지 않음).
+  `SchoolCampReminderScheduler` 자체(cron이 이 메서드를 호출하는지)는 단위 테스트로 이미
+  검증됐고, 이 스케줄러는 `OutingMissedScheduler`와 동일하게 시각만 구해 위임하는 3줄짜리
+  컴포넌트라 실행 경로 검증의 우선순위를 `sendOutingReminders`(실제 로직)에 뒀다.
+- 검증에는 기존 QA에서 써온 실 계정(`testuser01`/`testuser02`, 비밀번호는 이미 쓰던 값 그대로)을
+  썼고, `testuser01`에 세션 등록을 위해 ADMIN 역할을 임시로 부여했다(`#67`/`#68`/`#70` QA와
+  동일한 방식) — **검증 후 전부 원복**했다(역할 삭제, 등록한 세션/신청/팀원/외출증/알림
+  레코드 전부 삭제, 로그인 재시도 없이 SQL로 직접 원복 확인).
+- 로컬에 `mysql` CLI가 설치돼 있고(`MySQL Server 8.0`) 로컬 MySQL(3306)/Redis(6379)가 이미
+  떠 있어(보스 확인), `#42` QA와 달리 이번에는 **DB에 직접 접속해 결과(`notification` 테이블
+  행 생성 여부)를 확인**할 수 있었다.
+
+## 실제 검증
+
+### 시나리오 구성
+1. `testuser01`(ADMIN 임시 부여)로 오늘 날짜를 스쿨캠핑 세션으로 등록(`sessionId=61`).
+2. `testuser02`(대표 신청자)가 그 세션에 신청, 팀원으로 `testuser01` 추가
+   (`applicationId=14`) — 신청 시점에 `testuser01`에게 초대 알림이 정상 발송됨을 확인
+   (기존 `#68` 로직 회귀 확인 겸).
+3. `testuser01`(팀원, 계정 있음, 외출증 없음) / `testuser02`(대표 신청자, 계정 있음, 외출증
+   없음) 둘 다 초기 상태에서는 리마인더 대상이어야 한다.
+
+### 1차 시도 — 실제 HTTP로 CUSTOM 외출증 생성 시도 (실패, 환경 제약)
+`testuser01`에게 점심시간(12:30~13:40)을 포함하는 `CUSTOM` 외출증(11:00~15:00)을
+`POST /api/v1/outings`로 실제로 신청해보려 했으나, QA를 진행한 시각(오후 2시경)이 이미
+11:00을 지나 있어 `400 OUTING_001`("이미 그 시간대 시작 시각이 지났습니다")로 거부됐다 —
+스케줄러 자체는 매일 08:30에 돌아 이 문제가 없지만, QA를 실시간으로 수행하는 시점의 인공적
+제약이다. 아래 2차 시도로 대체했다.
+
+### 2차 시도 — DB 직접 삽입으로 재현 (1차 실패, 유의미한 부수 발견)
+`POST /api/v1/outings`를 우회해 `testuser01`의 외출증을 DB에 직접 `INSERT`(`PENDING`,
+`CUSTOM`, `11:00~15:00`, 오늘)했더니, **`OutingMissedScheduler`(#42, 1분 주기로 계속 실행
+중인 기존 스케줄러)가 곧바로 이 행을 `MISSED`로 갱신해버렸다**(시작 시각 11:00이 이미
+지났다고 판단 — 정상 동작, `#71`의 버그 아님). 그 결과 리마인더 실행 시 `testuser01`도
+리마인더 대상에 포함됐는데, 이는 `#71`의 결함이 아니라 `MISSED`가 `ACTIVE_STATUSES`에
+없어 "신청 안 한 것"으로 취급되는 게 설계대로 맞는 동작임을 오히려 재확인한 것이다(기획서
+"REJECTED는 다시 알림 대상" 규칙과 같은 선상).
+
+### 3차 시도 — 상태를 `APPROVED`로 직접 삽입 (성공)
+같은 외출증 행의 `status`만 `APPROVED`로 바꿔(`OutingMissedScheduler`는 `PENDING`만
+갱신 대상으로 삼아 이후 건드리지 않음) `sendOutingReminders(오늘)`를 1회 실행했다.
+
+| # | 대상 | 상태 | 기대 | 결과 |
+|---|---|---|---|---|
+| 1 | `testuser02`(대표 신청자, 외출증 없음) | - | 리마인더 발송(`notification` 새 행) | ✅ `id=8` 생성 확인 |
+| 2 | `testuser01`(팀원, 점심시간을 포함하는 `CUSTOM` 외출증 `APPROVED`) | 코드 리뷰 High 수정 대상 | 발송 안 함 | ✅ 새 행 없음(기존 초대 알림 `id=5`만 유지) |
+
+DB(`notification` 테이블)를 직접 조회해 두 결과 모두 SQL로 확인했다 — `testuser02`(user_id=2)
+앞으로 "오늘 스쿨캠핑이 있어요!" 행이 새로 생겼고, `testuser01`(user_id=1)에게는 생기지
+않았다. **코드 리뷰 High 1번(`CUSTOM` 외출증이 점심시간을 포함해도 `timeSlot` 이름만
+보고 놓치던 문제)의 수정이 실제 DB 레벨에서 의도대로 동작함을 확인했다.**
+
+## 발견 사항
+Critical/High/Medium/Low 모두 새로 발견된 것은 없다. 위 "2차 시도"에서 관찰한 현상
+(`MISSED` 외출증은 리마인더 대상에서 빠지지 않음)은 결함이 아니라 기획서에 이미 명시된
+설계(신청 여부만 보고, `REJECTED`/`MISSED`는 재알림 대상)와 일치하는 정상 동작임을
+재확인한 것으로 정리한다.
+
+**Medium — 08:30 정시 cron 발동 자체는 실시간 검증 못 함(환경 제약)**: `SchoolCampReminderScheduler`
+가 실제로 KST 08:30에 정확히 실행되는지는 QA 세션 시간대 제약으로 실시간 대기 검증을 하지
+못했다. 대신 (1) 컨텍스트 기동 시 cron 표현식이 파싱 오류 없이 등록됨을 확인했고, (2)
+`SchoolCampReminderSchedulerTest`가 `LocalDate.now(KST)`를 그대로 위임하는지 단위
+테스트로 확인했다 — `OutingMissedScheduler`도 최초 도입(#42) 당시 동일한 판단(스케줄러
+자체 얇은 위임부는 단위 테스트로, 무거운 로직은 실 DB로 검증)을 따른 전례가 있다.
+
+## 결론
+기획서에 정의된 리마인더 로직(대상 판정, LUNCH 겹침 판단, 게스트 제외, 단일 트랜잭션)과
+코드 리뷰에서 고친 CUSTOM 겹침 오판정이 전부 단위 테스트 + 실제 HTTP로 준비한 데이터에
+대한 실 DB 실행으로 확인됐다. 이 이슈의 완료 조건(로컬 빌드/테스트 통과)을 충족하며, CI
+통과 여부는 PR 생성(16단계) 후 확인한다 — 이 프로젝트의 CI 워크플로우는 `main`/`dev`로의
+PR·push에서만 트리거되어 기능 브랜치 단독 push로는 미리 확인할 수 없다(`#67`/`#68`/`#70`
+QA와 동일한 제약).

--- a/docs/domain/schoolcamp/71-schoolcamp-outing-reminder-code-review.md
+++ b/docs/domain/schoolcamp/71-schoolcamp-outing-reminder-code-review.md
@@ -1,0 +1,125 @@
+# #71 스쿨캠핑 외출 연동 리마인더 스케줄러 — 코드 리뷰
+
+관련 이슈/기획서: [71-schoolcamp-outing-reminder.md](./71-schoolcamp-outing-reminder.md)
+
+## 리뷰 범위
+- 대상 diff: `git diff dev...HEAD` (base `dev` → `feat/#71-schoolcamp-outing-reminder`)
+- 대상 커밋 4개(기획서 커밋 `a8c1d6d`는 문서만이라 제외):
+  - `f2a592e` feat(schoolcamp): #71 리마인더용 리포지토리 조회 메서드 추가
+  - `c4e9d82` feat(schoolcamp): #71 리마인더 발송 서비스 로직 구현
+  - `de06df0` feat(schoolcamp): #71 외출 연동 리마인더 스케줄러 추가
+  - `5a63335` test(schoolcamp): #71 리마인더 스케줄러/서비스 단위 테스트 추가
+- 변경 파일: `OutingRepository.java`, `SchoolCampApplicationRepository.java`,
+  `SchoolCampReminderScheduler.java`(신규), `SchoolCampService.java`,
+  `SchoolCampReminderSchedulerTest.java`(신규), `SchoolCampServiceTest.java` — 기획서 범위를
+  벗어난 변경 없음(신규 HTTP 엔드포인트/에러코드/마이그레이션 없음, 기획서와 동일).
+- 리뷰 방법: 코드 정적 분석(diff 전문 확인, 관련 엔티티/기존 리포지토리 메서드와의 정합성 대조).
+  실서버 기동/DB 검증은 하지 않음(QA 단계로 이관).
+
+## 기획서-구현 일치 확인
+아래 4개 핵심 결정 사항 모두 구현과 일치한다.
+- **리마인더 대상 = 팀원 전체(계정 있는 학생만)**: `SchoolCampService.remindMembers`가
+  `memberRepository.findByApplicationId`로 전체 팀원(대표 신청자 포함, `SchoolCampMember`
+  엔티티 주석상 대표자도 `applicant=true`인 행으로 포함됨)을 조회하고
+  `member.getStudentUser() != null`로 필터링한다 — "기타" 게스트(계정 없음) 제외 확인.
+- **LUNCH 판단 기준 = `OutingStatus.ACTIVE_STATUSES`**: `remindIfNoLunchOuting`이
+  `existsByStudentIdAndOutingDateAndTimeSlotAndStatusIn(..., OutingTimeSlot.LUNCH,
+  OutingStatus.ACTIVE_STATUSES)`를 그대로 사용 — `PENDING/APPROVED/DEPARTED`만 "신청함"으로
+  간주, `REJECTED`는 포함되지 않아 재알림 대상이 되는 설계와 일치.
+- **취소된 신청은 조회에서 제외**: `SchoolCampApplicationRepository.
+  findBySessionCampDateAndCancelledAtIsNull`이 `cancelledAtIsNull` 조건을 포함 — 기획서의
+  `findBySession_CampDateAndCancelledAtIsNull`과 밑줄 유무만 다르고(Spring Data 프로퍼티
+  탐색으로 둘 다 유효), 오히려 기존 `findBySessionIdInAndCancelledAtIsNull`(밑줄 없음)과 더
+  일관된 네이밍이라 문제 아님.
+- **하나의 트랜잭션으로 처리**: `sendOutingReminders`에만 `@Transactional`이 있고,
+  `NotificationService.send`는 자체 트랜잭션이 없어(`@Transactional` 미부착) 호출자 트랜잭션에
+  합류한다 — 건별 독립 트랜잭션이 아니라 스케줄러 1회 실행 = 트랜잭션 1개로 확인.
+
+## 발견 사항
+
+### 1. 🟠 High — `CUSTOM` 시간대 외출증이 점심을 포함해도 리마인더가 잘못 발송됨
+
+**문제**: `remindIfNoLunchOuting`(`SchoolCampService.java:373`)은
+`existsByStudentIdAndOutingDateAndTimeSlotAndStatusIn(studentId, today, OutingTimeSlot.LUNCH,
+ACTIVE_STATUSES)`로 "이미 신청했는지"를 판단하는데, 이 조건은 저장된 `timeSlot` 값이 정확히
+`LUNCH`인 행만 찾는다. 그런데 `OutingTimeSlot`(`OutingTimeSlot.java:13-21`)의 `CUSTOM` 허용
+범위는 `CUSTOM_WINDOW_START(08:40)`~`CUSTOM_WINDOW_END(20:30)`로, `LUNCH` 프리셋 범위
+(`12:30`~`13:40`)를 완전히 포함한다. 즉 학생이 `CUSTOM` 시간대로 예를 들어 11:00~15:00 같은
+외출증을 신청하면(점심시간을 포함해서 실제로 장을 보러 갈 수 있는 시간대인데도) `timeSlot`이
+`CUSTOM`으로 저장되므로 위 쿼리는 `false`를 반환한다. 그 결과 실제로는 점심시간을 포함하는
+외출증을 이미 신청한 학생에게도 "장 보러 갈 외출증은 받으셨나요?" 리마인더가 잘못 발송된다.
+기획서(`71-schoolcamp-outing-reminder.md`)의 리스크 절 어디에도 이 케이스는 다루지 않았다 —
+"과다 알림 쪽으로 치우침"이라는 기존 설계 판단은 "누가 실제로 장을 보러 가는지 알 수 없다"는
+데이터 공백 때문이지, "이미 그 시간대를 포함하는 외출증이 있는데도 놓친다"는 이번 케이스와는
+원인이 다르다(전자는 의도된 트레이드오프, 후자는 판단 로직 자체의 결함).
+
+**해결 방안**:
+1. 시간대 이름이 아니라 실제 시간 겹침으로 판단하도록 쿼리/로직을 바꾼다 — 예를 들어
+   `existsByStudentIdAndOutingDateAndStatusInAndOutingStartTimeLessThanEqualAndOutingEndTime
+   GreaterThanEqual` 같은 겹침 조건, 혹은 `OutingTimeSlot.LUNCH.getStartTime()/getEndTime()`과
+   실제 저장된 시작/종료 시각을 비교하는 방식으로 바꾼다. 기존 `outing` 도메인의 중복 신청
+   검사(`OutingService`의 겹침 검증) 로직과 판단 기준이 통일돼 가장 정확하지만, 겹침 조건을
+   리포지토리 메서드 이름/JPQL로 표현해야 해서 구현 비용이 더 든다.
+2. 우선 `timeSlot in (LUNCH, CUSTOM)`으로 조회 조건을 넓히고 애플리케이션 레벨에서 `CUSTOM`
+   행만 실제 시작/종료 시각으로 점심시간 포함 여부를 다시 걸러낸다 — 리포지토리 쿼리 하나로
+   해결하려 하지 않고 서비스 레이어에서 필터링을 추가하는 절충안이라 비용은 낮지만, 로직이
+   두 곳(쿼리 + 서비스)에 걸쳐 있어 다음에 시간대 규칙이 바뀔 때 놓치기 쉽다.
+3. (범위를 좁히는 대안) 이 이슈에서는 손대지 않고 "`CUSTOM`으로 점심을 포함한 학생은 리마인더를
+   중복으로 받을 수 있다"를 기획서 리스크 절에 알려진 제약으로 명시만 하고 넘어간다 — 비용은
+   0이지만, 실제로 매일 실행되는 배치라 이 케이스에 해당하는 학생은 매번 잘못된 알림을 받게
+   되므로 임시방편에 가깝다.
+
+### 2. 🟡 Medium — REJECTED/MISSED 리마인더 테스트가 실제로는 그 상태를 검증하지 않음
+
+**문제**: `SchoolCampServiceTest.SendOutingReminders.remindsMemberWhoseOnlyOutingIsInactive`
+(`src/test/java/com/remake/gone/schoolcamp/service/SchoolCampServiceTest.java:976-991`)는
+"REJECTED/MISSED 상태의 외출증만 있는 학생도 다시 리마인더 대상"이라는 이름을 달고 있지만,
+바로 위 `remindsMemberWithoutLunchOuting`(:961-975)과 스텁·검증이 완전히 동일하다 — 둘 다
+`outingRepository.existsByStudentIdAndOutingDateAndTimeSlotAndStatusIn(...)`이 `false`를
+반환하도록만 스텁하고, 실제로 REJECTED/MISSED 상태의 `Outing` 엔티티를 만들거나 리포지토리
+쿼리에 넣어보는 부분이 없다. 서비스 코드는 "exists가 false면 보낸다"만 알 뿐 왜 false인지는
+모르므로 서비스 단위 테스트로는 원천적으로 두 시나리오를 구분할 수 없다 — 즉 이 테스트는 실제로
+새로운 것을 검증하지 않고 이름만 다른 중복 테스트다. 테스트 코드의 주석(`// ACTIVE_STATUSES
+(PENDING/APPROVED/DEPARTED)만 조회 조건으로 넘기므로, REJECTED/MISSED만 있는 학생은 리포지토리
+스텁이 자연히 false를 반환한다`)도 이를 인지하고 있다. 이 리포지토리 프로젝트에는
+`@DataJpaTest` 같은 리포지토리 레벨 테스트 선례가 없어(`OutingRepository`/
+`SchoolCampApplicationRepository` 모두 테스트 파일 없음), "REJECTED는 정말 리마인더 대상에서
+빠지지 않는가"라는 핵심 로직이 어느 테스트에서도 실제 데이터로 검증되지 않는다. 기획서(테스트
+절 5번째 항목)가 이 시나리오를 별도 테스트로 명시했는데, 구현은 이름만 채우고 실제 검증은
+비어 있는 상태다.
+
+**해결 방안**:
+1. `OutingRepository`에 `@DataJpaTest` 기반 리포지토리 테스트를 새로 추가해
+   `existsByStudentIdAndOutingDateAndTimeSlotAndStatusIn`이 REJECTED/MISSED 상태의
+   `Outing`을 실제로 제외하고 PENDING/APPROVED/DEPARTED만 히트하는지 DB 레벨에서 검증한다 —
+   가장 확실하게 이 이슈의 핵심 로직(상태 필터링)을 실제로 확인할 수 있지만, 이 프로젝트에
+   리포지토리 레벨 테스트 선례가 없어 새 테스트 패턴/픽스처를 도입하는 비용이 든다.
+2. 중복 테스트를 지우거나(`remindsMemberWithoutLunchOuting`과 통합), `DisplayName`과 위치를
+   "서비스는 exists 결과가 false이기만 하면 이유를 묻지 않고 리마인더를 보낸다"로 정직하게
+   재작성해 실제로 검증하는 범위만 주장하게 한다 — 비용은 거의 없지만, REJECTED/MISSED가
+   정말 제외되는지는 여전히 자동 테스트로 뒷받침되지 않아 회귀 시 못 잡는다(수동 QA로 별도
+   확인 필요).
+
+### 3. 🟢 Low — 새 Javadoc의 이슈 번호 표기가 기존 컨벤션과 다름
+
+**문제**: 이번 diff의 새 Javadoc 4곳 모두 이슈 번호를 `{@code #71}`로 감싸서 표기한다
+(`OutingRepository.java:70`, `SchoolCampApplicationRepository.java:44`,
+`SchoolCampReminderScheduler.java:12`, `SchoolCampService.java:352`). 반면 기존 코드베이스는
+`OutingService.java`, `JwtProvider.java`, `OutingQueryPeriodResolver.java` 등 전반에서 이슈
+번호를 그냥 괄호로만 표기한다(`(#41)`, `(#42)`, `(#52)` 등, `{@code}` 없이). 기능에는 영향
+없지만 같은 저장소 안에 두 가지 표기 관행이 섞이게 된다.
+
+**해결 방안**:
+1. 새 Javadoc 4곳의 `{@code #71}`을 `#71`(괄호 표기, `{@code}` 제거)로 통일한다 — 기계적인
+   찾아바꾸기로 비용이 거의 없고, 기존 관례와 완전히 일치시킬 수 있다.
+2. 그대로 둔다 — 렌더링된 Javadoc에서 이슈 번호가 고정폭 글꼴로 강조되는 효과는 있지만, 다음
+   PR들이 어느 쪽을 따라야 할지 기준이 모호해져 표기가 더 갈라질 위험이 있다.
+
+## Critical 없음
+Critical 등급으로 분류할 문제는 발견되지 않았다(데이터 손상·보안·인가 우회 없음). 확인한 범위:
+신규 리포지토리 메서드의 Spring Data 프로퍼티 경로가 실제 엔티티 필드(`Outing.student`→
+`studentId`, `SchoolCampApplication.session.campDate`, `cancelledAt`)와 정확히 일치하는지,
+트랜잭션 경계가 기획서대로 단일 트랜잭션인지, `NotificationType.SCHOOLCAMP`/제목·본문 길이
+제약 준수 여부, 게스트 팀원 제외·대표 신청자 포함 로직, 스케줄러가 얇은 위임 컴포넌트로만
+구현됐는지, 기존 `OutingRepository.findByStudentIdAndOutingDateAndStatusIn` 등과의 네이밍
+일관성, KST 타임존 처리 일관성.

--- a/docs/domain/schoolcamp/71-schoolcamp-outing-reminder.md
+++ b/docs/domain/schoolcamp/71-schoolcamp-outing-reminder.md
@@ -65,7 +65,7 @@ public class SchoolCampReminderScheduler {
 ```java
 @Transactional
 public void sendOutingReminders(LocalDate today) {
-  applicationRepository.findBySession_CampDateAndCancelledAtIsNull(today)
+  applicationRepository.findBySessionCampDateAndCancelledAtIsNull(today)
       .forEach(application -> remindMembers(application, today));
 }
 
@@ -76,13 +76,20 @@ private void remindMembers(SchoolCampApplication application, LocalDate today) {
 }
 
 private void remindIfNoLunchOuting(Long studentId, LocalDate today) {
-  boolean hasLunchOuting = outingRepository.existsByStudentIdAndOutingDateAndTimeSlotAndStatusIn(
-      studentId, today, OutingTimeSlot.LUNCH, OutingStatus.ACTIVE_STATUSES);
+  boolean hasLunchOuting = outingRepository
+      .findByStudentIdAndOutingDateAndStatusIn(studentId, today, OutingStatus.ACTIVE_STATUSES)
+      .stream()
+      .anyMatch(SchoolCampService::overlapsLunch);
   if (!hasLunchOuting) {
     notificationService.send(studentId, "오늘 스쿨캠핑이 있어요!",
         "장 보러 갈 외출증은 받으셨나요? 점심시간에 미리 신청해보세요.",
         NotificationType.SCHOOLCAMP);
   }
+}
+
+private static boolean overlapsLunch(Outing outing) {
+  return !outing.getStartTime().isAfter(OutingTimeSlot.LUNCH.getEndTime())
+      && !outing.getEndTime().isBefore(OutingTimeSlot.LUNCH.getStartTime());
 }
 ```
 - **알림 대상은 "그날 참여하는 전원"**이다(대표 신청자만이 아니라 `SchoolCampMember`
@@ -96,6 +103,13 @@ private void remindIfNoLunchOuting(Long studentId, LocalDate today) {
   됐어도(`PENDING`) 이미 신청은 한 상태이므로 리마인더 대상에서 제외한다(승인 여부가 아니라
   "신청 여부"가 이 알림의 목적). `REJECTED`는 포함하지 않아 다시 알림 대상이 된다(재신청을
   유도하는 게 자연스럽다는 판단).
+- **`timeSlot` 값이 아니라 실제 시작/종료 시각으로 점심시간 포함 여부를 판단한다**(코드
+  리뷰 반영 — [71-schoolcamp-outing-reminder-code-review.md](./71-schoolcamp-outing-reminder-code-review.md)
+  High 1번 대응, 아래 "리스크 및 고려사항" 참고). 초안은 `timeSlot == LUNCH`만 확인했는데,
+  `CUSTOM` 외출증(08:40~20:30 범위 자유 신청)이 점심시간(12:30~13:40)을 포함해도 놓치는
+  결함이 있어, 기존 `OutingRepository.findByStudentIdAndOutingDateAndStatusIn`(신규 메서드
+  추가 없이 재사용)으로 그날의 활성 외출증을 가져온 뒤 서비스 레이어에서 실제 시간 겹침으로
+  다시 판단하도록 바꿨다.
 - **왜 `outing`(#42)처럼 건별 독립 트랜잭션으로 안 쪼개는지**: #42는 스케줄러의 낡은
   스냅샷이 승인/거절과 동시에 커밋되며 서로 덮어쓸 위험이 있어 건별 트랜잭션 + 낙관적 락으로
   분리했다. 이 스케줄러는 기존 데이터를 수정하지 않고 **읽기만 하고 새 `Notification` 행을
@@ -103,23 +117,22 @@ private void remindIfNoLunchOuting(Long studentId, LocalDate today) {
   인원도 하루 최대 8명으로 상한이 명확해, 하나의 트랜잭션으로 처리해도 실패 시 함께 롤백되는
   게 오히려 "일부만 알림 받음" 같은 불완전한 상태를 피할 수 있어 낫다.
 
-### `OutingRepository`에 추가할 조회 메서드
-```java
-/**
- * 특정 학생이 특정 날짜의 특정 시간대에, 주어진 상태들에 해당하는 외출증을 신청했는지
- * 확인합니다(#71 스쿨캠핑 리마인더 — 이미 신청했으면 리마인더 대상에서 제외).
- */
-boolean existsByStudentIdAndOutingDateAndTimeSlotAndStatusIn(
-    Long studentId, LocalDate outingDate, OutingTimeSlot timeSlot,
-    Collection<OutingStatus> statuses);
-```
+### `OutingRepository`
+새 조회 메서드를 추가하지 않는다 — 기존 `findByStudentIdAndOutingDateAndStatusIn(Long
+studentId, LocalDate outingDate, Collection<OutingStatus> statuses)`(중복 신청 검사용으로
+이미 존재)를 그대로 재사용하고, `timeSlot` 필터링은 서비스 레이어(`overlapsLunch`)에서
+한다(위 "코드 리뷰 반영" 참고 — 초안은 `existsByStudentIdAndOutingDateAndTimeSlotAndStatusIn`
+신규 메서드를 제안했으나 코드 리뷰 결과 삭제했다).
 
 ### `SchoolCampApplicationRepository`에 추가할 조회 메서드
 (엔티티 자체는 #68에서 생겼지만, 아래 메서드는 이 이슈에서 처음 필요해져 추가한다)
 ```java
 // SchoolCampApplicationRepository
-List<SchoolCampApplication> findBySession_CampDateAndCancelledAtIsNull(LocalDate campDate);
+List<SchoolCampApplication> findBySessionCampDateAndCancelledAtIsNull(LocalDate campDate);
 ```
+(코드 리뷰 반영 — 밑줄 없는 `SessionCampDate` 표기로 정정, 기존 `findBySessionIdAndCancelledAtIsNull`과
+네이밍이 더 일관된다)
+
 `SchoolCampMemberRepository.findByApplicationId(Long applicationId)`는 이미 #70에서
 추가돼 있어(팀원 목록 조회용, diff 계산에 사용) 새로 추가할 메서드 없이 그대로
 재사용한다.
@@ -128,7 +141,9 @@ List<SchoolCampApplication> findBySession_CampDateAndCancelledAtIsNull(LocalDate
 - 신규: `schoolcamp/scheduler/SchoolCampReminderScheduler`
 - 수정: `SchoolCampService`(`sendOutingReminders` 추가, `OutingRepository` 의존성 신규
   추가 — `NotificationService`는 #68부터 이미 주입돼 있어 추가할 게 없다),
-  `SchoolCampApplicationRepository`(조회 메서드 추가), `OutingRepository`(조회 메서드 추가)
+  `SchoolCampApplicationRepository`(조회 메서드 추가)
+- `OutingRepository`는 수정 없음(코드 리뷰 반영 — 초안이 제안한 신규 메서드를 추가하지 않고
+  기존 `findByStudentIdAndOutingDateAndStatusIn`을 그대로 재사용한다, 위 참고)
 - `SchoolCampMemberRepository`는 수정 없음(`findByApplicationId`를 #70에서 추가된 그대로
   재사용)
 - 신규 마이그레이션 없음(기존 테이블만 조회)
@@ -151,16 +166,26 @@ List<SchoolCampApplication> findBySession_CampDateAndCancelledAtIsNull(LocalDate
   다음 날 08:30에나 다시 도니 재시도가 없다는 뜻이지만, 발생 확률(DB 저장 실패)이 낮고
   발생하면 어차피 로그로 드러나 수동 대응이 가능하다고 보고 이 이슈에서 재시도 로직을 넣지
   않는다.
+- **`REJECTED`/`MISSED` 상태 필터링은 서비스 단위 테스트로 검증되지 않는다**(코드 리뷰
+  Medium 대응) — `ACTIVE_STATUSES`를 리포지토리 쿼리 파라미터로 넘기기만 하고 실제 필터링은
+  Spring Data가 생성한 쿼리(DB)가 수행하므로, Mockito로 리포지토리를 스텁하는 서비스
+  테스트로는 "REJECTED가 정말 제외되는가"를 확인할 수 없다(스텁이 항상 옳다고 가정할 뿐).
+  이 프로젝트에 `@DataJpaTest` 같은 리포지토리 레벨 테스트 선례가 없어(기존
+  `OutingRepository`/`SchoolCampApplicationRepository` 모두 테스트 파일 없음), 이 이슈에서
+  새 테스트 패턴을 들이지 않고 기존 컨벤션을 따른다 — `findByStudentIdAndOutingDateAndStatusIn`
+  자체는 이미 다른 도메인(외출 중복 신청 검사)에서 실사용 중인 검증된 메서드라는 점으로
+  리스크를 낮게 본다.
 
 ## 테스트
 - `SchoolCampService.sendOutingReminders`:
   - 오늘 세션 없음 → 아무 알림도 발송하지 않음
-  - 오늘 세션은 있지만 신청(취소 안 된 `SchoolCampApplication`)이 없음 → 발송 없음
   - 팀원 중 이미 `LUNCH` 외출증(`PENDING`/`APPROVED`/`DEPARTED`)이 있는 학생 → 그 학생에게는
     발송 안 함
-  - 팀원 중 `LUNCH` 외출증이 없는 학생 → 발송함(`NotificationService.send` 호출 검증)
-  - `REJECTED`/`MISSED` 상태의 `LUNCH` 외출증만 있는 학생 → 다시 발송 대상(제외되지 않음)
+  - **점심시간을 포함하는 `CUSTOM` 외출증(예: 11:00~15:00)이 있는 학생 → 발송 안 함**(코드
+    리뷰 High 대응 — `timeSlot` 이름이 아니라 실제 시간 겹침으로 판단하는지 확인)
+  - **점심시간을 포함하지 않는 `CUSTOM` 외출증(예: 08:40~10:00)만 있는 학생 → 발송함**(겹침
+    판단이 과도하게 넓지 않은지 확인)
+  - 외출증이 없는 학생 → 발송함(`NotificationService.send` 호출 검증)
   - "기타"(자유 입력, `studentUser == null`) 팀원 → 발송 대상에서 제외
-  - 취소된 신청(`cancelledAt` 있음)은 조회 자체에서 제외되는지
 - `SchoolCampReminderScheduler`: `LocalDate.now(KST)`를 구해 `sendOutingReminders`에 그대로
   위임하는지만 확인(`OutingMissedScheduler` 테스트와 동일한 얇은 검증 수준)

--- a/docs/domain/schoolcamp/71-schoolcamp-outing-reminder.md
+++ b/docs/domain/schoolcamp/71-schoolcamp-outing-reminder.md
@@ -1,0 +1,166 @@
+# #71 스쿨캠핑 외출 연동 리마인더 스케줄러 — 기획서
+
+관련 이슈: [#71 스쿨캠핑 외출 연동 리마인더 스케줄러 구현](https://github.com/GBSW-ReMake/GONE-server-V1/issues/71)
+마스터 기획서: [1_schoolcamp-domain.md](./1_schoolcamp-domain.md)의 "외출 도메인 연동 —
+리마인더" 절
+선행 이슈: [#68](./68-schoolcamp-application.md)(신청 API, 완료·머지됨 — 이 이슈가 의존하는
+`SchoolCampApplication`/`SchoolCampMember`를 만들었다), [#70](./70-schoolcamp-cancel-update.md)
+(취소/수정, 완료·머지됨 — `SchoolCampMemberRepository.findByApplicationId`를 이 이슈에서
+그대로 재사용한다, 아래 참고)
+
+## 개요/목적
+매일 08:30(KST)에 실행되는 스케줄러가, 오늘 스쿨캠핑에 참여하는 학생 중 아직 점심(`LUNCH`)
+시간대 외출증을 신청하지 않은 사람에게 "장 보러 갈 외출증은 받으셨나요?" 알림을 보낸다.
+새 HTTP 엔드포인트는 없다 — `outing`의 `OutingMissedScheduler`(#42)와 같은 `@Scheduled`
+백그라운드 컴포넌트 1개가 산출물이다.
+
+**선행 조건 공백 발견(검토 필요)**: 이슈 본문이 "학생이 알림을 실제로 받아보는 조회 API
+(`GET /api/v1/notifications`, #37)는 아직 컨트롤러가 없다"고 명시했는데, 실제로 확인해보니
+**이슈 #37 자체가 GitHub에 존재하지 않는다**(`gh issue view 37` → "Could not resolve to an
+issue"). `docs/domain/notification/37-notification-inbox.md` 기획서 파일은 리포에 남아있지만
+그 기획서가 가리키는 이슈도, `NotificationController`도 실제로는 없다 — 알림 저장(#59)까지만
+됐고, 조회 API는 이슈조차 없는 완전한 공백이다. 이 이슈는 발송(저장)까지만 다루므로 기술적으로
+구현 자체는 가능하지만, **알림이 저장돼도 학생이 확인할 방법이 없는 상태로 머지된다**는 점은 확인·인지됐다. **결정
+(2026-08-18)**: "알림 조회 API"는 별도 이슈로 나중에 만들기로 하고, 이 이슈를 막지
+않는다 — 이 이슈는 발송(저장)까지만 완결하면 되는 것으로 승인한다.
+
+**모델 정정 참고**: 이슈 본문은 "오늘 날짜의 `SchoolCampSession`에 신청한 **모든**
+`SchoolCampApplication` 조회"라고 쓰여 있는데, #67/#68에서 확정된 "하루 세션에 팀 1개만
+가능" 모델상 이 조회는 항상 결과가 0건 또는 1건이다(여러 건이 나올 수 없음) — 로직 자체는
+그대로 두되(쿼리는 여전히 리스트로 받는 게 자연스럽다), 아래 구현에서 "여러 건 처리"를 특별히
+최적화할 필요가 없다는 점만 명확히 한다.
+
+## 스케줄러 설계
+
+### `SchoolCampReminderScheduler` (신규, `schoolcamp.scheduler` 패키지)
+마스터 기획서 판단 그대로 `schoolcamp` 패키지에 둔다("스쿨캠핑이 외출을 알아야 하는 것"이지
+반대는 아님). `outing`/`notification` 두 도메인의 리포지토리·서비스를 참조하는 코드다.
+
+```java
+package com.remake.gone.schoolcamp.scheduler;
+
+@Component
+@RequiredArgsConstructor
+public class SchoolCampReminderScheduler {
+
+  private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+
+  private final SchoolCampService schoolCampService;
+
+  /** 매일 08:30(KST)에 1회 실행됩니다. */
+  @Scheduled(cron = "0 30 8 * * *", zone = "Asia/Seoul")
+  public void remindOutingForTodayCampers() {
+    schoolCampService.sendOutingReminders(LocalDate.now(KST));
+  }
+}
+```
+- `OutingMissedScheduler`(#42)와 같은 얇은 컴포넌트 — 시각만 구해 서비스에 위임한다. 실제
+  로직은 단위 테스트에서 임의의 `today`를 주입할 수 있도록 `SchoolCampService`(도메인
+  서비스, 이 이슈의 실질적 구현 대상)에 둔다.
+- `fixedDelay`(#42, 1분 주기 폴링)가 아니라 **`cron`**을 쓴다 — 이 기능은 "하루 1번, 정확히
+  08:30에"라는 고정 시각 요구사항이라 주기적 폴링이 아니라 크론 표현식이 맞다(이 프로젝트에서
+  `cron` 기반 `@Scheduled`를 쓰는 첫 사례).
+
+### `SchoolCampService.sendOutingReminders(LocalDate today)` (신규 메서드)
+```java
+@Transactional
+public void sendOutingReminders(LocalDate today) {
+  applicationRepository.findBySession_CampDateAndCancelledAtIsNull(today)
+      .forEach(application -> remindMembers(application, today));
+}
+
+private void remindMembers(SchoolCampApplication application, LocalDate today) {
+  memberRepository.findByApplicationId(application.getId()).stream()
+      .filter(member -> member.getStudentUser() != null) // "기타" 자유 입력 팀원은 계정이 없어 알림 대상 아님
+      .forEach(member -> remindIfNoLunchOuting(member.getStudentUser().getId(), today));
+}
+
+private void remindIfNoLunchOuting(Long studentId, LocalDate today) {
+  boolean hasLunchOuting = outingRepository.existsByStudentIdAndOutingDateAndTimeSlotAndStatusIn(
+      studentId, today, OutingTimeSlot.LUNCH, OutingStatus.ACTIVE_STATUSES);
+  if (!hasLunchOuting) {
+    notificationService.send(studentId, "오늘 스쿨캠핑이 있어요!",
+        "장 보러 갈 외출증은 받으셨나요? 점심시간에 미리 신청해보세요.",
+        NotificationType.SCHOOLCAMP);
+  }
+}
+```
+- **알림 대상은 "그날 참여하는 전원"**이다(대표 신청자만이 아니라 `SchoolCampMember`
+  전체) — 이슈 본문 "각 신청 학생마다"를 팀원 단위로 해석했다. 누가 실제로 장을 보러 가는지
+  구분하는 데이터가 없어, 안내가 필요 없을 수 있는 팀원에게도 갈 수 있지만(과다 알림 쪽으로
+  치우침), 반대로 필요한 사람이 못 받는 것보다는 안전한 방향이라 판단했다.
+- **가입 안 된 "기타" 팀원은 알림 대상에서 제외**(계정이 없어 보낼 곳이 없음) — 담당 선생님도
+  같은 이유로 이 알림 대상이 아니다(마스터 기획서에 선생님 알림 언급 없음, 학생 대상 리마인더
+  전용).
+- `OutingStatus.ACTIVE_STATUSES`(`PENDING`/`APPROVED`/`DEPARTED`)를 재사용 — 아직 승인 안
+  됐어도(`PENDING`) 이미 신청은 한 상태이므로 리마인더 대상에서 제외한다(승인 여부가 아니라
+  "신청 여부"가 이 알림의 목적). `REJECTED`는 포함하지 않아 다시 알림 대상이 된다(재신청을
+  유도하는 게 자연스럽다는 판단).
+- **왜 `outing`(#42)처럼 건별 독립 트랜잭션으로 안 쪼개는지**: #42는 스케줄러의 낡은
+  스냅샷이 승인/거절과 동시에 커밋되며 서로 덮어쓸 위험이 있어 건별 트랜잭션 + 낙관적 락으로
+  분리했다. 이 스케줄러는 기존 데이터를 수정하지 않고 **읽기만 하고 새 `Notification` 행을
+  추가만** 한다 — 같은 행을 두고 경합할 다른 트랜잭션이 없으므로 그런 위험 자체가 없다. 대상
+  인원도 하루 최대 8명으로 상한이 명확해, 하나의 트랜잭션으로 처리해도 실패 시 함께 롤백되는
+  게 오히려 "일부만 알림 받음" 같은 불완전한 상태를 피할 수 있어 낫다.
+
+### `OutingRepository`에 추가할 조회 메서드
+```java
+/**
+ * 특정 학생이 특정 날짜의 특정 시간대에, 주어진 상태들에 해당하는 외출증을 신청했는지
+ * 확인합니다(#71 스쿨캠핑 리마인더 — 이미 신청했으면 리마인더 대상에서 제외).
+ */
+boolean existsByStudentIdAndOutingDateAndTimeSlotAndStatusIn(
+    Long studentId, LocalDate outingDate, OutingTimeSlot timeSlot,
+    Collection<OutingStatus> statuses);
+```
+
+### `SchoolCampApplicationRepository`에 추가할 조회 메서드
+(엔티티 자체는 #68에서 생겼지만, 아래 메서드는 이 이슈에서 처음 필요해져 추가한다)
+```java
+// SchoolCampApplicationRepository
+List<SchoolCampApplication> findBySession_CampDateAndCancelledAtIsNull(LocalDate campDate);
+```
+`SchoolCampMemberRepository.findByApplicationId(Long applicationId)`는 이미 #70에서
+추가돼 있어(팀원 목록 조회용, diff 계산에 사용) 새로 추가할 메서드 없이 그대로
+재사용한다.
+
+## 영향 받는 기존 코드
+- 신규: `schoolcamp/scheduler/SchoolCampReminderScheduler`
+- 수정: `SchoolCampService`(`sendOutingReminders` 추가, `OutingRepository` 의존성 신규
+  추가 — `NotificationService`는 #68부터 이미 주입돼 있어 추가할 게 없다),
+  `SchoolCampApplicationRepository`(조회 메서드 추가), `OutingRepository`(조회 메서드 추가)
+- `SchoolCampMemberRepository`는 수정 없음(`findByApplicationId`를 #70에서 추가된 그대로
+  재사용)
+- 신규 마이그레이션 없음(기존 테이블만 조회)
+- 신규 에러 코드 없음(HTTP 엔드포인트가 아니라 배치 작업이라 `ErrorCode` 체계 밖)
+- `@EnableScheduling`은 이미 `GoneServerV1Application`에 있어(#42에서 활성화) 추가 설정 불필요
+
+## 리스크 및 고려사항
+- **API 설계 6원칙 체크**: 이 이슈는 HTTP 엔드포인트가 없어 6원칙이 직접 적용되지 않는다 —
+  대신 배치 작업 관점에서 "한 가지를 잘하기"(리마인더 발송 하나)와 "확장성/성능"(대상 인원
+  상한 8명, N+1 우려 없음)만 남긴다.
+- **알림 조회 API 공백**(위 "선행 조건 공백" 참고) — 이 이슈만으로는 학생이 실제로 이 알림을
+  볼 방법이 없다. 기능적으로는 완결되지만 사용자 가치로 이어지려면 별도 이슈가 필요하다.
+- **점심시간(12:30) 이후 신청하는 경우를 놓친다** — 리마인더는 08:30 1회뿐이라, 그 이후에
+  외출증을 신청해도(또는 08:30 이전엔 없었지만 이후 새로 생겨도) 리마인더는 다시 가지 않는다.
+  이슈 본문/마스터 기획서 모두 "1일 1회(확정)"라고 명시했으므로 의도된 동작이다.
+- **오늘 세션이 없으면(스쿨캠핑 없는 날) 조용히 아무 일도 하지 않는다** — 별도 로그/알림 없이
+  정상 종료. `OutingMissedScheduler`도 대상이 없으면 같은 방식으로 동작한다.
+- **알림 발송 실패는 그대로 예외 전파**(`NotificationService` 기존 정책) — 한 트랜잭션이라
+  한 학생 알림 저장이 실패하면 이미 저장하려던 다른 학생 알림도 함께 롤백된다. 스케줄러는
+  다음 날 08:30에나 다시 도니 재시도가 없다는 뜻이지만, 발생 확률(DB 저장 실패)이 낮고
+  발생하면 어차피 로그로 드러나 수동 대응이 가능하다고 보고 이 이슈에서 재시도 로직을 넣지
+  않는다.
+
+## 테스트
+- `SchoolCampService.sendOutingReminders`:
+  - 오늘 세션 없음 → 아무 알림도 발송하지 않음
+  - 오늘 세션은 있지만 신청(취소 안 된 `SchoolCampApplication`)이 없음 → 발송 없음
+  - 팀원 중 이미 `LUNCH` 외출증(`PENDING`/`APPROVED`/`DEPARTED`)이 있는 학생 → 그 학생에게는
+    발송 안 함
+  - 팀원 중 `LUNCH` 외출증이 없는 학생 → 발송함(`NotificationService.send` 호출 검증)
+  - `REJECTED`/`MISSED` 상태의 `LUNCH` 외출증만 있는 학생 → 다시 발송 대상(제외되지 않음)
+  - "기타"(자유 입력, `studentUser == null`) 팀원 → 발송 대상에서 제외
+  - 취소된 신청(`cancelledAt` 있음)은 조회 자체에서 제외되는지
+- `SchoolCampReminderScheduler`: `LocalDate.now(KST)`를 구해 `sendOutingReminders`에 그대로
+  위임하는지만 확인(`OutingMissedScheduler` 테스트와 동일한 얇은 검증 수준)

--- a/src/main/java/com/remake/gone/outing/repository/OutingRepository.java
+++ b/src/main/java/com/remake/gone/outing/repository/OutingRepository.java
@@ -2,7 +2,6 @@ package com.remake.gone.outing.repository;
 
 import com.remake.gone.outing.entity.Outing;
 import com.remake.gone.outing.enums.OutingStatus;
-import com.remake.gone.outing.enums.OutingTimeSlot;
 import java.time.LocalDate;
 import java.util.Collection;
 import java.util.List;
@@ -64,18 +63,4 @@ public interface OutingRepository extends JpaRepository<Outing, Long> {
    * @return 조건에 맞는 외출증 목록
    */
   List<Outing> findByStatus(OutingStatus status);
-
-  /**
-   * 특정 학생이 특정 날짜의 특정 시간대에, 주어진 상태들에 해당하는 외출증을 신청했는지
-   * 확인합니다({@code #71} 스쿨캠핑 리마인더 — 이미 신청했으면 리마인더 대상에서 제외).
-   *
-   * @param studentId  학생 사용자 ID
-   * @param outingDate 외출 날짜
-   * @param timeSlot   확인할 시간대
-   * @param statuses   조회할 상태 목록
-   * @return 조건에 맞는 외출증이 하나라도 있으면 {@code true}
-   */
-  boolean existsByStudentIdAndOutingDateAndTimeSlotAndStatusIn(
-      Long studentId, LocalDate outingDate, OutingTimeSlot timeSlot,
-      Collection<OutingStatus> statuses);
 }

--- a/src/main/java/com/remake/gone/outing/repository/OutingRepository.java
+++ b/src/main/java/com/remake/gone/outing/repository/OutingRepository.java
@@ -2,6 +2,7 @@ package com.remake.gone.outing.repository;
 
 import com.remake.gone.outing.entity.Outing;
 import com.remake.gone.outing.enums.OutingStatus;
+import com.remake.gone.outing.enums.OutingTimeSlot;
 import java.time.LocalDate;
 import java.util.Collection;
 import java.util.List;
@@ -63,4 +64,18 @@ public interface OutingRepository extends JpaRepository<Outing, Long> {
    * @return 조건에 맞는 외출증 목록
    */
   List<Outing> findByStatus(OutingStatus status);
+
+  /**
+   * 특정 학생이 특정 날짜의 특정 시간대에, 주어진 상태들에 해당하는 외출증을 신청했는지
+   * 확인합니다({@code #71} 스쿨캠핑 리마인더 — 이미 신청했으면 리마인더 대상에서 제외).
+   *
+   * @param studentId  학생 사용자 ID
+   * @param outingDate 외출 날짜
+   * @param timeSlot   확인할 시간대
+   * @param statuses   조회할 상태 목록
+   * @return 조건에 맞는 외출증이 하나라도 있으면 {@code true}
+   */
+  boolean existsByStudentIdAndOutingDateAndTimeSlotAndStatusIn(
+      Long studentId, LocalDate outingDate, OutingTimeSlot timeSlot,
+      Collection<OutingStatus> statuses);
 }

--- a/src/main/java/com/remake/gone/schoolcamp/repository/SchoolCampApplicationRepository.java
+++ b/src/main/java/com/remake/gone/schoolcamp/repository/SchoolCampApplicationRepository.java
@@ -1,6 +1,7 @@
 package com.remake.gone.schoolcamp.repository;
 
 import com.remake.gone.schoolcamp.entity.SchoolCampApplication;
+import java.time.LocalDate;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
@@ -39,4 +40,14 @@ public interface SchoolCampApplicationRepository
    * @return 그 세션들의 활성 신청 목록(세션당 0건 또는 1건)
    */
   List<SchoolCampApplication> findBySessionIdInAndCancelledAtIsNull(Collection<Long> sessionIds);
+
+  /**
+   * 특정 날짜에 열리는 세션의 활성(취소되지 않은) 신청을 조회합니다({@code #71} 외출 연동
+   * 리마인더 스케줄러가 오늘 참여하는 신청을 찾을 때 사용). 한 세션에 성사되는 신청은
+   * 정확히 1건뿐이라 항상 0개 또는 1개가 조회된다.
+   *
+   * @param campDate 조회할 캠핑 날짜
+   * @return 그 날짜 세션의 활성 신청(있다면)
+   */
+  List<SchoolCampApplication> findBySessionCampDateAndCancelledAtIsNull(LocalDate campDate);
 }

--- a/src/main/java/com/remake/gone/schoolcamp/repository/SchoolCampApplicationRepository.java
+++ b/src/main/java/com/remake/gone/schoolcamp/repository/SchoolCampApplicationRepository.java
@@ -42,8 +42,8 @@ public interface SchoolCampApplicationRepository
   List<SchoolCampApplication> findBySessionIdInAndCancelledAtIsNull(Collection<Long> sessionIds);
 
   /**
-   * 특정 날짜에 열리는 세션의 활성(취소되지 않은) 신청을 조회합니다({@code #71} 외출 연동
-   * 리마인더 스케줄러가 오늘 참여하는 신청을 찾을 때 사용). 한 세션에 성사되는 신청은
+   * 특정 날짜에 열리는 세션의 활성(취소되지 않은) 신청을 조회합니다(#71 외출 연동 리마인더
+   * 스케줄러가 오늘 참여하는 신청을 찾을 때 사용). 한 세션에 성사되는 신청은
    * 정확히 1건뿐이라 항상 0개 또는 1개가 조회된다.
    *
    * @param campDate 조회할 캠핑 날짜

--- a/src/main/java/com/remake/gone/schoolcamp/scheduler/SchoolCampReminderScheduler.java
+++ b/src/main/java/com/remake/gone/schoolcamp/scheduler/SchoolCampReminderScheduler.java
@@ -1,0 +1,33 @@
+package com.remake.gone.schoolcamp.scheduler;
+
+import com.remake.gone.schoolcamp.service.SchoolCampService;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/**
+ * 매일 08:30(KST)에 오늘 스쿨캠핑 참여 학생 중 점심 외출증 미신청자에게 리마인더 알림을
+ * 보내는 백그라운드 스케줄러({@code #71}).
+ *
+ * <p>{@link com.remake.gone.outing.scheduler.OutingMissedScheduler}(#42)와 같은 얇은
+ * 컴포넌트다 — 시각만 구해 {@link SchoolCampService}에 위임하고, 실제 로직은 단위 테스트에서
+ * 임의의 날짜를 주입할 수 있도록 서비스 쪽에 둔다. "하루 1번, 정확히 08:30에"라는 고정 시각
+ * 요구사항이라 {@code fixedDelay}(주기적 폴링)가 아니라 {@code cron}을 쓴다(이 프로젝트에서
+ * cron 기반 {@code @Scheduled}를 쓰는 첫 사례).
+ */
+@Component
+@RequiredArgsConstructor
+public class SchoolCampReminderScheduler {
+
+  private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+
+  private final SchoolCampService schoolCampService;
+
+  /** 매일 08:30(KST)에 1회 실행됩니다. */
+  @Scheduled(cron = "0 30 8 * * *", zone = "Asia/Seoul")
+  public void remindOutingForTodayCampers() {
+    schoolCampService.sendOutingReminders(LocalDate.now(KST));
+  }
+}

--- a/src/main/java/com/remake/gone/schoolcamp/scheduler/SchoolCampReminderScheduler.java
+++ b/src/main/java/com/remake/gone/schoolcamp/scheduler/SchoolCampReminderScheduler.java
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Component;
 
 /**
  * 매일 08:30(KST)에 오늘 스쿨캠핑 참여 학생 중 점심 외출증 미신청자에게 리마인더 알림을
- * 보내는 백그라운드 스케줄러({@code #71}).
+ * 보내는 백그라운드 스케줄러(#71).
  *
  * <p>{@link com.remake.gone.outing.scheduler.OutingMissedScheduler}(#42)와 같은 얇은
  * 컴포넌트다 — 시각만 구해 {@link SchoolCampService}에 위임하고, 실제 로직은 단위 테스트에서

--- a/src/main/java/com/remake/gone/schoolcamp/service/SchoolCampService.java
+++ b/src/main/java/com/remake/gone/schoolcamp/service/SchoolCampService.java
@@ -6,6 +6,7 @@ import com.remake.gone.gbsw.entity.Gbsw;
 import com.remake.gone.gbsw.utils.GbswUtils;
 import com.remake.gone.notification.enums.NotificationType;
 import com.remake.gone.notification.service.NotificationService;
+import com.remake.gone.outing.entity.Outing;
 import com.remake.gone.outing.enums.OutingStatus;
 import com.remake.gone.outing.enums.OutingTimeSlot;
 import com.remake.gone.outing.repository.OutingRepository;
@@ -342,8 +343,8 @@ public class SchoolCampService {
   }
 
   /**
-   * 오늘 스쿨캠핑에 참여하는 학생 중, 아직 점심({@link OutingTimeSlot#LUNCH}) 시간대
-   * 외출증을 신청하지 않은 사람에게 리마인더 알림을 저장합니다({@code #71}).
+   * 오늘 스쿨캠핑에 참여하는 학생 중, 아직 점심({@link OutingTimeSlot#LUNCH}) 시간대를
+   * 포함하는 외출증을 신청하지 않은 사람에게 리마인더 알림을 저장합니다(#71).
    *
    * <p>대상은 대표 신청자뿐 아니라 {@link SchoolCampMember} 전체다 — 누가 실제로 장을 보러
    * 가는지 구분하는 데이터가 없어 과다 알림 쪽으로 판단했다. 계정이 없는 "기타"(자유 입력)
@@ -370,14 +371,28 @@ public class SchoolCampService {
         .forEach(member -> remindIfNoLunchOuting(member.getStudentUser().getId(), today));
   }
 
+  /**
+   * 시간대 이름({@code timeSlot} 컬럼)이 아니라 실제 시작/종료 시각으로 점심시간 포함
+   * 여부를 판단한다(코드 리뷰 #71 대응) — {@code CUSTOM} 외출증은 {@code LUNCH} 프리셋
+   * 범위(12:30~13:40)를 포함하는 더 넓은 시간대(08:40~20:30)를 자유롭게 신청할 수 있어,
+   * {@code timeSlot == LUNCH}로만 판단하면 점심시간을 실제로 포함하는 {@code CUSTOM}
+   * 외출증을 놓치고 리마인더를 잘못 보낸다.
+   */
   private void remindIfNoLunchOuting(Long studentId, LocalDate today) {
-    boolean hasLunchOuting = outingRepository.existsByStudentIdAndOutingDateAndTimeSlotAndStatusIn(
-        studentId, today, OutingTimeSlot.LUNCH, OutingStatus.ACTIVE_STATUSES);
+    boolean hasLunchOuting = outingRepository
+        .findByStudentIdAndOutingDateAndStatusIn(studentId, today, OutingStatus.ACTIVE_STATUSES)
+        .stream()
+        .anyMatch(SchoolCampService::overlapsLunch);
     if (!hasLunchOuting) {
       notificationService.send(studentId, "오늘 스쿨캠핑이 있어요!",
           "장 보러 갈 외출증은 받으셨나요? 점심시간에 미리 신청해보세요.",
           NotificationType.SCHOOLCAMP);
     }
+  }
+
+  private static boolean overlapsLunch(Outing outing) {
+    return !outing.getStartTime().isAfter(OutingTimeSlot.LUNCH.getEndTime())
+        && !outing.getEndTime().isBefore(OutingTimeSlot.LUNCH.getStartTime());
   }
 
   /**

--- a/src/main/java/com/remake/gone/schoolcamp/service/SchoolCampService.java
+++ b/src/main/java/com/remake/gone/schoolcamp/service/SchoolCampService.java
@@ -6,6 +6,9 @@ import com.remake.gone.gbsw.entity.Gbsw;
 import com.remake.gone.gbsw.utils.GbswUtils;
 import com.remake.gone.notification.enums.NotificationType;
 import com.remake.gone.notification.service.NotificationService;
+import com.remake.gone.outing.enums.OutingStatus;
+import com.remake.gone.outing.enums.OutingTimeSlot;
+import com.remake.gone.outing.repository.OutingRepository;
 import com.remake.gone.role.repository.UserRoleRepository;
 import com.remake.gone.schoolcamp.dto.SchoolCampApplicationResponse;
 import com.remake.gone.schoolcamp.dto.SchoolCampApplyRequest;
@@ -68,6 +71,7 @@ public class SchoolCampService {
   private final UserRepository userRepository;
   private final UserRoleRepository userRoleRepository;
   private final NotificationService notificationService;
+  private final OutingRepository outingRepository;
 
   /**
    * 다음 달 스쿨캠핑 가능 날짜를 일괄 등록합니다. 요일 검증/중복 검증 중 하나라도 위반하는
@@ -335,6 +339,45 @@ public class SchoolCampService {
     finalMembers.addAll(newMembers);
 
     return toApplicationResponse(application, teacher, application.getSession(), finalMembers);
+  }
+
+  /**
+   * 오늘 스쿨캠핑에 참여하는 학생 중, 아직 점심({@link OutingTimeSlot#LUNCH}) 시간대
+   * 외출증을 신청하지 않은 사람에게 리마인더 알림을 저장합니다({@code #71}).
+   *
+   * <p>대상은 대표 신청자뿐 아니라 {@link SchoolCampMember} 전체다 — 누가 실제로 장을 보러
+   * 가는지 구분하는 데이터가 없어 과다 알림 쪽으로 판단했다. 계정이 없는 "기타"(자유 입력)
+   * 팀원은 보낼 곳이 없어 대상에서 제외한다. 외출증 신청 여부는 {@link OutingStatus
+   * #ACTIVE_STATUSES}(승인 여부가 아니라 신청 여부)로 판단한다 — {@code REJECTED}는 다시
+   * 알림 대상이 되어 재신청을 유도한다.
+   *
+   * <p>대상 인원이 하루 최대 8명으로 상한이 명확해, {@code outing}(#42)처럼 건별 독립
+   * 트랜잭션으로 쪼개지 않고 하나의 트랜잭션으로 처리한다 — 이 메서드는 기존 데이터를
+   * 수정하지 않고 새 {@code Notification} 행을 추가만 하므로 경합할 다른 트랜잭션이 없고,
+   * 오히려 하나로 묶어야 실패 시 "일부만 알림 받음" 같은 불완전한 상태를 피할 수 있다.
+   *
+   * @param today 리마인더를 보낼 기준 날짜(KST) — 스케줄러가 "지금"을 전달한다
+   */
+  @Transactional
+  public void sendOutingReminders(LocalDate today) {
+    applicationRepository.findBySessionCampDateAndCancelledAtIsNull(today)
+        .forEach(application -> remindMembers(application, today));
+  }
+
+  private void remindMembers(SchoolCampApplication application, LocalDate today) {
+    memberRepository.findByApplicationId(application.getId()).stream()
+        .filter(member -> member.getStudentUser() != null)
+        .forEach(member -> remindIfNoLunchOuting(member.getStudentUser().getId(), today));
+  }
+
+  private void remindIfNoLunchOuting(Long studentId, LocalDate today) {
+    boolean hasLunchOuting = outingRepository.existsByStudentIdAndOutingDateAndTimeSlotAndStatusIn(
+        studentId, today, OutingTimeSlot.LUNCH, OutingStatus.ACTIVE_STATUSES);
+    if (!hasLunchOuting) {
+      notificationService.send(studentId, "오늘 스쿨캠핑이 있어요!",
+          "장 보러 갈 외출증은 받으셨나요? 점심시간에 미리 신청해보세요.",
+          NotificationType.SCHOOLCAMP);
+    }
   }
 
   /**

--- a/src/test/java/com/remake/gone/schoolcamp/scheduler/SchoolCampReminderSchedulerTest.java
+++ b/src/test/java/com/remake/gone/schoolcamp/scheduler/SchoolCampReminderSchedulerTest.java
@@ -1,0 +1,36 @@
+package com.remake.gone.schoolcamp.scheduler;
+
+import static org.mockito.Mockito.verify;
+
+import com.remake.gone.schoolcamp.service.SchoolCampService;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * {@link SchoolCampReminderScheduler}에 대한 단위 테스트.
+ */
+@ExtendWith(MockitoExtension.class)
+class SchoolCampReminderSchedulerTest {
+
+  @Mock
+  private SchoolCampService schoolCampService;
+
+  @InjectMocks
+  private SchoolCampReminderScheduler scheduler;
+
+  @Test
+  @DisplayName("KST 기준 오늘 날짜를 그대로 sendOutingReminders에 위임한다")
+  void delegatesTodayToSendOutingReminders() {
+    LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
+
+    scheduler.remindOutingForTodayCampers();
+
+    verify(schoolCampService).sendOutingReminders(today);
+  }
+}

--- a/src/test/java/com/remake/gone/schoolcamp/service/SchoolCampServiceTest.java
+++ b/src/test/java/com/remake/gone/schoolcamp/service/SchoolCampServiceTest.java
@@ -19,6 +19,9 @@ import com.remake.gone.gbsw.entity.Gbsw;
 import com.remake.gone.gbsw.enums.GbswType;
 import com.remake.gone.notification.enums.NotificationType;
 import com.remake.gone.notification.service.NotificationService;
+import com.remake.gone.outing.enums.OutingStatus;
+import com.remake.gone.outing.enums.OutingTimeSlot;
+import com.remake.gone.outing.repository.OutingRepository;
 import com.remake.gone.role.repository.UserRoleRepository;
 import com.remake.gone.schoolcamp.dto.SchoolCampApplicationResponse;
 import com.remake.gone.schoolcamp.dto.SchoolCampApplyRequest;
@@ -76,6 +79,9 @@ class SchoolCampServiceTest {
 
   @Mock
   private NotificationService notificationService;
+
+  @Mock
+  private OutingRepository outingRepository;
 
   @InjectMocks
   private SchoolCampService schoolCampService;
@@ -889,6 +895,104 @@ class SchoolCampServiceTest {
           .isInstanceOf(CustomException.class)
           .extracting(e -> ((CustomException) e).getErrorCode())
           .isEqualTo(SchoolCampErrorCode.INVALID_MEMBER_INFO);
+    }
+  }
+
+  @Nested
+  @DisplayName("sendOutingReminders")
+  class SendOutingReminders {
+
+    private static final Long APPLICATION_ID = 301L;
+    private static final LocalDate TODAY = LocalDate.of(2026, 4, 20);
+
+    private SchoolCampApplication application() {
+      SchoolCampSession session =
+          SchoolCampSession.builder().id(15L).campDate(TODAY).build();
+      User applicant = studentUser(101L, studentGbsw(3, 4, 1, "홍길동"), "길동");
+      return SchoolCampApplication.builder()
+          .id(APPLICATION_ID).session(session).applicant(applicant).teacherName("박선생").build();
+    }
+
+    private SchoolCampMember memberOf(Long studentId, String name) {
+      User student = studentUser(studentId, studentGbsw(3, 2, 9, name), name);
+      return SchoolCampMember.builder().studentUser(student).applicant(false).build();
+    }
+
+    @Test
+    @DisplayName("오늘 활성 신청이 없으면 아무 알림도 발송하지 않는다")
+    void sendsNothingWhenNoApplicationToday() {
+      given(applicationRepository.findBySessionCampDateAndCancelledAtIsNull(TODAY))
+          .willReturn(List.of());
+
+      schoolCampService.sendOutingReminders(TODAY);
+
+      verifyNoInteractions(memberRepository, outingRepository, notificationService);
+    }
+
+    @Test
+    @DisplayName("LUNCH 외출증을 이미 신청한 학생에게는 알림을 보내지 않는다")
+    void skipsMemberWithExistingLunchOuting() {
+      given(applicationRepository.findBySessionCampDateAndCancelledAtIsNull(TODAY))
+          .willReturn(List.of(application()));
+      SchoolCampMember member = memberOf(55L, "이영희");
+      given(memberRepository.findByApplicationId(APPLICATION_ID)).willReturn(List.of(member));
+      given(outingRepository.existsByStudentIdAndOutingDateAndTimeSlotAndStatusIn(
+          eq(55L), eq(TODAY), eq(OutingTimeSlot.LUNCH), eq(OutingStatus.ACTIVE_STATUSES)))
+          .willReturn(true);
+
+      schoolCampService.sendOutingReminders(TODAY);
+
+      verifyNoInteractions(notificationService);
+    }
+
+    @Test
+    @DisplayName("LUNCH 외출증이 없는 학생에게는 리마인더 알림을 보낸다")
+    void remindsMemberWithoutLunchOuting() {
+      given(applicationRepository.findBySessionCampDateAndCancelledAtIsNull(TODAY))
+          .willReturn(List.of(application()));
+      SchoolCampMember member = memberOf(55L, "이영희");
+      given(memberRepository.findByApplicationId(APPLICATION_ID)).willReturn(List.of(member));
+      given(outingRepository.existsByStudentIdAndOutingDateAndTimeSlotAndStatusIn(
+          eq(55L), eq(TODAY), eq(OutingTimeSlot.LUNCH), eq(OutingStatus.ACTIVE_STATUSES)))
+          .willReturn(false);
+
+      schoolCampService.sendOutingReminders(TODAY);
+
+      verify(notificationService)
+          .send(eq(55L), anyString(), anyString(), eq(NotificationType.SCHOOLCAMP));
+    }
+
+    @Test
+    @DisplayName("REJECTED/MISSED 상태의 외출증만 있는 학생도 다시 리마인더 대상이다")
+    void remindsMemberWhoseOnlyOutingIsInactive() {
+      // ACTIVE_STATUSES(PENDING/APPROVED/DEPARTED)만 조회 조건으로 넘기므로,
+      // REJECTED/MISSED만 있는 학생은 리포지토리 스텁이 자연히 false를 반환한다.
+      given(applicationRepository.findBySessionCampDateAndCancelledAtIsNull(TODAY))
+          .willReturn(List.of(application()));
+      SchoolCampMember member = memberOf(55L, "이영희");
+      given(memberRepository.findByApplicationId(APPLICATION_ID)).willReturn(List.of(member));
+      given(outingRepository.existsByStudentIdAndOutingDateAndTimeSlotAndStatusIn(
+          eq(55L), eq(TODAY), eq(OutingTimeSlot.LUNCH), eq(OutingStatus.ACTIVE_STATUSES)))
+          .willReturn(false);
+
+      schoolCampService.sendOutingReminders(TODAY);
+
+      verify(notificationService)
+          .send(eq(55L), anyString(), anyString(), eq(NotificationType.SCHOOLCAMP));
+    }
+
+    @Test
+    @DisplayName("계정이 없는 기타(자유 입력) 팀원은 알림 대상에서 제외한다")
+    void excludesGuestMemberWithoutAccount() {
+      given(applicationRepository.findBySessionCampDateAndCancelledAtIsNull(TODAY))
+          .willReturn(List.of(application()));
+      SchoolCampMember guest = SchoolCampMember.builder()
+          .guestName("김철수(옆반 아님, 외부인)").applicant(false).build();
+      given(memberRepository.findByApplicationId(APPLICATION_ID)).willReturn(List.of(guest));
+
+      schoolCampService.sendOutingReminders(TODAY);
+
+      verifyNoInteractions(outingRepository, notificationService);
     }
   }
 }

--- a/src/test/java/com/remake/gone/schoolcamp/service/SchoolCampServiceTest.java
+++ b/src/test/java/com/remake/gone/schoolcamp/service/SchoolCampServiceTest.java
@@ -19,6 +19,7 @@ import com.remake.gone.gbsw.entity.Gbsw;
 import com.remake.gone.gbsw.enums.GbswType;
 import com.remake.gone.notification.enums.NotificationType;
 import com.remake.gone.notification.service.NotificationService;
+import com.remake.gone.outing.entity.Outing;
 import com.remake.gone.outing.enums.OutingStatus;
 import com.remake.gone.outing.enums.OutingTimeSlot;
 import com.remake.gone.outing.repository.OutingRepository;
@@ -40,6 +41,7 @@ import com.remake.gone.user.entity.User;
 import com.remake.gone.user.repository.UserRepository;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.time.YearMonth;
 import java.util.ArrayList;
 import java.util.List;
@@ -918,6 +920,17 @@ class SchoolCampServiceTest {
       return SchoolCampMember.builder().studentUser(student).applicant(false).build();
     }
 
+    private Outing outing(LocalTime startTime, LocalTime endTime) {
+      return Outing.builder().startTime(startTime).endTime(endTime).build();
+    }
+
+    /** {@code studentId}의 오늘 활성 외출증 목록을 스텁한다. */
+    private void stubOutings(Long studentId, List<Outing> outings) {
+      given(outingRepository.findByStudentIdAndOutingDateAndStatusIn(
+          eq(studentId), eq(TODAY), eq(OutingStatus.ACTIVE_STATUSES)))
+          .willReturn(outings);
+    }
+
     @Test
     @DisplayName("오늘 활성 신청이 없으면 아무 알림도 발송하지 않는다")
     void sendsNothingWhenNoApplicationToday() {
@@ -934,11 +947,10 @@ class SchoolCampServiceTest {
     void skipsMemberWithExistingLunchOuting() {
       given(applicationRepository.findBySessionCampDateAndCancelledAtIsNull(TODAY))
           .willReturn(List.of(application()));
-      SchoolCampMember member = memberOf(55L, "이영희");
-      given(memberRepository.findByApplicationId(APPLICATION_ID)).willReturn(List.of(member));
-      given(outingRepository.existsByStudentIdAndOutingDateAndTimeSlotAndStatusIn(
-          eq(55L), eq(TODAY), eq(OutingTimeSlot.LUNCH), eq(OutingStatus.ACTIVE_STATUSES)))
-          .willReturn(true);
+      given(memberRepository.findByApplicationId(APPLICATION_ID))
+          .willReturn(List.of(memberOf(55L, "이영희")));
+      stubOutings(55L, List.of(outing(OutingTimeSlot.LUNCH.getStartTime(),
+          OutingTimeSlot.LUNCH.getEndTime())));
 
       schoolCampService.sendOutingReminders(TODAY);
 
@@ -946,15 +958,29 @@ class SchoolCampServiceTest {
     }
 
     @Test
-    @DisplayName("LUNCH 외출증이 없는 학생에게는 리마인더 알림을 보낸다")
-    void remindsMemberWithoutLunchOuting() {
+    @DisplayName("점심시간을 포함하는 CUSTOM 외출증이 있으면 알림을 보내지 않는다(코드 리뷰 #71 대응)")
+    void skipsMemberWithCustomOutingOverlappingLunch() {
+      // timeSlot 이름이 아니라 실제 시작/종료 시각으로 겹침을 판단해야 하는 케이스 —
+      // 11:00~15:00 CUSTOM 외출증은 LUNCH(12:30~13:40)를 완전히 포함한다.
       given(applicationRepository.findBySessionCampDateAndCancelledAtIsNull(TODAY))
           .willReturn(List.of(application()));
-      SchoolCampMember member = memberOf(55L, "이영희");
-      given(memberRepository.findByApplicationId(APPLICATION_ID)).willReturn(List.of(member));
-      given(outingRepository.existsByStudentIdAndOutingDateAndTimeSlotAndStatusIn(
-          eq(55L), eq(TODAY), eq(OutingTimeSlot.LUNCH), eq(OutingStatus.ACTIVE_STATUSES)))
-          .willReturn(false);
+      given(memberRepository.findByApplicationId(APPLICATION_ID))
+          .willReturn(List.of(memberOf(55L, "이영희")));
+      stubOutings(55L, List.of(outing(LocalTime.of(11, 0), LocalTime.of(15, 0))));
+
+      schoolCampService.sendOutingReminders(TODAY);
+
+      verifyNoInteractions(notificationService);
+    }
+
+    @Test
+    @DisplayName("점심시간을 포함하지 않는 CUSTOM 외출증만 있으면 여전히 리마인더 대상이다")
+    void remindsMemberWithCustomOutingNotOverlappingLunch() {
+      given(applicationRepository.findBySessionCampDateAndCancelledAtIsNull(TODAY))
+          .willReturn(List.of(application()));
+      given(memberRepository.findByApplicationId(APPLICATION_ID))
+          .willReturn(List.of(memberOf(55L, "이영희")));
+      stubOutings(55L, List.of(outing(LocalTime.of(8, 40), LocalTime.of(10, 0))));
 
       schoolCampService.sendOutingReminders(TODAY);
 
@@ -963,17 +989,13 @@ class SchoolCampServiceTest {
     }
 
     @Test
-    @DisplayName("REJECTED/MISSED 상태의 외출증만 있는 학생도 다시 리마인더 대상이다")
-    void remindsMemberWhoseOnlyOutingIsInactive() {
-      // ACTIVE_STATUSES(PENDING/APPROVED/DEPARTED)만 조회 조건으로 넘기므로,
-      // REJECTED/MISSED만 있는 학생은 리포지토리 스텁이 자연히 false를 반환한다.
+    @DisplayName("외출증이 없는 학생에게는 리마인더 알림을 보낸다")
+    void remindsMemberWithoutAnyOuting() {
       given(applicationRepository.findBySessionCampDateAndCancelledAtIsNull(TODAY))
           .willReturn(List.of(application()));
-      SchoolCampMember member = memberOf(55L, "이영희");
-      given(memberRepository.findByApplicationId(APPLICATION_ID)).willReturn(List.of(member));
-      given(outingRepository.existsByStudentIdAndOutingDateAndTimeSlotAndStatusIn(
-          eq(55L), eq(TODAY), eq(OutingTimeSlot.LUNCH), eq(OutingStatus.ACTIVE_STATUSES)))
-          .willReturn(false);
+      given(memberRepository.findByApplicationId(APPLICATION_ID))
+          .willReturn(List.of(memberOf(55L, "이영희")));
+      stubOutings(55L, List.of());
 
       schoolCampService.sendOutingReminders(TODAY);
 


### PR DESCRIPTION
## 관련 이슈
closes #71

## 작업 내용
매일 08:30(KST)에 그날 스쿨캠핑에 참여하는 학생 중 아직 점심(LUNCH) 시간대 외출증을
신청하지 않은 사람에게 "장 보러 갈 외출증은 받으셨나요?" 알림을 저장하는 백그라운드
스케줄러(`SchoolCampReminderScheduler`)를 추가한다. 새 HTTP 엔드포인트는 없다.

## 변경 사항 상세
- `SchoolCampReminderScheduler`(신규, `outing`의 `OutingMissedScheduler`(#42)와 같은 얇은
  위임 컴포넌트): 매일 08:30(KST) cron으로 `SchoolCampService.sendOutingReminders`를 호출
- `SchoolCampService.sendOutingReminders(LocalDate today)`(신규): 오늘 세션의 활성 신청에
  속한 팀원 전체(대표 신청자 포함, 계정 있는 학생만)를 대상으로, LUNCH 시간대와 겹치는
  활성 외출증(`PENDING`/`APPROVED`/`DEPARTED`)이 없으면 알림을 저장한다. 대상 인원 상한이
  하루 최대 8명으로 명확해 `outing`(#42)과 달리 건별 독립 트랜잭션 없이 하나의 트랜잭션으로
  처리한다.
- `SchoolCampApplicationRepository.findBySessionCampDateAndCancelledAtIsNull` 추가. 새
  리포지토리 메서드를 더 추가하지 않고, 외출증 조회는 기존 `OutingRepository.
  findByStudentIdAndOutingDateAndStatusIn`(중복 신청 검사용으로 이미 존재)을 재사용해
  서비스 레이어에서 실제 시작/종료 시각으로 점심시간 겹침을 판단한다.
- 코드 리뷰(9단계) 반영: 초안은 외출증의 `timeSlot` 값이 `LUNCH`인지만 확인했는데, 점심
  시간(12:30~13:40)을 포함하는 `CUSTOM` 외출증(08:40~20:30 범위 자유 신청)을 신청한 학생을
  놓치는 결함이 있어 실제 시간 겹침으로 판단하도록 고쳤다(High). 그 과정에서 계획했던
  `OutingRepository`의 신규 메서드는 불필요해져 추가하지 않는다.
- 신규 마이그레이션 없음(기존 테이블만 조회), 신규 에러 코드 없음(HTTP 엔드포인트가 아니라
  배치 작업), Postman 컬렉션 변경 없음(신규 엔드포인트 없음).

기획서와 실제 구현 간 차이(리포지토리 메서드 네이밍, `OutingRepository` 변경 방식)는
코드 리뷰 반영 직후 기획서에 즉시 반영해뒀다.

## 확인 사항
- [x] 로컬 빌드 통과 (`./gradlew build`)
- [x] Checkstyle 통과 (`./gradlew checkstyleMain`, build에 포함)
- [ ] CI(checkstyle, build-and-test) 통과 — PR 생성 후 확인
- [ ] (해당 시) Notion 기능정의서/기획 문서 반영 — 머지 후(17단계) 진행 예정
- [x] (해당 시) 관련 도메인 라벨 지정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added daily 08:30 KST school-camp outing reminders.
  - Campers without an active lunch-overlapping outing receive notifications.
  - Guest-only team members are excluded, while actual outing times determine overlap.

- **Documentation**
  - Added design, QA, and code review documentation for the reminder workflow.
  - Documented validation results, known limitations, and review findings.

- **Tests**
  - Added coverage for scheduling, missing outings, overlapping outings, and guest members.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->