### PR TITLE
feat(schoolcamp): #83 자리나면 알림받기(대기자 알림) 기능

### DIFF
--- a/docs/domain/schoolcamp/83-schoolcamp-waitlist-notification-QA.md
+++ b/docs/domain/schoolcamp/83-schoolcamp-waitlist-notification-QA.md
@@ -1,0 +1,58 @@
+# #83 스쿨캠핑 자리나면 알림받기(대기자 알림) 기능 — QA 결과
+
+관련 기획서: [83-schoolcamp-waitlist-notification.md](./83-schoolcamp-waitlist-notification.md)
+관련 코드 리뷰: [83-schoolcamp-waitlist-notification-code-review.md](./83-schoolcamp-waitlist-notification-code-review.md)
+(9단계 코드 리뷰 지적 사항(High 1건, Low 1건)은 QA 이전에 전부 반영 완료 — 이 문서는 QA에서
+새로 발견된 것만 다룬다)
+
+## 검증 방법/범위
+- `./gradlew build`(checkstyle + 전체 테스트, `V14` 마이그레이션이 실 DB에 적용되는지 포함)
+  통과 확인.
+- 로컬 서버 실제 기동(`./gradlew bootRun`, `dev` 프로필, 로컬 MySQL(3306)/Redis(6379)).
+- 실제 로그인 절차 대신, `JwtProvider`와 동일한 HS256 서명 방식(`application-dev.yml`의
+  `jwt.access-token-secret`)으로 로컬 전용 토큰을 직접 발급해 사용했다 — 시크릿 값은 로컬
+  `application-dev.yml`에 이미 평문으로 존재하는 값이고 로컬호스트에서만 사용했다.
+- 기존 로컬 dev DB의 실 계정(`id=1` STUDENT, `id=2` STUDENT, `id=13` TEACHER+ADMIN)을
+  그대로 사용했다. 이번 QA로 새로 만든 세션 1건(`id=101`, `20260826`)/신청 1건(`id=25`)/
+  알림 1건은 QA 종료 후 전부 삭제했고, 등록했던 대기(`school_camp_waitlist id=1`)도
+  삭제해 dev DB를 QA 이전 상태로 되돌렸다(`#70` QA와 동일한 원칙).
+- 한글 페이로드는 `#68`/`#70` QA에서 확인된 Windows Git Bash 인코딩 이슈를 피하기 위해
+  Write 도구로 UTF-8 파일을 먼저 만들고 `curl --data-binary @file`로 전송했다.
+
+## 실제 HTTP E2E 검증
+
+### `POST/DELETE /api/v1/school-camps/waitlist`, `GET /api/v1/school-camps/waitlist/me`
+1. 등록 전 상태 조회 → `200`, `{"registered": false, "registeredAt": null}`
+2. 정상 등록(파라미터 없음) → `201`, `{"month": "202608", "registeredAt": "..."}` — 서버가
+   요청 시점 기준 "이번 달"을 정확히 계산함을 확인
+3. 등록 직후 상태 조회 → `registered: true`
+4. 같은 달에 중복 등록 시도 → `409 SCHOOLCAMP_014`
+5. 취소 → `200`
+6. 취소 직후 상태 조회 → `registered: false`
+7. 등록된 적 없는 상태에서 다시 취소 시도 → `404 SCHOOLCAMP_015`
+8. 취소했던 같은 달에 재등록 → `201`. DB에서 `school_camp_waitlist` 행이 여전히 1건뿐임을
+   확인(새 행이 아니라 기존 행이 재활성화됨, `id=1` 그대로 `cancelled_at=NULL`로 갱신)
+9. 인증 없이 등록 시도 → `401`
+10. `TEACHER` 역할로 등록 시도 → `403`(`STUDENT` 전용)
+
+### 취소 발생 시 대기자 알림 발송 (기획서 핵심 시나리오)
+11. `id=1`이 이번 달(2026-08) 대기 등록된 상태에서, ADMIN으로 새 세션(`20260826`,
+    `id=101`) 등록 → `id=2`가 그 세션에 신청(`id=25`) → `id=2`가 본인 신청을 취소.
+    직후 `notification` 테이블에서 `id=1`에게 새 알림이 실제로 생겼음을 확인:
+    `title="스쿨캠핑 자리가 났어요!"`,
+    `body="2026년 8월 스쿨캠핑에 취소로 빈 자리가 생겼어요. 캘린더에서 확인하고 신청해보세요!"`
+    — 기획서가 명시한 "취소 시점이 아니라 세션의 캠핑 날짜가 속한 달" 기준이 실제로도
+    정확히 8월로 계산됨을 실 데이터로 확인했다.
+
+### `releaseQuietly` 경로가 알림을 보내지 않는지 (코드 리뷰 High 1번 재검증)
+12. 위 11번과 별개로, `id=2`가 같은 세션(재오픈된 `id=101`)에 `teacherUserId=1`(`STUDENT`
+    역할이라 유효하지 않은 선생님)로 신청을 시도 → 세션 claim 이후 검증에서
+    `400 SCHOOLCAMP_004`로 실패, `releaseQuietly`로 세션이 다시 반환됨(`taken_at`이 다시
+    `NULL`로 확인됨). 이 실패 직후 `notification` 테이블의 `id=1` 최신 알림 id가 11번
+    검증 때와 동일하게 유지됨을 확인 — 실패한 신청 시도가 대기자에게 스팸 알림을 보내지
+    않음을 실제 DB 상태로 재확인했다(단위 테스트는 코드 리뷰 반영 시 이미 추가함).
+
+## 발견 사항
+Critical/High/Medium/Low 모두 없음 — 코드 리뷰(9단계)에서 지적/반영된 사항(특히 High
+1번, `releaseQuietly` 무알림)이 실제 HTTP 요청과 DB 레벨에서도 의도대로 동작함을
+재확인했고, QA 단계에서 새로 발견된 문제는 없다.

--- a/docs/domain/schoolcamp/83-schoolcamp-waitlist-notification-code-review.md
+++ b/docs/domain/schoolcamp/83-schoolcamp-waitlist-notification-code-review.md
@@ -1,0 +1,233 @@
+# #83 스쿨캠핑 자리나면 알림받기(대기자 알림) 기능 — 코드 리뷰 결과
+
+리뷰 대상: `git diff dev...feat/#83-schoolcamp-waitlist`
+(`SchoolCampController`, `SchoolCampWaitlist`/`SchoolCampWaitlistResponse`/
+`SchoolCampWaitlistStatusResponse`, `SchoolCampWaitlistRepository`,
+`SchoolCampWaitlistService`(신규), `SchoolCampService.cancelApplication`(수정),
+`SchoolCampErrorCode`(014~015 추가), `V14__add_schoolcamp_waitlist.sql`, 관련 테스트 4종)
+
+리뷰어는 구현 과정에 관여하지 않은 격리된 세션에서, 기획서
+(`83-schoolcamp-waitlist-notification.md`)만 참고해 진행했다
+([code-review-isolation.md](../../rules/code-review-isolation.md) 준수). 정적 코드 대조 외에
+`./gradlew checkstyleMain checkstyleTest`와 `./gradlew test --tests "*SchoolCamp*"`를 실제로
+실행해 스타일/테스트 통과 여부를 확인했다.
+
+## 발견 사항
+
+### 1. 🟠 High — `SchoolCampSessionClaimService.release`/`releaseQuietly` 경로가 알림을 보내지 않는다는 회귀 테스트가 없음 → **반영 완료**
+
+기존 `applyToCamp` 실패 케이스 5곳(`releaseQuietly` 경로가 호출되는 지점) 전부에
+`verifyNoInteractions(waitlistService)`를 추가했다(해결 방안 1번 채택).
+
+
+**문제**: 기획서 "테스트" 절은 "`SchoolCampSessionClaimService.release`/`releaseQuietly` 경로는
+알림을 보내지 않는지 확인하는 회귀 테스트(이번 이슈에서 가장 중요한 케이스)"를 명시적으로
+요구한다. 그런데 diff에는 `SchoolCampSessionClaimService.java`도,
+`SchoolCampSessionClaimServiceIntegrationTest.java`도 변경되지 않았고,
+`SchoolCampServiceTest`의 기존 `applyToCamp` 실패 케이스들(claim 이후 검증 실패로
+`releaseQuietly`가 호출되는 경로 — 선생님 검증 실패, 팀원 검증 실패, 월 중복 검증 실패 등
+여러 곳에서 `verify(sessionClaimService).release(SESSION_ID)`로 이미 검증되고 있다)에도
+`waitlistService`와 상호작용하지 않는지 확인하는 어서션이 하나도 추가되지 않았다.
+
+현재 구현 자체는 구조적으로 안전하다 — `SchoolCampSessionClaimService`는
+`SchoolCampWaitlistService`를 주입받지 않고, `SchoolCampService.releaseQuietly`도
+`sessionClaimService.release(sessionId)`만 호출할 뿐 `waitlistService`를 전혀 건드리지
+않는다(코드 확인 완료, 실제 알림 스팸 버그는 없음). 다만 기획서가 이 케이스를 "가장
+중요"하다고 못 박은 이유는, 향후 #84(유령 점유 회수 스케줄러)가 이 이슈가 만든
+`notifyForMonth`를 재사용하려 할 때 실수로 `releaseQuietly` 경로에도 알림을 연결해버리는
+회귀를 미리 잡아두려는 의도로 읽힌다. 지금 그 안전장치가 비어 있어, 이 이슈가 명시적으로
+요구한 테스트 커버리지 항목 하나가 구현되지 않은 상태다.
+
+**해결 방안**:
+1. `SchoolCampServiceTest`의 기존 `applyToCamp` 실패 케이스(claim 이후 검증 실패로
+   `releaseQuietly`가 호출되는 경로)에 `verifyNoInteractions(waitlistService)`를 한 줄씩
+   추가한다 — `cancelApplication` 테스트에 이미 같은 패턴(`verify(waitlistService)
+   .notifyForMonth(...)`/`verifyNoInteractions(waitlistService)`)이 적용돼 있어 일관된
+   방식이고, 기존 테스트 메서드에 검증 한 줄만 추가하면 되어 비용도 낮다. 단점은 여러
+   실패 케이스마다 반복해서 넣어야 해 다소 번거롭다는 점 정도다.
+2. `SchoolCampSessionClaimService`를 직접 겨냥한 단위 테스트를 새로 만들어, 이 클래스가
+   `NotificationService`/`SchoolCampWaitlistService`를 아예 주입받지 않는다는 것과
+   `release` 호출이 그 두 빈과 전혀 상호작용하지 않음을 클래스 레벨에서 증명한다 — 이
+   클래스가 애초에 두 빈을 주입받지 않으므로 사실 컴파일 타임에 이미 보장되는 성질이라
+   테스트로서의 실효성은 1번 방안보다 낮지만, "이 클래스는 알림 인프라를 절대 모른다"는
+   아키텍처적 의도를 명시적으로 문서화하는 효과가 있고 #84 구현 시 참고할 앵커가 된다.
+
+### 2. 🟡 Medium — `notifyForMonth` 알림 저장 실패가 이미 유효했던 취소 자체를 함께 롤백시킬 수 있음 → **수용(해결 방안 1번), 코드 변경 없음**
+
+프로젝트 전역이 이미 채택한 "알림 저장 실패 = 호출자 트랜잭션과 함께 롤백" 정책과
+일관되게 그대로 둔다. 이 트레이드오프를 여기 문서에 남겨 향후 동일 지적이 반복되지
+않게 한다.
+
+**문제**: `SchoolCampService.cancelApplication`(`SchoolCampService.java:290`)은
+`application.setCancelledAt`/`applicationRepository.save`/`sessionRepository.release`가 모두
+성공한 뒤, 같은 `@Transactional` 안에서 `waitlistService.notifyForMonth(...)`를 호출한다.
+`notifyForMonth`는 그 달 대기자 전원을 순회하며 `notificationService.send(...)`를
+호출하는데, `NotificationService.send`의 클래스 문서(`NotificationService.java:14-17`)는
+"저장 실패는 그대로 예외로 전파한다 — 호출자 트랜잭션과 함께 롤백되는 게 맞는 동작"이라고
+명시된 정책이다. 즉 대기자 중 단 한 명에게라도 알림 저장이 실패하면(일시적 DB 오류 등),
+그 대기자와 아무 상관 없는 원래 취소 요청자의 정상적인 신청 취소·세션 반환까지 통째로
+롤백된다.
+
+이건 새로 만든 버그라기보다 `NotificationService`가 이미 채택한 정책(#59/#65 마스터
+기획서 "정책 가정")을 그대로 물려받은 것이고, `updateApplication`의
+`sendInviteNotifications`도 같은 트랜잭션 안에서 같은 방식으로 호출된다 — #83 기획서도
+"같은 방식으로 호출 트랜잭션 안에서 저장되므로 패턴을 맞춘다"고 이 정합성을 명시적으로
+의도했다. 다만 `cancelApplication`은 #83 이전에는 대기자 수만큼 반복 호출되는 구간이 전혀
+없었으므로, 이번 변경으로 "취소 1건 처리 중 실패할 수 있는 지점의 개수"가 대기자 수만큼
+늘어난 것은 사실이라 별도로 짚어둘 값어치가 있다.
+
+**해결 방안**:
+1. 지금처럼 그대로 둔다 — 프로젝트 전체가 "알림 저장 실패 = 트랜잭션 롤백"을 일관된
+   정책으로 채택했고, 재학생 규모(대기자 수십 명)에서 `notificationService.send`가
+   실패할 상황은 DB 자체 장애 수준이라 실무적 발생 빈도가 매우 낮다. 이 경우 원래 취소
+   자체도 어차피 같은 DB 장애로 실패했을 가능성이 높아, 롤백이 "부수 피해"라기보다
+   "같이 실패하는 게 자연스러운 상황"에 가깝다고 볼 수도 있다. 비용은 0이지만, 이
+   트레이드오프를 문서에 남기지 않으면 다음에 유사한 지적이 반복될 수 있다.
+2. `notifyForMonth` 호출부만 별도 `try/catch`로 감싸 예외를 로그로만 남기고 삼킨다
+   (`releaseQuietly`가 release 실패를 삼키는 것과 같은 패턴) — 대기자 알림은 "가능하면
+   보내는" 부가 기능이고 취소 자체의 성공 여부와는 독립적이어야 한다는 관점에 부합한다.
+   단점은 알림 저장 실패가 조용히 묻혀 관측이 어려워지고(로그 감시 없이는 알림 유실을
+   아무도 모른다), `NotificationService`가 이미 "실패 시 트랜잭션과 함께 롤백"을 공식
+   정책으로 문서화해 둔 상태라 이 호출부만 예외로 두면 프로젝트 전역 정책과 어긋난다.
+
+### 3. 🟡 Medium — `register()` 재활성화 경로는 동시 재등록 레이스에 대한 보호가 없음 → **수용(해결 방안 2번), 코드 변경 없음**
+
+"같은 학생이 취소 직후 두 번 등록 버튼을 거의 동시에 누르는" 매우 좁은 창에서만
+발생하고, 결과도 두 요청 모두 "등록됨"으로 수렴해 데이터 정합성이 깨지지 않는다.
+`@Version` 낙관적 락 도입은 이 도메인에 전례가 없어 비용 대비 이득이 낮다고 판단해
+지금은 그대로 둔다.
+
+**문제**: `SchoolCampWaitlistService.register`(`SchoolCampWaitlistService.java:351-370`)에서
+신규 삽입 경로(`newWaitlist`)는 `DataIntegrityViolationException`을 잡아 `SCHOOLCAMP_014`로
+변환하지만, 같은 학생이 이미 취소했던 같은 달 행을 재활성화하는 경로(`existing.isPresent()
+&& cancelledAt != null`)는 `(student_user_id, month)` 유니크 제약을 건드리지 않는 단순
+`UPDATE`라, 두 요청이 동시에 같은 취소된 행을 재활성화하려 하면 어느 쪽도 예외를 만나지
+않고 둘 다 201 응답을 받는다 — 마지막에 커밋된 값이 조용히 이긴다. 클라이언트 입장에서는
+자신이 받은 응답의 `registeredAt`이 실제로 DB에 남아있는 값과 다를 수 있다는 뜻이다.
+기획서는 "동시에 같은 학생이 같은 순간 두 번 등록을 시도하는 경우도 이 제약이 그대로
+막아준다"고 서술했는데, 이 문장은 신규 삽입 레이스에만 해당하고 재활성화 레이스는 실제로
+유니크 제약의 보호를 받지 못한다.
+
+**해결 방안**:
+1. 낙관적 락(`@Version`)을 `SchoolCampWaitlist`에 추가해 재활성화 `UPDATE`가 동시에
+   충돌하면 `OptimisticLockException`이 나도록 하고, 이를 잡아 동일하게 `SCHOOLCAMP_014`로
+   변환한다 — 신규 삽입 레이스와 정확히 같은 사용자 경험(409)을 준다는 장점이 있지만,
+   이 프로젝트에서 `@Version`을 쓰는 전례가 `Outing` 엔티티 하나뿐이라(스쿨캠핑 도메인에는
+   전례 없음) 새 패턴을 처음 들이는 비용이 든다.
+2. 실무 영향이 미미하다고 보고 그대로 둔다 — 재활성화 레이스는 "같은 학생이 취소 직후 두
+   번 등록 버튼을 거의 동시에 누르는" 매우 좁은 창에서만 발생하고, 결과도 기능적으로는
+   두 요청 모두 "등록됨" 상태로 수렴해(단지 `registeredAt` 값만 근소하게 다를 뿐) 데이터
+   정합성이 깨지는 수준은 아니다. 비용은 0이지만, 이 레이스를 인지하고 수용했다는 근거를
+   기획서나 이 문서에 남겨두지 않으면 나중에 같은 지적이 반복될 수 있다.
+
+### 4. 🟢 Low — `newWaitlist`의 `DataIntegrityViolationException` 캐치가 원인을 구분하지 않고 전부 `SCHOOLCAMP_014`로 변환함 → **수용(해결 방안 1번), 코드 변경 없음**
+
+기존 `updateApplication`의 동일 패턴과 일관성을 유지한다.
+
+**문제**: `SchoolCampWaitlistService.newWaitlist`(`SchoolCampWaitlistService.java:372-385`)는
+`waitlistRepository.save(waitlist)`에서 나는 `DataIntegrityViolationException`을 원인과
+무관하게 전부 `SCHOOLCAMP_014`(이미 대기 등록됨)로 변환한다. 실제로는
+`(student_user_id, month)` 유니크 제약 위반 외에도 `student_user_id`의 FK 제약 위반(예:
+요청 처리 중 해당 사용자 계정이 삭제되는 극단적 레이스) 등 다른 원인으로도 같은 예외
+타입이 날 수 있는데, 이 경우에도 클라이언트는 원인과 무관한 "이미 대기 등록되어 있습니다"
+메시지를 받는다.
+
+이는 `SchoolCampService.updateApplication`이 `memberRepository.saveAll`의
+`DataIntegrityViolationException`을 원인 구분 없이 `CONCURRENT_UPDATE_CONFLICT`로 변환하는
+기존 컨벤션과 일치한다 — 이번 diff가 새로 도입한 패턴은 아니다.
+
+**해결 방안**:
+1. 지금처럼 둔다 — `student_user_id`는 인증된 JWT에서 추출된 값이라 FK 위반이 실무에서
+   발생할 가능성이 극히 낮고, 기존 컨벤션과의 일관성이 더 중요하다고 볼 수 있다. 비용 0.
+2. 예외의 근본 원인(`getMostSpecificCause().getMessage()` 등)에 유니크 제약 이름
+   (`uq_waitlist_student_month`)이 포함돼 있는지 확인한 뒤에만 `SCHOOLCAMP_014`로
+   변환하고, 그 외에는 원래 예외를 다시 던지거나 범용 500으로 처리한다 — 원인 진단
+   정확도는 올라가지만, DB 드라이버가 노출하는 예외 메시지 포맷에 문자열 매칭으로
+   의존하게 돼 깨지기 쉽고(DB 벤더/버전 변경 시 문자열이 바뀔 수 있음), 이 프로젝트에
+   아직 이런 패턴의 전례가 없어 오히려 기존 컨벤션과 어긋난다.
+
+### 5. 🟢 Low — `register()`의 `waitlist` 지역 변수가 두 분기 모두에서 대입만 되고 이후 읽히지 않음 → **반영 완료**
+
+해결 방안 1번대로 `waitlist` 변수를 없애고, 재활성화 로직을 `reactivate` 메서드로
+분리했다. `newWaitlist`도 반환값을 쓰지 않아 `void`로 바꿨다.
+
+**문제**: `SchoolCampWaitlistService.register`에서 `if`/`else` 두 분기 모두 지역 변수
+`waitlist`에 값을 대입하지만(`waitlist = existing.get()` 또는 `waitlist =
+newWaitlist(...)`), 메서드의 반환값은 `thisMonth`와 매개변수 `now`만으로 만들어져
+`waitlist`를 전혀 읽지 않는다. 죽은 대입(dead store)이라 동작에는 영향이 없지만, 다음에
+이 코드를 보는 사람이 "이 변수가 응답에 쓰이나?"를 확인하려고 시간을 쓰게 만든다.
+
+**해결 방안**:
+1. `waitlist` 변수를 없애고 각 분기 안에서 필요한 호출만 남긴다(예: 재활성화 분기는
+   `existing.get()`의 결과를 지역 변수로 받아 그 블록 스코프 안에서만 쓰고, 신규 삽입
+   분기는 `newWaitlist(...)`의 반환값을 아예 버린다) — 가장 단순하고 위험이 없는 정리다.
+2. 지금처럼 두되, 향후 응답에 대기 등록의 PK나 상태를 더 담아야 할 때를 대비해 일부러
+   남겨둔 것이라면 그 의도를 주석으로 남긴다 — 실질적으로 지금 당장 쓰이지 않는 코드를
+   정당화하는 방식이라 1번보다 권장하지 않지만, "곧 필드가 늘어날 예정"이라는 확실한
+   근거가 있다면 선택지가 될 수 있다.
+
+## 확인했지만 문제 없었던 항목 (Critical 없음)
+
+- **데이터 모델**: `SchoolCampWaitlist` 엔티티와 `V14__add_schoolcamp_waitlist.sql`이
+  기획서와 정확히 일치한다 — `(student_user_id, month)` 유니크 제약(`uq_waitlist_student_
+  month`), `month`를 `YearMonth.atDay(1)`로 그 달의 1일에 저장, `cancelled_at` nullable로
+  soft-cancel(등록 시점의 `@CreationTimestamp` 대신 재활성화 때 `registeredAt`을 직접
+  갱신하는 이유까지 엔티티 javadoc에 명시). `SchoolCampApplication` 엔티티와 Lombok
+  어노테이션 조합(`@Getter @Setter @NoArgsConstructor(PROTECTED) @AllArgsConstructor
+  @Builder`), 필드 스타일까지 나란히 비교해 일치를 확인했다.
+- **엔드포인트 3개 무파라미터**: `POST/DELETE /api/v1/school-camps/waitlist`,
+  `GET /api/v1/school-camps/waitlist/me` 모두 `@AuthenticationPrincipal`만 받고
+  `@RequestBody`/`@RequestParam`이 전혀 없으며, "이번 달"은 컨트롤러에서
+  `LocalDateTime.now(KST)`로 매 요청마다 계산해 서비스에 넘긴다(같은 컨트롤러의
+  `cancelApplication`/`updateApplication`과 동일한 패턴).
+- **재등록 시 같은 행 재활성화**: `register()`가 `findByStudentUserIdAndMonth`로 취소
+  여부와 무관하게 기존 행을 먼저 찾고, 있으면 `cancelledAt = null`/`registeredAt = now`로
+  갱신 후 저장(새 행 생성 없음)하는 것을 코드와
+  `SchoolCampWaitlistServiceTest.Register.reactivatesCancelledRow` 테스트 양쪽에서
+  확인했다.
+- **신규 삽입 레이스 처리**: 동시에 같은 학생이 같은 순간 처음 등록을 시도하는 케이스는
+  `newWaitlist`의 `try/catch(DataIntegrityViolationException) → SCHOOLCAMP_014` 변환으로
+  막힌다. `updateApplication`의 `memberRepository.saveAll` 예외 변환과 동일한 패턴이고,
+  `throwsOnConcurrentRegisterRace` 테스트로 커버된다(재활성화 경로의 레이스는 별도
+  finding 3 참고).
+- **알림 트리거의 기준 달**: `SchoolCampService.cancelApplication`이
+  `waitlistService.notifyForMonth(YearMonth.from(application.getSession().getCampDate()))`를
+  호출해, 취소 시점의 "이번 달"이 아니라 세션의 캠핑 날짜가 속한 달로 정확히 조회한다.
+  `SchoolCampServiceTest`에 `verify(waitlistService).notifyForMonth(YearMonth.from(
+  application.getSession().getCampDate()))` 어서션이 추가돼 회귀도 잡는다.
+- **`releaseQuietly` 경로에 알림 미호출**: `SchoolCampSessionClaimService.java`는 diff에서
+  전혀 수정되지 않았고 `SchoolCampWaitlistService`를 주입받지 않는다.
+  `SchoolCampService.releaseQuietly`도 `sessionClaimService.release(sessionId)`만 호출할
+  뿐 `waitlistService`를 건드리지 않는다 — 다만 이를 검증하는 자동화된 회귀 테스트가
+  없다는 점은 finding 1로 별도 지적했다.
+- **월 중복 참여자 필터링 없음**: `register()`는 기존 참여 여부를 조회하지 않고,
+  `notifyForMonth`도 `findByMonthAndCancelledAtIsNull` 결과 전원에게 예외 없이 발송한다 —
+  기획서의 "확정" 사항과 일치.
+- **에러 코드**: `SCHOOLCAMP_014`(409 CONFLICT)/`SCHOOLCAMP_015`(404 NOT_FOUND) 모두 기획서
+  명세와 일치. `grep -n "SCHOOLCAMP_0"`로 001~015까지 순번 중복 없이 이어지는 것을
+  확인했다.
+- **`@PreAuthorize`**: 등록/취소/상태 조회 3개 엔드포인트 모두 `hasRole('STUDENT')`이고,
+  `SchoolCampAuthorizationTest`에 401(미인증)/403(TEACHER 역할) 케이스가 6개 추가돼
+  검증된다.
+- **N+1 가능성**: `notifyForMonth`의 순회는 `waitlist.getStudentUser().getId()`만 접근하고,
+  이는 지연 로딩된 프록시라도 식별자 접근만으로는 추가 SELECT를 유발하지 않는 Hibernate의
+  최적화 대상이라 N+1이 발생하지 않는다. 대기자 수 자체를 반복문으로 순회하며 알림을
+  저장하는 설계는 기획서가 "재학생 규모(300명)에서 문제 없다고 판단"해 의도적으로 수용한
+  사항이라 결함으로 잡지 않았다.
+- **트랜잭션 경계**: `register`/`cancel`/`notifyForMonth`는 `@Transactional`,
+  `getStatus`는 `@Transactional(readOnly = true)`로 적절히 구분돼 있다. `notifyForMonth`가
+  별도 빈(`SchoolCampWaitlistService`)의 메서드라 `cancelApplication`의 트랜잭션에
+  `REQUIRED`(기본값)로 합류하는 것도 자기 자신을 호출하는(self-invocation) 프록시 우회
+  문제 없이 정상 동작한다(트랜잭션 결합 자체의 리스크는 finding 2 참고).
+- **마이그레이션 스타일**: `V14`의 `KEY idx_waitlist_month_cancelled`/`CONSTRAINT
+  uq_waitlist_student_month` 네이밍, 이슈 번호를 단 Korean 헤더 주석, FK 선언 방식이
+  `V11`~`V13`과 일관된다.
+- **checkstyle/테스트 실행**: `./gradlew checkstyleMain checkstyleTest`가
+  `maxWarnings=0`(Google 스타일) 조건에서 경고 없이 통과했고, `./gradlew test --tests
+  "*SchoolCamp*"`도 전부 통과했다(Flyway `V14` 마이그레이션이 테스트 컨텍스트에서 정상
+  적용됨을 함께 확인).
+
+## 반영 시점
+
+코드 리뷰 직후(9단계) 작성. QA(10단계) 시작 전 이 문서가 먼저 존재해야 한다는
+[code-review-template.md](../../rules/code-review-template.md) 규칙을 따랐다.

--- a/docs/domain/schoolcamp/83-schoolcamp-waitlist-notification.md
+++ b/docs/domain/schoolcamp/83-schoolcamp-waitlist-notification.md
@@ -1,0 +1,288 @@
+# #83 스쿨캠핑 자리나면 알림받기(대기자 알림) 기능 — 기획서
+
+관련 이슈: [#83 스쿨캠핑 자리나면 알림받기(대기자 알림) 기능](https://github.com/GBSW-ReMake/GONE-server-V1/issues/83)
+마스터 기획서: [1_schoolcamp-domain.md](./1_schoolcamp-domain.md)의 "아직 결정 안 된 것" 절에서
+별도 이슈로 분리하기로 확정한 항목.
+선행 이슈: [#70](./70-schoolcamp-cancel-update.md)(취소, 완료·머지됨) — 이 이슈의 알림 발송
+트리거가 #70의 `cancelApplication`에 붙는다. `notification` 인프라(#59/#65)도 이미
+구현되어 있어 추가 선행 조건 없음.
+
+> **갱신(2026-08-21, 리뷰 반영)**: 초안은 대기 등록을 `month`(yyyyMM) 파라미터로 받아 특정
+> 미래 달을 미리 등록할 수 있게 설계했으나, 보스 리뷰에서 **"미래 달 미리 등록" 개념 자체를
+> 없애고 세 엔드포인트(등록/취소/조회) 전부 파라미터 없이 서버가 "지금 이 순간의 이번 달"만
+> 다루도록 구조를 단순화**하기로 확정했다. 아래 본문은 이 확정 구조를 기준으로 다시 썼다.
+
+## 개요/목적
+학생이 마감된(CLOSED) 날짜에 "자리나면 알림받기"를 등록해두면, **이번 달 안에서 어느
+세션이든** 취소가 발생할 때마다 알림을 받는 기능. 확정된 핵심 설계:
+
+- **대기 등록은 세션(날짜)도 아니고 임의의 달도 아니고, 항상 "지금 이 순간의 이번 달"
+  하나뿐이다.** 등록/취소/조회 세 엔드포인트 모두 `month` 같은 파라미터를 받지 않는다 —
+  서버가 요청 시점에 `YearMonth.now(KST)`로 계산한 달을 그대로 쓴다. UI는 마스터 기획서가
+  구상한 대로 캘린더의 마감된 날짜 카드에 "자리나면 알림받기" 버튼을 슬라이딩으로 붙이지만,
+  실제로 등록되는 건 그 버튼을 누른 시점의 "이번 달" 전체다 — 같은 달의 다른 마감된 카드도
+  동시에 "등록됨" 상태로 보인다(프론트 구현 시 참고). 다음 달 캘린더를 미리 보면서 다음 달
+  대기를 등록하는 시나리오는 이번 범위에 없다.
+- **월 중복 참여자(이미 이번 달 확정 참여 중인 학생)도 대기 등록 자체는 막지 않는다.**
+  실제로 신청을 시도하는 시점에 기존 `SCHOOLCAMP_003`이 알아서 막아준다 — 대기 등록
+  단계에서 미리 차단하는 추가 검증을 넣지 않는다.
+- **월 중복 참여자에게도 취소 알림은 그대로 보낸다(확정).** 그 학생이 신청을 시도하면
+  결국 `SCHOOLCAMP_003`으로 막히더라도, 알림 발송 시점에 "이미 참여 확정된 사람인지"를
+  걸러내는 별도 필터링은 넣지 않는다 — 단순하게 그 달 대기자 전원에게 동일하게 보낸다.
+- **알림은 그 달에 대기 등록한 사람 전원에게 동시에 간다**(선착순 1명에게만 보내는
+  방식 아님). 실제 신청 성사는 기존 세션 원자적 점유(`SchoolCampSessionClaimService.
+  claim`, #68)가 이미 레이스를 정리해주므로, 알림 발송 단계에서 순서를 가릴 필요가 없다.
+- **대기 등록은 알림을 한 번 보냈다고 자동으로 사라지지 않는다.** 본인이 직접 취소하기
+  전까지 계속 유효해서, 같은 달 안에 취소가 여러 번(다른 날짜에서도) 발생하면 그때마다
+  매번 알림을 받는다. "이번 달이 끝나면 자동 소멸"은 별도 배치로 구현하지 않는다 — 아래
+  "데이터 모델"의 조회 방식 자체가 달이 바뀌면 자연히 예전 등록을 더 이상 찾지 않게
+  되어 있어(항상 "지금 이 순간의 이번 달"로만 조회), 실질적으로 같은 효과를 낸다(상세는
+  아래 참고).
+- **유령 점유 회수 스케줄러(#84, 아직 미구현)로 세션이 반환될 때는 이번 이슈 범위에서
+  알림을 보내지 않는다.** #84가 실제로 구현될 때 이 이슈가 만드는
+  `SchoolCampWaitlistService.notifyForMonth(YearMonth)`를 그대로 재사용할지 검토하라는
+  메모를 남겨둔다.
+
+## 권한 모델
+- 등록/취소/상태 조회: `STUDENT`(마스터 기획서의 신청 권한과 동일 — 대기 개념도 학생
+  전용 기능이다)
+
+## 데이터 모델
+
+### `SchoolCampWaitlist` 엔티티 (`school_camp_waitlist` 테이블, 신규, `V14__add_
+schoolcamp_waitlist.sql`)
+한 학생의 "이번 달 자리나면 알림받기" 구독 1건.
+
+- `id`
+- `student_user_id` — 대기 등록한 학생(`User` FK)
+- `month` — 등록 시점에 계산한 "그 순간의 이번 달"(`DATE`, 항상 그 달의 1일로 저장 —
+  예: 2026년 4월에 등록 → `2026-04-01`). API 요청/응답에서 클라이언트가 이 값을 직접
+  지정하는 일은 없다 — 오직 서버가 등록 시점에 채워 넣고, 이후 조회/취소 시 "지금 이
+  순간의 이번 달"과 비교하는 내부 값이다
+- `registered_at` — 등록(또는 재등록) 시각
+- `cancelled_at` — 취소 시각(nullable). `null`이면 유효한 대기 등록, 값이 있으면 취소됨
+- **유니크 제약**: `(student_user_id, month)` — 학생 1명당 달 1개에 대해 행이 **딱 하나만
+  영구히 존재**한다(soft-delete로 매번 새 행을 쌓는 `SchoolCampApplication` 패턴과 다름).
+  같은 달 안에서 취소 후 재등록하면 새 행을 만들지 않고 **기존 행을 재활성화**한다
+  (`cancelled_at = null`, `registered_at`을 현재 시각으로 갱신) — 동시에 같은 학생이 같은
+  순간 두 번 등록을 시도하는 경우도 이 제약이 그대로 막아준다(#70의 `(application_id,
+  student_user_id)` 유니크 제약과 같은 이유 — `DataIntegrityViolationException`을 잡아
+  `SCHOOLCAMP_014`로 변환).
+
+**"달이 바뀌면 자연히 안 보이는" 이유**: 등록/취소/조회 세 엔드포인트가 전부 조회 조건에
+`month = YearMonth.now(KST)`를 그대로 쓴다. 4월에 등록한 행(`month = 2026-04-01`)은
+5월이 되는 순간부터 세 엔드포인트 중 어느 것도 그 행을 다시 찾지 않는다(5월 요청은
+`month = 2026-05-01`로 조회하므로) — 그래서 "이번 달이 끝나면 자동으로 해제된 것처럼
+보이는" 효과가 별도 배치 없이 자연히 나온다. 다만 이건 **조회가 안 될 뿐 DB 행 자체는
+`cancelled_at = null`인 채로 영구히 남는다**는 뜻이다(아래 "리스크" 절의 잔여 위험 참고).
+
+## 엔드포인트
+
+### 1. `POST /api/v1/school-camps/waitlist` — 이번 달 대기 등록
+**권한**: `STUDENT`
+
+**요청**: 바디 없음(파라미터 없음 — 서버가 요청 시점을 "이번 달"로 계산)
+
+**응답** (`201 Created`)
+```json
+{
+  "success": true,
+  "data": { "month": "202604", "registeredAt": "2026-04-03T09:12:00" },
+  "message": "자리나면 알림받기를 등록했습니다.",
+  "code": null
+}
+```
+
+**구현 로직**
+1. `thisMonth = YearMonth.now(KST)`
+2. `(student_user_id, thisMonth)`로 기존 행 조회
+   - 없으면 새 행 삽입(`cancelled_at = null`)
+   - 있고 `cancelled_at IS NULL`이면 이미 등록된 상태 → `409` `SCHOOLCAMP_014`
+   - 있고 `cancelled_at IS NOT NULL`이면 재활성화(`cancelled_at = null`,
+     `registered_at = now`)
+3. 삽입 시 유니크 제약 위반(`DataIntegrityViolationException`, 동시 등록 레이스) →
+   `409` `SCHOOLCAMP_014`로 변환
+
+**에러**
+- 이번 달에 이미 등록됨(동시 요청 포함) → `409` `SCHOOLCAMP_014`
+
+---
+
+### 2. `DELETE /api/v1/school-camps/waitlist` — 이번 달 대기 취소
+**권한**: `STUDENT`(본인 것만)
+
+**요청**: 바디/파라미터 없음
+
+**응답** (`200 OK`)
+```json
+{ "success": true, "data": null, "message": "자리나면 알림받기를 취소했습니다.", "code": null }
+```
+
+**구현 로직**
+1. `thisMonth = YearMonth.now(KST)`
+2. `(student_user_id, thisMonth)` + `cancelled_at IS NULL`로 조회, 없으면 `404`
+   `SCHOOLCAMP_015`
+3. `cancelled_at = now`로 갱신
+
+**에러**
+- 이번 달에 유효한 대기 등록이 없음 → `404` `SCHOOLCAMP_015`
+
+---
+
+### 3. `GET /api/v1/school-camps/waitlist/me` — 이번 달 대기 등록 상태 조회
+**권한**: `STUDENT`
+
+**요청**: 파라미터 없음 — 캘린더에서 "이번 달"을 보고 있는 프론트가 버튼을 "등록됨"/
+"등록 안 됨" 어느 상태로 그릴지 판단하는 용도
+
+**응답** (`200 OK`)
+```json
+{
+  "success": true,
+  "data": { "registered": true, "registeredAt": "2026-04-03T09:12:00" },
+  "message": "대기 등록 상태를 조회했습니다.",
+  "code": null
+}
+```
+등록 안 된 상태면 `{ "registered": false, "registeredAt": null }`.
+
+**구현 로직**
+1. `thisMonth = YearMonth.now(KST)`
+2. `(student_user_id, thisMonth)` + `cancelled_at IS NULL`로 조회
+3. 있으면 `registered: true` + `registeredAt`, 없으면 `registered: false` +
+   `registeredAt: null`
+
+---
+
+## 기존 로직 수정 — 취소 시 알림 발송 트리거
+
+### 트리거 위치: `SchoolCampService.cancelApplication`(#70)만
+`sessionRepository.release(sessionId)`를 호출하는 지점은 이 코드베이스에 **두 곳**이다.
+이번 이슈는 그중 하나에만 알림을 붙인다.
+
+| 호출 위치 | 의미 | 알림 발송 |
+|---|---|---|
+| `SchoolCampService.cancelApplication`(#70, 엔드포인트 4) | **실제로 확정됐던 신청**이 취소돼 날짜가 다시 열림 — 대기 중이던 학생 입장에서 진짜 "자리가 났다" | **O** (이번 이슈) |
+| `SchoolCampSessionClaimService.release`(#68, `releaseQuietly`를 통해 claim 직후 검증 실패 시 호출) | 새 신청이 세션을 막 점유했다가 선생님 검증 등 후속 검증에 실패해 **자기 자신의 점유를 되돌리는** 것 — 그 날짜는 애초에 다른 사람에게 "마감"으로 보인 적조차 없다(같은 요청 안에서 수 ms 만에 점유·해제가 끝남) | **X** |
+
+두 번째 경로에서 알림을 보내면, 실패한 신청 시도마다 대기자 전원에게 스팸성 알림이 갈 수
+있다 — 실제로는 아무도 그 날짜를 "잃었다"고 느낀 적이 없는데 "자리 났어요"라는 알림만
+반복해서 받는 상황이 된다. 그래서 `cancelApplication`에만 명시적으로 붙인다.
+
+`#84`(유령 점유 회수 스케줄러, 아직 미구현)가 다루는 `SchoolCampSessionClaimService.
+release` 호출도 마찬가지로 이번 범위에서 제외한다 — 다만 그 스케줄러가 실제로 세션을
+반환하는 시점은 "정말로 아무도 신청하지 않은 채 방치된 자리가 다시 열리는" 순간이라
+`cancelApplication`과 실질적으로 같은 성격의 이벤트다. #84 구현 시 이 이슈가 만드는
+`SchoolCampWaitlistService.notifyForMonth(YearMonth)`를 그대로 재사용할지 검토하라는
+메모를 남겨둔다(재사용 여부는 #84 기획 단계에서 다시 판단).
+
+### 변경 후 `cancelApplication` 동작
+```java
+@Transactional
+public void cancelApplication(Long applicantUserId, Long applicationId, LocalDateTime now) {
+  // ... 기존 소유권 확인, 당일 취소 금지 확인, cancelledAt 갱신 ...
+  sessionRepository.release(application.getSession().getId());
+  waitlistService.notifyForMonth(YearMonth.from(application.getSession().getCampDate()));
+}
+```
+`notifyForMonth(month)`는 **그 세션이 실제로 속한 달**(취소 시점의 "이번 달"이 아니라
+`session.campDate` 기준)로 대기자를 조회해, `cancelled_at IS NULL`인 `SchoolCampWaitlist`
+전원에게 `NotificationService.send(studentUserId, title, body,
+NotificationType.SCHOOLCAMP)`를 반복 호출한다. `cancelApplication`과 같은 트랜잭션 안에서
+실행한다 — 기존 신청 시 팀원 초대 알림(#68 엔드포인트 2의 9번)도 같은 방식으로 호출
+트랜잭션 안에서 저장되므로 패턴을 맞춘다.
+
+> ⚠️ **잔여 위험(인지, 수용)**: #70의 당일 취소 금지 검증은 `campDate == 오늘`만 막고,
+> `campDate`가 과거인 경우는 막지 않는다(코드 확인 완료) — 즉 이론상 학생이 지난달 세션의
+> 신청을 뒤늦게 취소할 수 있고, 그러면 `notifyForMonth`가 그 지난달로 조회를 시도한다. 이
+> 시점에 그 지난달에 등록됐다가 한 번도 취소되지 않은 오래된 `SchoolCampWaitlist` 행이
+> 남아있다면(위 "데이터 모델"의 "조회가 안 될 뿐 행은 남는다" 참고) 그 학생에게 뒤늦은
+> 알림이 갈 수 있다. 등록 자체가 항상 "요청 시점의 이번 달"로만 이뤄지고 클라이언트가
+> 임의의 과거/미래 달을 지정할 방법이 없어 실무에서 거의 발생하지 않을 극히 드문 경로로
+> 보고, 이번 범위에서 별도 가드(예: `session.campDate`의 달이 오늘의 달보다 과거면
+> 알림 생략)를 추가하지 않는다.
+
+**알림 문구**: `title = "스쿨캠핑 자리가 났어요!"`, `body = "{year}년 {month}월 스쿨캠핑에
+취소로 빈 자리가 생겼어요. 캘린더에서 확인하고 신청해보세요!"`(예: "2026년 4월 스쿨캠핑에
+취소로 빈 자리가 생겼어요. 캘린더에서 확인하고 신청해보세요!")
+
+## 신규 DTO
+```java
+public record SchoolCampWaitlistResponse(
+    String month,          // yyyyMM, 서버가 계산한 값(응답 전용, 요청 파라미터 아님)
+    LocalDateTime registeredAt
+) {}
+
+public record SchoolCampWaitlistStatusResponse(
+    boolean registered,
+    LocalDateTime registeredAt  // registered == false면 null
+) {}
+```
+
+## 신규 컴포넌트
+- `SchoolCampWaitlistService`(신규, `schoolcamp/service` 패키지): 등록/취소/상태 조회 +
+  `notifyForMonth(YearMonth)`. `SchoolCampSessionClaimService`처럼 관심사를 분리한
+  전용 서비스로 둔다 — `SchoolCampService`가 이미 700줄을 넘어 더 이상 책임을 늘리지
+  않는다.
+- `SchoolCampWaitlistRepository`(신규): `findByStudentUserIdAndMonth`,
+  `findByStudentUserIdAndMonthAndCancelledAtIsNull`,
+  `findByMonthAndCancelledAtIsNull`(알림 발송 대상 조회용)
+- 엔드포인트 3개는 기존 `SchoolCampController`에 추가한다 — 스쿨캠핑 전체를 다루는
+  컨트롤러가 이미 있어 별도 컨트롤러를 새로 만들 이유가 없다.
+
+## 에러 코드 (`SchoolCampErrorCode`에 추가, 014~015)
+14. `SCHOOLCAMP_014` (409) — 이미 대기 등록되어 있습니다
+15. `SCHOOLCAMP_015` (404) — 유효한 대기 등록을 찾을 수 없습니다
+
+## 영향 받는 기존 코드
+- 신규: `SchoolCampWaitlist`(엔티티), `SchoolCampWaitlistRepository`,
+  `SchoolCampWaitlistService`, `SchoolCampWaitlistResponse`/
+  `SchoolCampWaitlistStatusResponse`(DTO), `V14__add_schoolcamp_waitlist.sql`(마이그레이션)
+- 수정: `SchoolCampController`(엔드포인트 3개 추가), `SchoolCampService.cancelApplication`
+  (알림 트리거 1줄 추가, `SchoolCampWaitlistService` 주입), `SchoolCampErrorCode`(014~015
+  추가)
+- 변경 없음: `SchoolCampSessionClaimService`(`releaseQuietly` 경로는 건드리지 않음),
+  기존 엔드포인트 1~6번의 요청/응답 스키마
+
+## 리스크 및 고려사항
+- **API 설계 6원칙 체크**:
+  - 1번(한 가지를 잘하기): 등록/취소/조회 3개로 나눠 각각 한 가지 책임만 지게 했다.
+  - 2번(빠른 시작): 세 엔드포인트 모두 파라미터가 없어 요청/응답 예시만으로 바로 호출
+    가능하다.
+  - 5번(확장성): `notifyForMonth`가 그 달 대기자 전원을 순회하며 알림을 저장한다 —
+    재학생 규모(300명)에서 한 달에 대기자가 수십 명 수준일 걸로 예상돼 별도 배치/비동기
+    처리 없이 반복 저장으로 충분하다고 본다.
+  - 6번(하위 호환성): 새 엔드포인트만 추가하고 기존 엔드포인트는 건드리지 않아(트리거
+    추가는 `cancelApplication`의 응답 스키마에 영향 없음) 해당 없음.
+- **동시성**: 대기 등록의 유일한 경합 지점은 "같은 학생이 같은 순간 두 번 등록"뿐이고,
+  `(student_user_id, month)` 유니크 제약 + `DataIntegrityViolationException` 캐치로
+  #70의 `SCHOOLCAMP_011`과 동일한 패턴으로 처리한다.
+- **알림 스팸 가능성(인지, 수용)**: 한 달에 취소가 여러 번 발생하면 같은 학생이 여러 번
+  알림을 받는다 — 확정된 동작이다(대기 항목이 자동 소멸하지 않으므로).
+- **월 중복 참여자 필터링 없음(확정)**: 이미 이번 달 참여가 확정된 학생도 대기 등록·알림
+  수신 양쪽 다 막지 않는다. 신청을 시도하면 결국 `SCHOOLCAMP_003`으로 막힌다.
+- **과거 달 지연 취소로 인한 잔여 알림 위험(인지, 수용)**: 위 "기존 로직 수정" 절의 경고
+  박스 참고 — 별도 가드를 추가하지 않는다.
+- **오래된 대기 행이 DB에 영구히 남음(인지, 수용)**: 조회 조건이 항상 "이번 달"이라 지난
+  달 행은 다시 조회되지 않지만, 실제로 `cancelled_at`을 채워 정리하는 배치는 없다 —
+  단순히 안 보일 뿐 테이블에는 계속 쌓인다. 재학생 규모에서 몇 년 누적돼도 문제 될 양은
+  아니라고 보고 이번 범위에서 정리 배치를 만들지 않는다.
+- **FCM 등 실제 푸시 인프라는 여전히 없다**: `NotificationService.send`가 하는 일은
+  DB에 알림 레코드를 저장하는 것뿐이다(#59/#65와 동일) — 실시간 푸시가 아니라 앱 내
+  알림함에 쌓이는 방식이다. 이 이슈도 같은 한계를 그대로 물려받는다.
+- **Notion API 명세서**: 머지 후(17단계) 새 엔드포인트 3개를 반영해야 한다.
+
+## 테스트
+- `SchoolCampWaitlistService`:
+  - 등록: 첫 등록 성공, 이미 등록된 상태에서 재등록 시 `SCHOOLCAMP_014`, 취소했던 달
+    안에서 재등록 시 기존 행이 재활성화되는지(`cancelled_at`이 다시 `null`이 되는지)
+  - 취소: 정상 취소, 등록된 적 없는 상태에서 취소 시 `SCHOOLCAMP_015`
+  - 상태 조회: 등록됨/등록 안 됨/취소됨(등록 안 됨과 동일하게 취급되는지) 각각 확인
+  - `notifyForMonth`: 그 달 활성 대기자 전원에게 `NotificationService.send`가 호출되는지,
+    취소된(비활성) 대기 항목은 대상에서 빠지는지, 다른 달 대기자는 영향받지 않는지,
+    이미 이번 달 참여 확정된 학생도 대상에서 빠지지 않는지(필터링 없음 확인)
+- `SchoolCampService.cancelApplication`(#70 회귀 + 신규 검증):
+  - 취소 성공 시 `notifyForMonth`가 정확히 그 세션이 속한 달로 호출되는지
+- **`SchoolCampSessionClaimService.release`/`releaseQuietly` 경로는 알림을 보내지 않는지
+  확인하는 회귀 테스트**(이번 이슈에서 가장 중요한 케이스) — #68의 클레임 실패 롤백
+  시나리오를 재현해 `notifyForMonth`가 호출되지 않음을 검증한다.

--- a/postman/collections/gone-schoolcamp.postman_collection.json
+++ b/postman/collections/gone-schoolcamp.postman_collection.json
@@ -1,7 +1,7 @@
 {
   "info": {
     "name": "GONE - SchoolCamp API",
-    "description": "스쿨캠핑(SchoolCamp) 도메인 API 컬렉션. #67(세션 등록 + 캘린더 조회) 2개 + #68(신청) 1개 + #70(취소/수정) 2개 + #69(참여 내역 목록/상세) 2개, 총 7개 엔드포인트를 다룹니다.\n\n**폴더 구성**: \"사전 준비\" 폴더(관리자/학생/팀원 로그인 + 토큰 준비) 뒤에 최상위 \"스쿨캠핑 날짜 등록\"/\"스쿨캠핑 캘린더 조회\"/\"스쿨캠핑 신청\"/\"스쿨캠핑 신청 취소\"/\"스쿨캠핑 신청 수정\" → \"에러 케이스\" 폴더(관련 없는 순서로 무엇이든 실행 가능).\n\n**사전 준비**: `teacherLoginId`(teacher1)/`studentLoginId`(user1)/`loginId`(testuser01, #68 팀원용)/`loginId2`(testuser02, #70 월중복 시나리오용) 테스트 계정이 DB에 있어야 합니다. 관리자/학생 역할 부여 API가 아직 없어(#15 진행 중), `teacher1` 계정에 ADMIN 역할을, `testuser01`/`testuser02` 계정에 STUDENT 역할을 DB에서 직접 부여해야 각각 \"스쿨캠핑 날짜 등록\"과 팀원 관련 요청이 성공합니다(user_role 테이블에 직접 INSERT, 실행 후 원복 권장). #69의 선생님 조회(16~17단계)를 실행하려면 `testuser01` 계정에 TEACHER 역할도 추가로 임시 부여해야 합니다(같은 방식).\n\n**검증 폴더**: 두 엔드포인트를 처음부터 끝까지 순서대로 확인하는 \"#67 세션 등록 + 캘린더 조회 확인\" 폴더, 신청 엔드포인트의 정상/에러 시나리오를 재현하는 \"#68 스쿨캠핑 신청 확인\" 폴더, 취소/수정 시나리오를 재현하는 \"#70 스쿨캠핑 신청 취소/수정 확인\" 폴더, 참여 내역 목록/상세와 참여자 아님 403을 재현하는 \"#69 스쿨캠핑 참여 내역 확인\" 폴더를 각각 추가했습니다. #70 폴더의 \"당일 취소 금지\" 검증 요청은 실행 시점의 로컬 머신 날짜(KST 가정)를 pre-request 스크립트로 계산해 오늘 날짜 세션을 등록하므로, 금/토/일에 실행하면 그 등록 요청 자체가 400으로 실패한다.",
+    "description": "스쿨캠핑(SchoolCamp) 도메인 API 컬렉션. #67(세션 등록 + 캘린더 조회) 2개 + #68(신청) 1개 + #70(취소/수정) 2개 + #69(참여 내역 목록/상세) 2개 + #83(자리나면 알림받기 등록/취소/조회) 3개, 총 10개 엔드포인트를 다룹니다.\n\n**폴더 구성**: \"사전 준비\" 폴더(관리자/학생/팀원 로그인 + 토큰 준비) 뒤에 최상위 \"스쿨캠핑 날짜 등록\"/\"스쿨캠핑 캘린더 조회\"/\"스쿨캠핑 신청\"/\"스쿨캠핑 신청 취소\"/\"스쿨캠핑 신청 수정\"/\"스쿨캠핑 자리나면 알림받기 등록\"/\"스쿨캠핑 자리나면 알림받기 취소\"/\"스쿨캠핑 자리나면 알림받기 상태 조회\" → \"에러 케이스\" 폴더(관련 없는 순서로 무엇이든 실행 가능).\n\n**사전 준비**: `teacherLoginId`(teacher1)/`studentLoginId`(user1)/`loginId`(testuser01, #68 팀원용)/`loginId2`(testuser02, #70 월중복 시나리오용) 테스트 계정이 DB에 있어야 합니다. 관리자/학생 역할 부여 API가 아직 없어(#15 진행 중), `teacher1` 계정에 ADMIN 역할을, `testuser01`/`testuser02` 계정에 STUDENT 역할을 DB에서 직접 부여해야 각각 \"스쿨캠핑 날짜 등록\"과 팀원 관련 요청이 성공합니다(user_role 테이블에 직접 INSERT, 실행 후 원복 권장). #69의 선생님 조회(16~17단계)를 실행하려면 `testuser01` 계정에 TEACHER 역할도 추가로 임시 부여해야 합니다(같은 방식).\n\n**검증 폴더**: 두 엔드포인트를 처음부터 끝까지 순서대로 확인하는 \"#67 세션 등록 + 캘린더 조회 확인\" 폴더, 신청 엔드포인트의 정상/에러 시나리오를 재현하는 \"#68 스쿨캠핑 신청 확인\" 폴더, 취소/수정 시나리오를 재현하는 \"#70 스쿨캠핑 신청 취소/수정 확인\" 폴더, 참여 내역 목록/상세와 참여자 아님 403을 재현하는 \"#69 스쿨캠핑 참여 내역 확인\" 폴더, 대기 등록 후 다른 학생의 취소가 실제로 알림을 발송시키는지(그리고 releaseQuietly 경로는 발송시키지 않는지는 QA 문서에서 별도 확인) 재현하는 \"#83 스쿨캠핑 자리나면 알림받기 확인\" 폴더를 각각 추가했습니다. #70 폴더의 \"당일 취소 금지\" 검증 요청은 실행 시점의 로컬 머신 날짜(KST 가정)를 pre-request 스크립트로 계산해 오늘 날짜 세션을 등록하므로, 금/토/일에 실행하면 그 등록 요청 자체가 400으로 실패한다. \"#83 스쿨캠핑 자리나면 알림받기 확인\" 폴더의 campDateWaitlistTrigger도 실행 시점의 \"이번 달\" 안의 미등록 평일 날짜로 미리 맞춰둬야 한다(자동 계산 아님, 환경 변수 직접 수정).",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
   },
   "item": [
@@ -567,6 +567,124 @@
           ]
         },
         "description": "참여 신청 1건의 상세(담당 선생님/팀원 전체)를 조회한다(#69). STUDENT/TEACHER 둘 다 호출 가능. 본인이 그 신청의 참여자(대표, 팀원, 또는 담당 선생님)가 아니면 403 SCHOOLCAMP_013. 취소된 신청도 조회할 수 있다. 실행 전에 schoolCampApplicationId가 studentAccessToken/memberAccessToken 소유(또는 참여 중인) 신청을 가리켜야 한다 — 상세 순서는 \"#69 스쿨캠핑 참여 내역 확인\" 폴더 참고."
+      },
+      "response": [],
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "type": "text/javascript",
+            "exec": [
+              "pm.test(\"200 OK\", function () {",
+              "    pm.response.to.have.status(200);",
+              "});"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "스쿨캠핑 자리나면 알림받기 등록",
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Authorization",
+            "value": "Bearer {{studentAccessToken}}"
+          }
+        ],
+        "url": {
+          "raw": "{{baseUrl}}/api/v1/school-camps/waitlist",
+          "host": [
+            "{{baseUrl}}"
+          ],
+          "path": [
+            "api",
+            "v1",
+            "school-camps",
+            "waitlist"
+          ]
+        },
+        "description": "이번 달(요청 시점 기준) \"자리나면 알림받기\"를 등록한다(#83). 파라미터 없음 — 서버가 항상 \"지금 이 순간의 이번 달\"만 다룬다. 이미 취소된 적 있는 같은 달 행이 있으면 새로 만들지 않고 재활성화한다. 201 Created."
+      },
+      "response": [],
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "type": "text/javascript",
+            "exec": [
+              "pm.test(\"201 Created\", function () {",
+              "    pm.response.to.have.status(201);",
+              "});"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "스쿨캠핑 자리나면 알림받기 취소",
+      "request": {
+        "method": "DELETE",
+        "header": [
+          {
+            "key": "Authorization",
+            "value": "Bearer {{studentAccessToken}}"
+          }
+        ],
+        "url": {
+          "raw": "{{baseUrl}}/api/v1/school-camps/waitlist",
+          "host": [
+            "{{baseUrl}}"
+          ],
+          "path": [
+            "api",
+            "v1",
+            "school-camps",
+            "waitlist"
+          ]
+        },
+        "description": "이번 달 \"자리나면 알림받기\"를 취소한다(#83). 파라미터 없음. 200 OK, data는 null. 실행 전에 등록이 먼저 되어 있어야 한다."
+      },
+      "response": [],
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "type": "text/javascript",
+            "exec": [
+              "pm.test(\"200 OK\", function () {",
+              "    pm.response.to.have.status(200);",
+              "});"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "스쿨캠핑 자리나면 알림받기 상태 조회",
+      "request": {
+        "method": "GET",
+        "header": [
+          {
+            "key": "Authorization",
+            "value": "Bearer {{studentAccessToken}}"
+          }
+        ],
+        "url": {
+          "raw": "{{baseUrl}}/api/v1/school-camps/waitlist/me",
+          "host": [
+            "{{baseUrl}}"
+          ],
+          "path": [
+            "api",
+            "v1",
+            "school-camps",
+            "waitlist",
+            "me"
+          ]
+        },
+        "description": "이번 달 \"자리나면 알림받기\" 등록 상태를 조회한다(#83). 파라미터 없음. registered=true/false와 registeredAt을 반환한다."
       },
       "response": [],
       "event": [
@@ -1247,6 +1365,222 @@
             }
           },
           "response": []
+        },
+        {
+          "name": "이번 달에 이미 등록된 상태에서 재등록 시도 → 409 SCHOOLCAMP_014 (#83)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{studentAccessToken}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/school-camps/waitlist",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "school-camps",
+                "waitlist"
+              ]
+            },
+            "description": "실행 전에 '스쿨캠핑 자리나면 알림받기 등록'을 먼저 실행해 이번 달 등록이 유효한 상태여야 한다."
+          },
+          "response": [],
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test(\"409 SCHOOLCAMP_014 (#83)\", function () {",
+                  "    pm.response.to.have.status(409);",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "등록된 적 없는 상태에서 대기 취소 시도 → 404 SCHOOLCAMP_015 (#83)",
+          "request": {
+            "method": "DELETE",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{studentAccessToken}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/school-camps/waitlist",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "school-camps",
+                "waitlist"
+              ]
+            },
+            "description": "실행 전에 이번 달 대기 등록이 없는(또는 이미 취소된) 상태여야 한다."
+          },
+          "response": [],
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test(\"404 SCHOOLCAMP_015 (#83)\", function () {",
+                  "    pm.response.to.have.status(404);",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "TEACHER 계정으로 대기 등록 시도 → 403 (#83, STUDENT 전용)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{teacherAccessToken}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/school-camps/waitlist",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "school-camps",
+                "waitlist"
+              ]
+            }
+          },
+          "response": [],
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test(\"403 (#83, STUDENT 전용)\", function () {",
+                  "    pm.response.to.have.status(403);",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "인증 없이 대기 등록 시도 → 401 (#83)",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/school-camps/waitlist",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "school-camps",
+                "waitlist"
+              ]
+            }
+          },
+          "response": [],
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test(\"401 (#83)\", function () {",
+                  "    pm.response.to.have.status(401);",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "인증 없이 대기 취소 시도 → 401 (#83)",
+          "request": {
+            "method": "DELETE",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/school-camps/waitlist",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "school-camps",
+                "waitlist"
+              ]
+            }
+          },
+          "response": [],
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test(\"401 (#83)\", function () {",
+                  "    pm.response.to.have.status(401);",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "인증 없이 대기 상태 조회 시도 → 401 (#83)",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/school-camps/waitlist/me",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "school-camps",
+                "waitlist",
+                "me"
+              ]
+            }
+          },
+          "response": [],
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test(\"401 (#83)\", function () {",
+                  "    pm.response.to.have.status(401);",
+                  "});"
+                ]
+              }
+            }
+          ]
         }
       ]
     },
@@ -4625,6 +4959,537 @@
                   "    pm.response.to.have.status(200);",
                   "    pm.expect(pm.response.json().data.myRole).to.eql(\"TEACHER\");",
                   "});"
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "#83 스쿨캠핑 자리나면 알림받기 확인",
+      "item": [
+        {
+          "name": "1. 학생 로그인 (user1)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/auth/login",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "auth",
+                "login"
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\"identifier\": \"{{studentLoginId}}\", \"password\": \"{{studentPassword}}\"}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            }
+          },
+          "response": [],
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test(\"200 OK\", function () { pm.response.to.have.status(200); });",
+                  "if (pm.response.code === 200) {",
+                  "    const body = pm.response.json();",
+                  "    if (body.success && body.data) {",
+                  "        pm.environment.set(\"studentAccessToken\", body.data.accessToken);",
+                  "    }",
+                  "}"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "2. 등록 전 상태 조회 → registered:false",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{studentAccessToken}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/school-camps/waitlist/me",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "school-camps",
+                "waitlist",
+                "me"
+              ]
+            }
+          },
+          "response": [],
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test(\"200 OK\", function () { pm.response.to.have.status(200); });",
+                  "pm.test(\"registered:false\", function () {",
+                  "    pm.expect(pm.response.json().data.registered).to.eql(false);",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "3. 이번 달 대기 등록 → 201",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{studentAccessToken}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/school-camps/waitlist",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "school-camps",
+                "waitlist"
+              ]
+            }
+          },
+          "response": [],
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test(\"201 Created\", function () { pm.response.to.have.status(201); });"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "4. 등록 후 상태 조회 → registered:true",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{studentAccessToken}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/school-camps/waitlist/me",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "school-camps",
+                "waitlist",
+                "me"
+              ]
+            }
+          },
+          "response": [],
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test(\"200 OK\", function () { pm.response.to.have.status(200); });",
+                  "pm.test(\"registered:true\", function () {",
+                  "    pm.expect(pm.response.json().data.registered).to.eql(true);",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "5. 중복 등록 시도 → 409 SCHOOLCAMP_014",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{studentAccessToken}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/school-camps/waitlist",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "school-camps",
+                "waitlist"
+              ]
+            }
+          },
+          "response": [],
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test(\"409\", function () { pm.response.to.have.status(409); });"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "6. 관리자 로그인 (teacher1, ADMIN)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/auth/login",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "auth",
+                "login"
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\"identifier\": \"{{teacherLoginId}}\", \"password\": \"{{teacherPassword}}\"}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            }
+          },
+          "response": [],
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test(\"200 OK\", function () { pm.response.to.have.status(200); });",
+                  "if (pm.response.code === 200) {",
+                  "    const body = pm.response.json();",
+                  "    if (body.success && body.data) {",
+                  "        pm.environment.set(\"teacherAccessToken\", body.data.accessToken);",
+                  "    }",
+                  "}"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "7. 날짜 등록 (campDateWaitlistTrigger, 이번 달)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{teacherAccessToken}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/school-camps",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "school-camps"
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\"campDates\": [\"{{campDateWaitlistTrigger}}\"]}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "description": "campDateWaitlistTrigger는 이 컬렉션을 실행하는 시점의 \"이번 달\" 안의 미등록 평일 날짜로 미리 맞춰둬야 한다 - 자리나면 알림받기는 세션의 캠핑 날짜가 속한 달로 대기자를 조회하므로, 2번에서 등록한 대기와 같은 달이어야 알림이 발송된다."
+          },
+          "response": [],
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test(\"201 Created\", function () { pm.response.to.have.status(201); });",
+                  "if (pm.response.code === 201) {",
+                  "    const body = pm.response.json();",
+                  "    pm.environment.set(\"schoolCampSessionIdWaitlist\", body.data[0].sessionId);",
+                  "}"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "8. 팀원2 학생 로그인 (testuser02)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/auth/login",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "auth",
+                "login"
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\"identifier\": \"{{loginId2}}\", \"password\": \"{{password2}}\"}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            }
+          },
+          "response": [],
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test(\"200 OK\", function () { pm.response.to.have.status(200); });",
+                  "if (pm.response.code === 200) {",
+                  "    const body = pm.response.json();",
+                  "    if (body.success && body.data) {",
+                  "        pm.environment.set(\"member2AccessToken\", body.data.accessToken);",
+                  "    }",
+                  "}"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "9. 신청 (testuser02, 7번 세션)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{member2AccessToken}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/school-camps/{{schoolCampSessionIdWaitlist}}/applications",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "school-camps",
+                "{{schoolCampSessionIdWaitlist}}",
+                "applications"
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\"teacherName\": \"QA선생님\"}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            }
+          },
+          "response": [],
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test(\"201 Created\", function () { pm.response.to.have.status(201); });",
+                  "if (pm.response.code === 201) {",
+                  "    const body = pm.response.json();",
+                  "    pm.environment.set(\"schoolCampApplicationIdWaitlist\", body.data.id);",
+                  "}"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "10. 신청 취소 → 1번 학생에게 알림 발송(서버 DB로 별도 확인, QA 문서 참고)",
+          "request": {
+            "method": "DELETE",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{member2AccessToken}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/school-camps/applications/{{schoolCampApplicationIdWaitlist}}",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "school-camps",
+                "applications",
+                "{{schoolCampApplicationIdWaitlist}}"
+              ]
+            },
+            "description": "이 취소로 SchoolCampService.cancelApplication이 waitlistService.notifyForMonth를 호출해, 2/3번에서 등록한 1번 학생(user1)에게 \"스쿨캠핑 자리가 났어요!\" 알림이 저장된다. 조회 API가 아직 없어(#59/#65 범위 밖) Postman에서 직접 확인할 수는 없다 - 실제 발송 여부는 QA 문서(83-schoolcamp-waitlist-notification-QA.md)에서 DB로 확인했다."
+          },
+          "response": [],
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test(\"200 OK\", function () { pm.response.to.have.status(200); });"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "11. 상태 재조회(1번 학생) → 알림 받아도 등록은 자동 해제되지 않음",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{studentAccessToken}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/school-camps/waitlist/me",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "school-camps",
+                "waitlist",
+                "me"
+              ]
+            }
+          },
+          "response": [],
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test(\"200 OK\", function () { pm.response.to.have.status(200); });",
+                  "pm.test(\"registered:true 유지\", function () {",
+                  "    pm.expect(pm.response.json().data.registered).to.eql(true);",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "12. 정리: 대기 취소",
+          "request": {
+            "method": "DELETE",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{studentAccessToken}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/school-camps/waitlist",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "school-camps",
+                "waitlist"
+              ]
+            }
+          },
+          "response": [],
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test(\"200 OK\", function () { pm.response.to.have.status(200); });"
                 ]
               }
             }

--- a/postman/environments/gone-local-dev.postman_environment.json
+++ b/postman/environments/gone-local-dev.postman_environment.json
@@ -336,6 +336,24 @@
       "value": "20260902",
       "type": "default",
       "enabled": true
+    },
+    {
+      "key": "campDateWaitlistTrigger",
+      "value": "20260827",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "schoolCampSessionIdWaitlist",
+      "value": "",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "schoolCampApplicationIdWaitlist",
+      "value": "",
+      "type": "default",
+      "enabled": true
     }
   ]
 }

--- a/src/main/java/com/remake/gone/schoolcamp/controller/SchoolCampController.java
+++ b/src/main/java/com/remake/gone/schoolcamp/controller/SchoolCampController.java
@@ -10,7 +10,10 @@ import com.remake.gone.schoolcamp.dto.SchoolCampCalendarResponse;
 import com.remake.gone.schoolcamp.dto.SchoolCampMyParticipationResponse;
 import com.remake.gone.schoolcamp.dto.SchoolCampMyParticipationSummaryResponse;
 import com.remake.gone.schoolcamp.dto.SchoolCampSessionResponse;
+import com.remake.gone.schoolcamp.dto.SchoolCampWaitlistResponse;
+import com.remake.gone.schoolcamp.dto.SchoolCampWaitlistStatusResponse;
 import com.remake.gone.schoolcamp.service.SchoolCampService;
+import com.remake.gone.schoolcamp.service.SchoolCampWaitlistService;
 import jakarta.validation.Valid;
 import java.time.LocalDateTime;
 import java.time.YearMonth;
@@ -43,6 +46,7 @@ public class SchoolCampController {
   private static final ZoneId KST = ZoneId.of("Asia/Seoul");
 
   private final SchoolCampService schoolCampService;
+  private final SchoolCampWaitlistService schoolCampWaitlistService;
 
   /**
    * 다음 달 스쿨캠핑 가능 날짜를 관리자가 일괄 등록합니다.
@@ -181,5 +185,55 @@ public class SchoolCampController {
     SchoolCampApplicationResponse response =
         schoolCampService.updateApplication(principal.userId(), applicationId, request);
     return ApiResponse.success(response, "신청 정보가 수정되었습니다.");
+  }
+
+  /**
+   * 이번 달 "자리나면 알림받기"를 등록합니다. 파라미터 없이 요청 시점의 "이번 달"만
+   * 다룹니다(#83). {@code STUDENT} 역할만 등록할 수 있습니다.
+   *
+   * @param principal 인증 필터가 Access Token에서 추출한 현재 사용자
+   * @return 등록된 대기 정보
+   */
+  @PostMapping("/waitlist")
+  @ResponseStatus(HttpStatus.CREATED)
+  @PreAuthorize("hasRole('STUDENT')")
+  public ApiResponse<SchoolCampWaitlistResponse> registerWaitlist(
+      @AuthenticationPrincipal UserPrincipal principal
+  ) {
+    SchoolCampWaitlistResponse response =
+        schoolCampWaitlistService.register(principal.userId(), LocalDateTime.now(KST));
+    return ApiResponse.success(response, "자리나면 알림받기를 등록했습니다.");
+  }
+
+  /**
+   * 이번 달 "자리나면 알림받기"를 취소합니다(#83).
+   *
+   * @param principal 인증 필터가 Access Token에서 추출한 현재 사용자
+   * @return 데이터 없는 성공 응답
+   */
+  @DeleteMapping("/waitlist")
+  @PreAuthorize("hasRole('STUDENT')")
+  public ApiResponse<Void> cancelWaitlist(
+      @AuthenticationPrincipal UserPrincipal principal
+  ) {
+    schoolCampWaitlistService.cancel(principal.userId(), LocalDateTime.now(KST));
+    return ApiResponse.success(null, "자리나면 알림받기를 취소했습니다.");
+  }
+
+  /**
+   * 이번 달 "자리나면 알림받기" 등록 상태를 조회합니다(#83). 캘린더에서 버튼을 "등록됨"/
+   * "등록 안 됨" 어느 상태로 그릴지 판단하는 용도입니다.
+   *
+   * @param principal 인증 필터가 Access Token에서 추출한 현재 사용자
+   * @return 등록 상태
+   */
+  @GetMapping("/waitlist/me")
+  @PreAuthorize("hasRole('STUDENT')")
+  public ApiResponse<SchoolCampWaitlistStatusResponse> getWaitlistStatus(
+      @AuthenticationPrincipal UserPrincipal principal
+  ) {
+    SchoolCampWaitlistStatusResponse response =
+        schoolCampWaitlistService.getStatus(principal.userId(), LocalDateTime.now(KST));
+    return ApiResponse.success(response, "대기 등록 상태를 조회했습니다.");
   }
 }

--- a/src/main/java/com/remake/gone/schoolcamp/dto/SchoolCampWaitlistResponse.java
+++ b/src/main/java/com/remake/gone/schoolcamp/dto/SchoolCampWaitlistResponse.java
@@ -1,0 +1,11 @@
+package com.remake.gone.schoolcamp.dto;
+
+import java.time.LocalDateTime;
+
+/**
+ * 스쿨캠핑 "자리나면 알림받기" 등록 응답.
+ *
+ * @param month        서버가 계산한 "이번 달"({@code yyyyMM}), 요청 파라미터 아님
+ * @param registeredAt 등록(또는 재등록) 시각
+ */
+public record SchoolCampWaitlistResponse(String month, LocalDateTime registeredAt) {}

--- a/src/main/java/com/remake/gone/schoolcamp/dto/SchoolCampWaitlistStatusResponse.java
+++ b/src/main/java/com/remake/gone/schoolcamp/dto/SchoolCampWaitlistStatusResponse.java
@@ -1,0 +1,11 @@
+package com.remake.gone.schoolcamp.dto;
+
+import java.time.LocalDateTime;
+
+/**
+ * 스쿨캠핑 "자리나면 알림받기" 이번 달 등록 상태 조회 응답.
+ *
+ * @param registered   이번 달 유효한 대기 등록이 있는지 여부
+ * @param registeredAt 등록 시각. {@code registered == false}면 {@code null}
+ */
+public record SchoolCampWaitlistStatusResponse(boolean registered, LocalDateTime registeredAt) {}

--- a/src/main/java/com/remake/gone/schoolcamp/entity/SchoolCampWaitlist.java
+++ b/src/main/java/com/remake/gone/schoolcamp/entity/SchoolCampWaitlist.java
@@ -1,0 +1,61 @@
+package com.remake.gone.schoolcamp.entity;
+
+import com.remake.gone.user.entity.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * 스쿨캠핑 "자리나면 알림받기" 대기 등록 엔티티.
+ *
+ * <p>{@code db/migration/V14__add_schoolcamp_waitlist.sql}의 {@code school_camp_waitlist}
+ * 테이블에 대응한다. 학생 1명의 "지금 이 순간의 이번 달" 대기 등록 1건을 나타낸다 — 세션(날짜)
+ * 단위가 아니라 달 단위다({@code 83-schoolcamp-waitlist-notification.md} 참고).
+ *
+ * <p>{@code (student_user_id, month)} 유니크 제약(V14)으로 학생 1명당 달 1개에 대해 행이 딱
+ * 하나만 영구히 존재한다 — 같은 달 안에서 취소 후 재등록하면 새 행을 만들지 않고 기존 행을
+ * 재활성화한다({@link #cancelledAt}을 {@code null}로, {@link #registeredAt}을 갱신).
+ */
+@Entity
+@Table(name = "school_camp_waitlist")
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class SchoolCampWaitlist {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "student_user_id", nullable = false)
+  private User studentUser;
+
+  /** 등록 시점에 계산한 "그 순간의 이번 달", 항상 그 달의 1일로 저장한다. */
+  @Column(name = "month", nullable = false)
+  private LocalDate month;
+
+  /** 등록(또는 재등록) 시각. {@code @CreationTimestamp}를 쓰지 않는다 — 재활성화 시 직접 갱신한다. */
+  @Column(name = "registered_at", nullable = false)
+  private LocalDateTime registeredAt;
+
+  /** 취소 시각. {@code null}이면 유효한 대기 등록. */
+  @Column(name = "cancelled_at")
+  private LocalDateTime cancelledAt;
+}

--- a/src/main/java/com/remake/gone/schoolcamp/exception/SchoolCampErrorCode.java
+++ b/src/main/java/com/remake/gone/schoolcamp/exception/SchoolCampErrorCode.java
@@ -9,7 +9,7 @@ import org.springframework.http.HttpStatus;
  * <p>코드 네이밍 규칙: {@code SCHOOLCAMP_NNN} (NNN은 3자리 순번). 번호는 마스터 기획서
  * (`docs/domain/schoolcamp/1_schoolcamp-domain.md`)의 전체 목록 중 실제로 구현되는 순서대로
  * 채운다 — #67에서는 005/006만 쓰였고, #68은 001/002/003/004/008을, #70은
- * 007/009/010/011을, #69는 012/013을 쓴다.
+ * 007/009/010/011을, #69는 012/013을, #83은 014/015를 쓴다.
  *
  * @see ErrorCode
  */
@@ -119,7 +119,22 @@ public enum SchoolCampErrorCode implements ErrorCode {
    * 이 코드는 읽기 전용 상세 조회에서, 대표든 팀원이든 참여자가 아니면 쓴다.
    */
   NOT_APPLICATION_PARTICIPANT(
-      HttpStatus.FORBIDDEN, "SCHOOLCAMP_013", "본인이 참여한 신청만 조회할 수 있습니다.");
+      HttpStatus.FORBIDDEN, "SCHOOLCAMP_013", "본인이 참여한 신청만 조회할 수 있습니다."),
+
+  /**
+   * 이번 달에 이미 유효한 "자리나면 알림받기" 대기 등록이 있습니다({@code #83}).
+   *
+   * <p>{@code (student_user_id, month)} 유니크 제약(V14) 위반({@code DataIntegrityViolation
+   * Exception}, 동시 등록 레이스)도 이 코드로 변환한다.
+   */
+  ALREADY_REGISTERED_WAITLIST(HttpStatus.CONFLICT, "SCHOOLCAMP_014", "이미 대기 등록되어 있습니다."),
+
+  /**
+   * 이번 달에 유효한 "자리나면 알림받기" 대기 등록을 찾을 수 없습니다({@code #83}).
+   *
+   * <p>등록된 적이 없거나 이미 취소된 상태에서 다시 취소를 시도할 때 쓴다.
+   */
+  WAITLIST_NOT_FOUND(HttpStatus.NOT_FOUND, "SCHOOLCAMP_015", "유효한 대기 등록을 찾을 수 없습니다.");
 
   private final HttpStatus httpStatus;
   private final String code;

--- a/src/main/java/com/remake/gone/schoolcamp/repository/SchoolCampWaitlistRepository.java
+++ b/src/main/java/com/remake/gone/schoolcamp/repository/SchoolCampWaitlistRepository.java
@@ -1,0 +1,41 @@
+package com.remake.gone.schoolcamp.repository;
+
+import com.remake.gone.schoolcamp.entity.SchoolCampWaitlist;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * {@link SchoolCampWaitlist} 리포지토리.
+ */
+public interface SchoolCampWaitlistRepository extends JpaRepository<SchoolCampWaitlist, Long> {
+
+  /**
+   * 학생 1명의 특정 달 대기 등록 행을 취소 여부와 무관하게 조회합니다(등록/재활성화 판단용).
+   *
+   * @param studentUserId 조회할 학생 사용자 ID
+   * @param month         조회할 달(그 달의 1일)
+   * @return 그 학생·그 달의 대기 등록 행(있다면)
+   */
+  Optional<SchoolCampWaitlist> findByStudentUserIdAndMonth(Long studentUserId, LocalDate month);
+
+  /**
+   * 학생 1명의 특정 달 유효한(취소되지 않은) 대기 등록을 조회합니다(취소/상태 조회에서 사용).
+   *
+   * @param studentUserId 조회할 학생 사용자 ID
+   * @param month         조회할 달(그 달의 1일)
+   * @return 유효한 대기 등록(있다면)
+   */
+  Optional<SchoolCampWaitlist> findByStudentUserIdAndMonthAndCancelledAtIsNull(
+      Long studentUserId, LocalDate month);
+
+  /**
+   * 특정 달의 유효한(취소되지 않은) 대기 등록 전체를 조회합니다(취소 발생 시 알림 발송 대상
+   * 조회용).
+   *
+   * @param month 조회할 달(그 달의 1일)
+   * @return 그 달의 유효한 대기 등록 목록
+   */
+  List<SchoolCampWaitlist> findByMonthAndCancelledAtIsNull(LocalDate month);
+}

--- a/src/main/java/com/remake/gone/schoolcamp/service/SchoolCampService.java
+++ b/src/main/java/com/remake/gone/schoolcamp/service/SchoolCampService.java
@@ -85,6 +85,7 @@ public class SchoolCampService {
   private final UserRoleRepository userRoleRepository;
   private final NotificationService notificationService;
   private final OutingRepository outingRepository;
+  private final SchoolCampWaitlistService waitlistService;
 
   /**
    * 다음 달 스쿨캠핑 가능 날짜를 일괄 등록합니다. 요일 검증/중복 검증 중 하나라도 위반하는
@@ -262,6 +263,10 @@ public class SchoolCampService {
    * 롤백돼 "신청은 취소됐는데 세션은 여전히 잠긴" 불일치가 생기지 않는다 — claim/release가
    * REQUIRES_NEW라서 안았던 "release 실패 시 유령 점유" 잔여 리스크가 이 메서드에는 없다.
    *
+   * <p>세션 반환 직후 그 세션이 속한 달의 대기자 전원에게 "자리가 났어요" 알림을
+   * 발송한다({@code SchoolCampWaitlistService#notifyForMonth}, #83). 같은 트랜잭션 안에서
+   * 실행되어, 취소 자체가 롤백되면 알림 저장도 함께 롤백된다.
+   *
    * @param applicantUserId 취소를 요청한 사용자 ID(Access Token에서 추출됨)
    * @param applicationId   취소할 신청의 PK
    * @param now             "지금"(KST) — 당일 취소 금지 판단과 {@code cancelledAt} 기록에 사용
@@ -282,6 +287,7 @@ public class SchoolCampService {
     application.setCancelledAt(now);
     applicationRepository.save(application);
     sessionRepository.release(application.getSession().getId());
+    waitlistService.notifyForMonth(YearMonth.from(application.getSession().getCampDate()));
   }
 
   /**

--- a/src/main/java/com/remake/gone/schoolcamp/service/SchoolCampWaitlistService.java
+++ b/src/main/java/com/remake/gone/schoolcamp/service/SchoolCampWaitlistService.java
@@ -1,0 +1,146 @@
+package com.remake.gone.schoolcamp.service;
+
+import com.remake.gone.common.exception.CustomException;
+import com.remake.gone.notification.enums.NotificationType;
+import com.remake.gone.notification.service.NotificationService;
+import com.remake.gone.schoolcamp.dto.SchoolCampWaitlistResponse;
+import com.remake.gone.schoolcamp.dto.SchoolCampWaitlistStatusResponse;
+import com.remake.gone.schoolcamp.entity.SchoolCampWaitlist;
+import com.remake.gone.schoolcamp.exception.SchoolCampErrorCode;
+import com.remake.gone.schoolcamp.repository.SchoolCampWaitlistRepository;
+import com.remake.gone.user.entity.User;
+import com.remake.gone.user.repository.UserRepository;
+import java.time.LocalDateTime;
+import java.time.YearMonth;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 스쿨캠핑 "자리나면 알림받기" 대기 등록/취소/상태 조회 + 취소 발생 시 대기자 알림 발송을
+ * 처리하는 서비스(#83).
+ *
+ * <p>등록/취소/조회 전부 파라미터를 받지 않고, 항상 호출 시점의 "지금 이 순간의 이번 달"만
+ * 다룬다({@code 83-schoolcamp-waitlist-notification.md} 참고). {@code SchoolCampService}처럼
+ * 이미 책임이 큰 서비스에 섞지 않고 별도 서비스로 분리했다({@code SchoolCampSessionClaimService}
+ * 와 같은 이유).
+ */
+@Service
+@RequiredArgsConstructor
+public class SchoolCampWaitlistService {
+
+  private static final DateTimeFormatter YYYYMM_FORMATTER = DateTimeFormatter.ofPattern("yyyyMM");
+
+  private final SchoolCampWaitlistRepository waitlistRepository;
+  private final UserRepository userRepository;
+  private final NotificationService notificationService;
+
+  /**
+   * 이번 달 대기를 등록합니다. 이미 취소된 적 있는 같은 달 행이 있으면 재활성화하고, 없으면
+   * 새로 만듭니다.
+   *
+   * @param studentUserId 등록하는 학생 사용자 ID(Access Token에서 추출됨)
+   * @param now           등록 시각으로 기록할 "지금"(KST) — 이 시각이 속한 달이 곧 "이번 달"
+   * @return 등록된 대기 정보
+   */
+  @Transactional
+  public SchoolCampWaitlistResponse register(Long studentUserId, LocalDateTime now) {
+    YearMonth thisMonth = YearMonth.from(now);
+    Optional<SchoolCampWaitlist> existing =
+        waitlistRepository.findByStudentUserIdAndMonth(studentUserId, thisMonth.atDay(1));
+
+    SchoolCampWaitlist waitlist;
+    if (existing.isPresent()) {
+      waitlist = existing.get();
+      if (waitlist.getCancelledAt() == null) {
+        throw new CustomException(SchoolCampErrorCode.ALREADY_REGISTERED_WAITLIST);
+      }
+      waitlist.setCancelledAt(null);
+      waitlist.setRegisteredAt(now);
+      waitlistRepository.save(waitlist);
+    } else {
+      waitlist = newWaitlist(studentUserId, thisMonth, now);
+    }
+
+    return new SchoolCampWaitlistResponse(thisMonth.format(YYYYMM_FORMATTER), now);
+  }
+
+  private SchoolCampWaitlist newWaitlist(Long studentUserId, YearMonth month, LocalDateTime now) {
+    User student = userRepository.getReferenceById(studentUserId);
+    SchoolCampWaitlist waitlist = SchoolCampWaitlist.builder()
+        .studentUser(student)
+        .month(month.atDay(1))
+        .registeredAt(now)
+        .build();
+    try {
+      return waitlistRepository.save(waitlist);
+    } catch (DataIntegrityViolationException e) {
+      // 동시에 같은 학생이 같은 순간 두 번 등록을 시도하는 레이스(V14 유니크 제약 위반).
+      throw new CustomException(SchoolCampErrorCode.ALREADY_REGISTERED_WAITLIST);
+    }
+  }
+
+  /**
+   * 이번 달 대기를 취소합니다.
+   *
+   * @param studentUserId 취소하는 학생 사용자 ID(Access Token에서 추출됨)
+   * @param now           취소 시각으로 기록할 "지금"(KST)
+   */
+  @Transactional
+  public void cancel(Long studentUserId, LocalDateTime now) {
+    YearMonth thisMonth = YearMonth.from(now);
+    SchoolCampWaitlist waitlist = waitlistRepository
+        .findByStudentUserIdAndMonthAndCancelledAtIsNull(studentUserId, thisMonth.atDay(1))
+        .orElseThrow(() -> new CustomException(SchoolCampErrorCode.WAITLIST_NOT_FOUND));
+
+    waitlist.setCancelledAt(now);
+    waitlistRepository.save(waitlist);
+  }
+
+  /**
+   * 이번 달 대기 등록 상태를 조회합니다.
+   *
+   * @param studentUserId 조회하는 학생 사용자 ID(Access Token에서 추출됨)
+   * @param now           기준 시각으로 쓸 "지금"(KST) — 이 시각이 속한 달이 곧 "이번 달"
+   * @return 등록 상태
+   */
+  @Transactional(readOnly = true)
+  public SchoolCampWaitlistStatusResponse getStatus(Long studentUserId, LocalDateTime now) {
+    YearMonth thisMonth = YearMonth.from(now);
+    return waitlistRepository
+        .findByStudentUserIdAndMonthAndCancelledAtIsNull(studentUserId, thisMonth.atDay(1))
+        .map(waitlist -> new SchoolCampWaitlistStatusResponse(true, waitlist.getRegisteredAt()))
+        .orElseGet(() -> new SchoolCampWaitlistStatusResponse(false, null));
+  }
+
+  /**
+   * 특정 달에 자리가 났음을 그 달의 유효한 대기자 전원에게 알립니다. 선착순 1명이 아니라
+   * 전원에게 동시에 보낸다 — 실제 신청 성사는 세션 원자적 점유가 정리해준다.
+   *
+   * <p>{@code SchoolCampService.cancelApplication}(#70)에서만 호출한다.
+   * {@code SchoolCampSessionClaimService.release}(claim 직후 검증 실패로 자기 자신의 점유를
+   * 되돌리는 경로)에서는 호출하지 않는다 — 그 경로는 실제로 아무도 그 날짜를 "잃은" 적이
+   * 없어, 호출하면 대기자에게 스팸성 알림이 간다.
+   *
+   * @param month 자리가 난 세션이 속한 달(취소 시점의 "이번 달"이 아니라 그 세션의 캠핑 날짜
+   *              기준)
+   */
+  @Transactional
+  public void notifyForMonth(YearMonth month) {
+    List<SchoolCampWaitlist> waitlists =
+        waitlistRepository.findByMonthAndCancelledAtIsNull(month.atDay(1));
+    if (waitlists.isEmpty()) {
+      return;
+    }
+
+    String title = "스쿨캠핑 자리가 났어요!";
+    String body = "%d년 %d월 스쿨캠핑에 취소로 빈 자리가 생겼어요. 캘린더에서 확인하고 신청해보세요!"
+        .formatted(month.getYear(), month.getMonthValue());
+    waitlists.forEach(waitlist -> notificationService.send(
+        waitlist.getStudentUser().getId(), title, body, NotificationType.SCHOOLCAMP));
+  }
+}

--- a/src/main/java/com/remake/gone/schoolcamp/service/SchoolCampWaitlistService.java
+++ b/src/main/java/com/remake/gone/schoolcamp/service/SchoolCampWaitlistService.java
@@ -53,23 +53,25 @@ public class SchoolCampWaitlistService {
     Optional<SchoolCampWaitlist> existing =
         waitlistRepository.findByStudentUserIdAndMonth(studentUserId, thisMonth.atDay(1));
 
-    SchoolCampWaitlist waitlist;
     if (existing.isPresent()) {
-      waitlist = existing.get();
-      if (waitlist.getCancelledAt() == null) {
-        throw new CustomException(SchoolCampErrorCode.ALREADY_REGISTERED_WAITLIST);
-      }
-      waitlist.setCancelledAt(null);
-      waitlist.setRegisteredAt(now);
-      waitlistRepository.save(waitlist);
+      reactivate(existing.get(), now);
     } else {
-      waitlist = newWaitlist(studentUserId, thisMonth, now);
+      newWaitlist(studentUserId, thisMonth, now);
     }
 
     return new SchoolCampWaitlistResponse(thisMonth.format(YYYYMM_FORMATTER), now);
   }
 
-  private SchoolCampWaitlist newWaitlist(Long studentUserId, YearMonth month, LocalDateTime now) {
+  private void reactivate(SchoolCampWaitlist waitlist, LocalDateTime now) {
+    if (waitlist.getCancelledAt() == null) {
+      throw new CustomException(SchoolCampErrorCode.ALREADY_REGISTERED_WAITLIST);
+    }
+    waitlist.setCancelledAt(null);
+    waitlist.setRegisteredAt(now);
+    waitlistRepository.save(waitlist);
+  }
+
+  private void newWaitlist(Long studentUserId, YearMonth month, LocalDateTime now) {
     User student = userRepository.getReferenceById(studentUserId);
     SchoolCampWaitlist waitlist = SchoolCampWaitlist.builder()
         .studentUser(student)
@@ -77,7 +79,7 @@ public class SchoolCampWaitlistService {
         .registeredAt(now)
         .build();
     try {
-      return waitlistRepository.save(waitlist);
+      waitlistRepository.save(waitlist);
     } catch (DataIntegrityViolationException e) {
       // 동시에 같은 학생이 같은 순간 두 번 등록을 시도하는 레이스(V14 유니크 제약 위반).
       throw new CustomException(SchoolCampErrorCode.ALREADY_REGISTERED_WAITLIST);

--- a/src/main/resources/db/migration/V14__add_schoolcamp_waitlist.sql
+++ b/src/main/resources/db/migration/V14__add_schoolcamp_waitlist.sql
@@ -1,0 +1,12 @@
+-- 스쿨캠핑 "자리나면 알림받기" 대기 등록 (#83)
+CREATE TABLE school_camp_waitlist (
+    id BIGINT PRIMARY KEY AUTO_INCREMENT,
+    student_user_id BIGINT NOT NULL,
+    month DATE NOT NULL,
+    registered_at DATETIME NOT NULL,
+    cancelled_at DATETIME NULL,
+
+    FOREIGN KEY (student_user_id) REFERENCES user(id),
+    CONSTRAINT uq_waitlist_student_month UNIQUE (student_user_id, month),
+    KEY idx_waitlist_month_cancelled (month, cancelled_at)
+);

--- a/src/test/java/com/remake/gone/schoolcamp/controller/SchoolCampAuthorizationTest.java
+++ b/src/test/java/com/remake/gone/schoolcamp/controller/SchoolCampAuthorizationTest.java
@@ -126,4 +126,55 @@ class SchoolCampAuthorizationTest {
             .header("Authorization", "Bearer " + token))
         .andExpect(status().isForbidden());
   }
+
+  @Test
+  @DisplayName("대기 등록 엔드포인트는 인증 없이 요청하면 401을 반환한다(#83)")
+  void registerWaitlistReturns401WithoutToken() throws Exception {
+    mockMvc.perform(post("/api/v1/school-camps/waitlist"))
+        .andExpect(status().isUnauthorized());
+  }
+
+  @Test
+  @DisplayName("대기 등록 엔드포인트는 TEACHER 역할로 요청하면 403을 반환한다(STUDENT 전용, #83)")
+  void registerWaitlistReturns403ForTeacherRole() throws Exception {
+    String token = jwtProvider.createAccessToken(1L, Set.of("TEACHER"));
+
+    mockMvc.perform(post("/api/v1/school-camps/waitlist")
+            .header("Authorization", "Bearer " + token))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
+  @DisplayName("대기 취소 엔드포인트는 인증 없이 요청하면 401을 반환한다(#83)")
+  void cancelWaitlistReturns401WithoutToken() throws Exception {
+    mockMvc.perform(delete("/api/v1/school-camps/waitlist"))
+        .andExpect(status().isUnauthorized());
+  }
+
+  @Test
+  @DisplayName("대기 취소 엔드포인트는 TEACHER 역할로 요청하면 403을 반환한다(STUDENT 전용, #83)")
+  void cancelWaitlistReturns403ForTeacherRole() throws Exception {
+    String token = jwtProvider.createAccessToken(1L, Set.of("TEACHER"));
+
+    mockMvc.perform(delete("/api/v1/school-camps/waitlist")
+            .header("Authorization", "Bearer " + token))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
+  @DisplayName("대기 상태 조회 엔드포인트는 인증 없이 요청하면 401을 반환한다(#83)")
+  void getWaitlistStatusReturns401WithoutToken() throws Exception {
+    mockMvc.perform(get("/api/v1/school-camps/waitlist/me"))
+        .andExpect(status().isUnauthorized());
+  }
+
+  @Test
+  @DisplayName("대기 상태 조회 엔드포인트는 TEACHER 역할로 요청하면 403을 반환한다(STUDENT 전용, #83)")
+  void getWaitlistStatusReturns403ForTeacherRole() throws Exception {
+    String token = jwtProvider.createAccessToken(1L, Set.of("TEACHER"));
+
+    mockMvc.perform(get("/api/v1/school-camps/waitlist/me")
+            .header("Authorization", "Bearer " + token))
+        .andExpect(status().isForbidden());
+  }
 }

--- a/src/test/java/com/remake/gone/schoolcamp/controller/SchoolCampControllerTest.java
+++ b/src/test/java/com/remake/gone/schoolcamp/controller/SchoolCampControllerTest.java
@@ -19,8 +19,11 @@ import com.remake.gone.schoolcamp.dto.SchoolCampCalendarResponse;
 import com.remake.gone.schoolcamp.dto.SchoolCampMemberRequest;
 import com.remake.gone.schoolcamp.dto.SchoolCampMemberResponse;
 import com.remake.gone.schoolcamp.dto.SchoolCampSessionResponse;
+import com.remake.gone.schoolcamp.dto.SchoolCampWaitlistResponse;
+import com.remake.gone.schoolcamp.dto.SchoolCampWaitlistStatusResponse;
 import com.remake.gone.schoolcamp.enums.SchoolCampStatus;
 import com.remake.gone.schoolcamp.service.SchoolCampService;
+import com.remake.gone.schoolcamp.service.SchoolCampWaitlistService;
 import java.time.LocalDateTime;
 import java.time.YearMonth;
 import java.util.List;
@@ -52,6 +55,9 @@ class SchoolCampControllerTest {
 
   @MockitoBean
   private SchoolCampService schoolCampService;
+
+  @MockitoBean
+  private SchoolCampWaitlistService schoolCampWaitlistService;
 
   @Nested
   @DisplayName("POST /api/v1/school-camps")
@@ -90,7 +96,8 @@ class SchoolCampControllerTest {
     @Test
     @DisplayName("요청받은 날짜 목록으로 서비스를 호출하고 결과를 그대로 반환한다")
     void callsServiceWithRequestedDates() {
-      SchoolCampController controller = new SchoolCampController(schoolCampService);
+      SchoolCampController controller =
+          new SchoolCampController(schoolCampService, schoolCampWaitlistService);
       List<SchoolCampSessionResponse> expected = List.of(
           new SchoolCampSessionResponse(12L, "20260403"));
       given(schoolCampService.registerCampDates(List.of("20260403"))).willReturn(expected);
@@ -124,7 +131,8 @@ class SchoolCampControllerTest {
     @Test
     @DisplayName("파싱된 month로 서비스를 호출하고 결과를 그대로 반환한다")
     void callsServiceWithParsedMonth() {
-      SchoolCampController controller = new SchoolCampController(schoolCampService);
+      SchoolCampController controller =
+          new SchoolCampController(schoolCampService, schoolCampWaitlistService);
       List<SchoolCampCalendarResponse> expected = List.of(
           new SchoolCampCalendarResponse(12L, "20260403", SchoolCampStatus.OPEN, null, null));
       given(schoolCampService.getCalendar(YearMonth.of(2026, 4))).willReturn(expected);
@@ -165,7 +173,8 @@ class SchoolCampControllerTest {
     @Test
     @DisplayName("정상 요청이면 201과 서비스 응답을 그대로 반환한다")
     void returns201OnSuccess() {
-      SchoolCampController controller = new SchoolCampController(schoolCampService);
+      SchoolCampController controller =
+          new SchoolCampController(schoolCampService, schoolCampWaitlistService);
       UserPrincipal principal = new UserPrincipal(101L);
       SchoolCampApplyRequest request = new SchoolCampApplyRequest(42L, null, List.of());
       SchoolCampApplicationResponse expected = new SchoolCampApplicationResponse(
@@ -190,7 +199,8 @@ class SchoolCampControllerTest {
     @Test
     @DisplayName("principal의 userId와 신청 id를 그대로 서비스에 전달한다")
     void callsServiceWithPrincipalAndApplicationId() {
-      SchoolCampController controller = new SchoolCampController(schoolCampService);
+      SchoolCampController controller =
+          new SchoolCampController(schoolCampService, schoolCampWaitlistService);
       UserPrincipal principal = new UserPrincipal(101L);
 
       ApiResponse<Void> response = controller.cancelApplication(principal, 301L);
@@ -219,7 +229,8 @@ class SchoolCampControllerTest {
     @Test
     @DisplayName("principal의 userId와 신청 id, 요청을 그대로 서비스에 전달한다")
     void callsServiceWithPrincipalAndRequest() {
-      SchoolCampController controller = new SchoolCampController(schoolCampService);
+      SchoolCampController controller =
+          new SchoolCampController(schoolCampService, schoolCampWaitlistService);
       UserPrincipal principal = new UserPrincipal(101L);
       SchoolCampApplyRequest request = new SchoolCampApplyRequest(42L, null, List.of());
       SchoolCampApplicationResponse expected = new SchoolCampApplicationResponse(
@@ -230,6 +241,70 @@ class SchoolCampControllerTest {
 
       ApiResponse<SchoolCampApplicationResponse> response =
           controller.updateApplication(principal, 301L, request);
+
+      assertThat(response.success()).isTrue();
+      assertThat(response.data()).isEqualTo(expected);
+    }
+  }
+
+  @Nested
+  @DisplayName("POST /api/v1/school-camps/waitlist")
+  class RegisterWaitlist {
+
+    @Test
+    @DisplayName("principal의 userId로 등록을 요청하고 결과를 그대로 반환한다")
+    void callsServiceWithPrincipal() {
+      SchoolCampController controller =
+          new SchoolCampController(schoolCampService, schoolCampWaitlistService);
+      UserPrincipal principal = new UserPrincipal(101L);
+      SchoolCampWaitlistResponse expected =
+          new SchoolCampWaitlistResponse("202604", LocalDateTime.of(2026, 4, 10, 9, 0));
+      given(schoolCampWaitlistService.register(eq(101L), any(LocalDateTime.class)))
+          .willReturn(expected);
+
+      ApiResponse<SchoolCampWaitlistResponse> response = controller.registerWaitlist(principal);
+
+      assertThat(response.success()).isTrue();
+      assertThat(response.data()).isEqualTo(expected);
+    }
+  }
+
+  @Nested
+  @DisplayName("DELETE /api/v1/school-camps/waitlist")
+  class CancelWaitlist {
+
+    @Test
+    @DisplayName("principal의 userId로 취소를 요청한다")
+    void callsServiceWithPrincipal() {
+      SchoolCampController controller =
+          new SchoolCampController(schoolCampService, schoolCampWaitlistService);
+      UserPrincipal principal = new UserPrincipal(101L);
+
+      ApiResponse<Void> response = controller.cancelWaitlist(principal);
+
+      assertThat(response.success()).isTrue();
+      assertThat(response.data()).isNull();
+      verify(schoolCampWaitlistService).cancel(eq(101L), any(LocalDateTime.class));
+    }
+  }
+
+  @Nested
+  @DisplayName("GET /api/v1/school-camps/waitlist/me")
+  class GetWaitlistStatus {
+
+    @Test
+    @DisplayName("principal의 userId로 상태를 조회하고 결과를 그대로 반환한다")
+    void callsServiceWithPrincipal() {
+      SchoolCampController controller =
+          new SchoolCampController(schoolCampService, schoolCampWaitlistService);
+      UserPrincipal principal = new UserPrincipal(101L);
+      SchoolCampWaitlistStatusResponse expected =
+          new SchoolCampWaitlistStatusResponse(true, LocalDateTime.of(2026, 4, 10, 9, 0));
+      given(schoolCampWaitlistService.getStatus(eq(101L), any(LocalDateTime.class)))
+          .willReturn(expected);
+
+      ApiResponse<SchoolCampWaitlistStatusResponse> response =
+          controller.getWaitlistStatus(principal);
 
       assertThat(response.success()).isTrue();
       assertThat(response.data()).isEqualTo(expected);

--- a/src/test/java/com/remake/gone/schoolcamp/service/SchoolCampServiceTest.java
+++ b/src/test/java/com/remake/gone/schoolcamp/service/SchoolCampServiceTest.java
@@ -403,6 +403,7 @@ class SchoolCampServiceTest {
           .isEqualTo(SchoolCampErrorCode.INVALID_APPLICATION_FORMAT);
 
       verify(sessionClaimService).release(SESSION_ID);
+      verifyNoInteractions(waitlistService);
       verifyNoInteractions(applicationRepository, memberRepository);
     }
 
@@ -423,6 +424,7 @@ class SchoolCampServiceTest {
           .isEqualTo(SchoolCampErrorCode.INVALID_MEMBER_INFO);
 
       verify(sessionClaimService).release(SESSION_ID);
+      verifyNoInteractions(waitlistService);
       verifyNoInteractions(applicationRepository, memberRepository);
     }
 
@@ -443,6 +445,7 @@ class SchoolCampServiceTest {
           .isEqualTo(SchoolCampErrorCode.INVALID_MEMBER_INFO);
 
       verify(sessionClaimService).release(SESSION_ID);
+      verifyNoInteractions(waitlistService);
       verifyNoInteractions(applicationRepository, memberRepository);
     }
 
@@ -464,6 +467,7 @@ class SchoolCampServiceTest {
           .isEqualTo(SchoolCampErrorCode.INVALID_MEMBER_INFO);
 
       verify(sessionClaimService).release(SESSION_ID);
+      verifyNoInteractions(waitlistService);
       verifyNoInteractions(applicationRepository, memberRepository);
     }
 
@@ -495,6 +499,7 @@ class SchoolCampServiceTest {
           });
 
       verify(sessionClaimService).release(SESSION_ID);
+      verifyNoInteractions(waitlistService);
       verifyNoInteractions(applicationRepository);
       verify(memberRepository, never()).saveAll(anyList());
     }

--- a/src/test/java/com/remake/gone/schoolcamp/service/SchoolCampServiceTest.java
+++ b/src/test/java/com/remake/gone/schoolcamp/service/SchoolCampServiceTest.java
@@ -91,6 +91,9 @@ class SchoolCampServiceTest {
   @Mock
   private OutingRepository outingRepository;
 
+  @Mock
+  private SchoolCampWaitlistService waitlistService;
+
   @InjectMocks
   private SchoolCampService schoolCampService;
 
@@ -611,6 +614,8 @@ class SchoolCampServiceTest {
       assertThat(application.getCancelledAt()).isEqualTo(NOW);
       verify(applicationRepository).save(application);
       verify(sessionRepository).release(SESSION_ID);
+      verify(waitlistService)
+          .notifyForMonth(YearMonth.from(application.getSession().getCampDate()));
       verifyNoInteractions(sessionClaimService);
     }
 
@@ -628,6 +633,7 @@ class SchoolCampServiceTest {
 
       verify(applicationRepository, never()).save(any());
       verify(sessionRepository, never()).release(anyLong());
+      verifyNoInteractions(waitlistService);
     }
 
     @Test
@@ -658,6 +664,7 @@ class SchoolCampServiceTest {
 
       verify(applicationRepository, never()).save(any());
       verify(sessionRepository, never()).release(anyLong());
+      verifyNoInteractions(waitlistService);
     }
   }
 

--- a/src/test/java/com/remake/gone/schoolcamp/service/SchoolCampWaitlistServiceTest.java
+++ b/src/test/java/com/remake/gone/schoolcamp/service/SchoolCampWaitlistServiceTest.java
@@ -1,0 +1,235 @@
+package com.remake.gone.schoolcamp.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import com.remake.gone.common.exception.CustomException;
+import com.remake.gone.notification.enums.NotificationType;
+import com.remake.gone.notification.service.NotificationService;
+import com.remake.gone.schoolcamp.dto.SchoolCampWaitlistResponse;
+import com.remake.gone.schoolcamp.dto.SchoolCampWaitlistStatusResponse;
+import com.remake.gone.schoolcamp.entity.SchoolCampWaitlist;
+import com.remake.gone.schoolcamp.exception.SchoolCampErrorCode;
+import com.remake.gone.schoolcamp.repository.SchoolCampWaitlistRepository;
+import com.remake.gone.user.entity.User;
+import com.remake.gone.user.repository.UserRepository;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.YearMonth;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
+
+/**
+ * {@link SchoolCampWaitlistService}에 대한 단위 테스트.
+ */
+@ExtendWith(MockitoExtension.class)
+class SchoolCampWaitlistServiceTest {
+
+  private static final Long STUDENT_ID = 101L;
+  private static final LocalDateTime NOW = LocalDateTime.of(2026, 4, 10, 9, 0);
+  private static final LocalDate MONTH_START = LocalDate.of(2026, 4, 1);
+
+  @Mock
+  private SchoolCampWaitlistRepository waitlistRepository;
+
+  @Mock
+  private UserRepository userRepository;
+
+  @Mock
+  private NotificationService notificationService;
+
+  @InjectMocks
+  private SchoolCampWaitlistService waitlistService;
+
+  private SchoolCampWaitlist waitlist(LocalDateTime registeredAt, LocalDateTime cancelledAt) {
+    User student = User.builder().id(STUDENT_ID).build();
+    return SchoolCampWaitlist.builder()
+        .id(1L)
+        .studentUser(student)
+        .month(MONTH_START)
+        .registeredAt(registeredAt)
+        .cancelledAt(cancelledAt)
+        .build();
+  }
+
+  @Nested
+  @DisplayName("register")
+  class Register {
+
+    @Test
+    @DisplayName("등록된 적 없으면 새로 등록한다")
+    void registersNewWhenNoExistingRow() {
+      given(waitlistRepository.findByStudentUserIdAndMonth(STUDENT_ID, MONTH_START))
+          .willReturn(Optional.empty());
+      given(userRepository.getReferenceById(STUDENT_ID))
+          .willReturn(User.builder().id(STUDENT_ID).build());
+
+      SchoolCampWaitlistResponse response = waitlistService.register(STUDENT_ID, NOW);
+
+      assertThat(response.month()).isEqualTo("202604");
+      assertThat(response.registeredAt()).isEqualTo(NOW);
+      verify(waitlistRepository).save(argThatWaitlistWith(MONTH_START, NOW, null));
+    }
+
+    @Test
+    @DisplayName("이미 유효한 등록이 있으면 409를 던진다")
+    void throwsWhenAlreadyRegistered() {
+      given(waitlistRepository.findByStudentUserIdAndMonth(STUDENT_ID, MONTH_START))
+          .willReturn(Optional.of(waitlist(NOW.minusDays(1), null)));
+
+      assertThatThrownBy(() -> waitlistService.register(STUDENT_ID, NOW))
+          .isInstanceOf(CustomException.class)
+          .extracting(e -> ((CustomException) e).getErrorCode())
+          .isEqualTo(SchoolCampErrorCode.ALREADY_REGISTERED_WAITLIST);
+
+      verify(waitlistRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("취소됐던 같은 달 행이 있으면 재활성화한다")
+    void reactivatesCancelledRow() {
+      SchoolCampWaitlist cancelled = waitlist(NOW.minusDays(10), NOW.minusDays(5));
+      given(waitlistRepository.findByStudentUserIdAndMonth(STUDENT_ID, MONTH_START))
+          .willReturn(Optional.of(cancelled));
+
+      SchoolCampWaitlistResponse response = waitlistService.register(STUDENT_ID, NOW);
+
+      assertThat(cancelled.getCancelledAt()).isNull();
+      assertThat(cancelled.getRegisteredAt()).isEqualTo(NOW);
+      assertThat(response.registeredAt()).isEqualTo(NOW);
+      verify(waitlistRepository).save(cancelled);
+      verifyNoInteractions(userRepository);
+    }
+
+    @Test
+    @DisplayName("동시 등록 레이스로 유니크 제약을 위반하면 409를 던진다")
+    void throwsOnConcurrentRegisterRace() {
+      given(waitlistRepository.findByStudentUserIdAndMonth(STUDENT_ID, MONTH_START))
+          .willReturn(Optional.empty());
+      given(userRepository.getReferenceById(STUDENT_ID))
+          .willReturn(User.builder().id(STUDENT_ID).build());
+      given(waitlistRepository.save(any()))
+          .willThrow(new DataIntegrityViolationException("duplicate"));
+
+      assertThatThrownBy(() -> waitlistService.register(STUDENT_ID, NOW))
+          .isInstanceOf(CustomException.class)
+          .extracting(e -> ((CustomException) e).getErrorCode())
+          .isEqualTo(SchoolCampErrorCode.ALREADY_REGISTERED_WAITLIST);
+    }
+
+    private SchoolCampWaitlist argThatWaitlistWith(
+        LocalDate month, LocalDateTime registeredAt, LocalDateTime cancelledAt) {
+      return argThat(w -> w.getMonth().equals(month)
+          && w.getRegisteredAt().equals(registeredAt)
+          && w.getCancelledAt() == cancelledAt);
+    }
+  }
+
+  @Nested
+  @DisplayName("cancel")
+  class Cancel {
+
+    @Test
+    @DisplayName("정상 취소 시 cancelledAt을 채운다")
+    void cancelsSuccessfully() {
+      SchoolCampWaitlist active = waitlist(NOW.minusDays(1), null);
+      given(waitlistRepository.findByStudentUserIdAndMonthAndCancelledAtIsNull(
+          STUDENT_ID, MONTH_START)).willReturn(Optional.of(active));
+
+      waitlistService.cancel(STUDENT_ID, NOW);
+
+      assertThat(active.getCancelledAt()).isEqualTo(NOW);
+      verify(waitlistRepository).save(active);
+    }
+
+    @Test
+    @DisplayName("유효한 등록이 없으면 404를 던진다")
+    void throwsWhenNotFound() {
+      given(waitlistRepository.findByStudentUserIdAndMonthAndCancelledAtIsNull(
+          STUDENT_ID, MONTH_START)).willReturn(Optional.empty());
+
+      assertThatThrownBy(() -> waitlistService.cancel(STUDENT_ID, NOW))
+          .isInstanceOf(CustomException.class)
+          .extracting(e -> ((CustomException) e).getErrorCode())
+          .isEqualTo(SchoolCampErrorCode.WAITLIST_NOT_FOUND);
+    }
+  }
+
+  @Nested
+  @DisplayName("getStatus")
+  class GetStatus {
+
+    @Test
+    @DisplayName("유효한 등록이 있으면 registered=true를 반환한다")
+    void returnsRegisteredTrue() {
+      SchoolCampWaitlist active = waitlist(NOW.minusDays(1), null);
+      given(waitlistRepository.findByStudentUserIdAndMonthAndCancelledAtIsNull(
+          STUDENT_ID, MONTH_START)).willReturn(Optional.of(active));
+
+      SchoolCampWaitlistStatusResponse response = waitlistService.getStatus(STUDENT_ID, NOW);
+
+      assertThat(response.registered()).isTrue();
+      assertThat(response.registeredAt()).isEqualTo(active.getRegisteredAt());
+    }
+
+    @Test
+    @DisplayName("유효한 등록이 없으면 registered=false를 반환한다")
+    void returnsRegisteredFalse() {
+      given(waitlistRepository.findByStudentUserIdAndMonthAndCancelledAtIsNull(
+          STUDENT_ID, MONTH_START)).willReturn(Optional.empty());
+
+      SchoolCampWaitlistStatusResponse response = waitlistService.getStatus(STUDENT_ID, NOW);
+
+      assertThat(response.registered()).isFalse();
+      assertThat(response.registeredAt()).isNull();
+    }
+  }
+
+  @Nested
+  @DisplayName("notifyForMonth")
+  class NotifyForMonth {
+
+    @Test
+    @DisplayName("그 달 유효한 대기자 전원에게 알림을 보낸다")
+    void notifiesAllActiveWaitlistersInMonth() {
+      SchoolCampWaitlist first = waitlist(NOW.minusDays(3), null);
+      SchoolCampWaitlist second = waitlist(NOW.minusDays(2), null);
+      given(waitlistRepository.findByMonthAndCancelledAtIsNull(MONTH_START))
+          .willReturn(List.of(first, second));
+
+      waitlistService.notifyForMonth(YearMonth.of(2026, 4));
+
+      verify(notificationService, times(2)).send(
+          eq(STUDENT_ID), eq("스쿨캠핑 자리가 났어요!"),
+          eq("2026년 4월 스쿨캠핑에 취소로 빈 자리가 생겼어요. 캘린더에서 확인하고 신청해보세요!"),
+          eq(NotificationType.SCHOOLCAMP));
+    }
+
+    @Test
+    @DisplayName("대기자가 없으면 알림을 보내지 않는다")
+    void doesNothingWhenNoWaitlisters() {
+      given(waitlistRepository.findByMonthAndCancelledAtIsNull(MONTH_START))
+          .willReturn(List.of());
+
+      waitlistService.notifyForMonth(YearMonth.of(2026, 4));
+
+      verifyNoInteractions(notificationService);
+    }
+  }
+}


### PR DESCRIPTION
## 관련 이슈
closes #83

## 작업 내용
스쿨캠핑 마감된 날짜에서 취소가 발생하면, 대기 등록한 학생 전원에게 "자리가 났어요" 알림을 보내는 "자리나면 알림받기" 기능이다. 대기 등록은 세션(날짜) 단위가 아니라 항상 "지금 이 순간의 이번 달" 하나만 다루며, 등록/취소/조회 세 엔드포인트 모두 파라미터를 받지 않는다.

## 변경 사항 상세
- `SchoolCampWaitlist` 엔티티 + `V14__add_schoolcamp_waitlist.sql`(`(student_user_id, month)` 유니크 제약, soft-cancel)
- `SchoolCampWaitlistService`: 등록(재활성화 포함)/취소/상태 조회/`notifyForMonth`
- `SchoolCampController`에 `POST/DELETE /api/v1/school-camps/waitlist`, `GET /api/v1/school-camps/waitlist/me` 3개 엔드포인트 추가(`STUDENT` 전용)
- `SchoolCampService.cancelApplication`이 세션 반환 직후 `notifyForMonth`를 호출하도록 연결(세션의 캠핑 날짜가 속한 달 기준, 취소 시점의 달이 아님). `SchoolCampSessionClaimService.release`/`releaseQuietly`(claim 직후 검증 실패로 자기 자신의 점유를 되돌리는 경로)는 의도적으로 제외 — 스팸 알림 방지
- `SchoolCampErrorCode`에 `SCHOOLCAMP_014`(409, 이미 대기 등록됨)/`SCHOOLCAMP_015`(404, 유효한 대기 등록 없음) 추가
- Postman 컬렉션(`GONE - SchoolCamp API`)에 엔드포인트 3개 + 에러 케이스 6개 + "#83 자리나면 알림받기 확인" 검증 폴더 추가, 워크스페이스에 반영 완료

기획서: [docs/domain/schoolcamp/83-schoolcamp-waitlist-notification.md](../blob/feat/%2383-schoolcamp-waitlist/docs/domain/schoolcamp/83-schoolcamp-waitlist-notification.md)
코드 리뷰: [docs/domain/schoolcamp/83-schoolcamp-waitlist-notification-code-review.md](../blob/feat/%2383-schoolcamp-waitlist/docs/domain/schoolcamp/83-schoolcamp-waitlist-notification-code-review.md) — High 1건(회귀 테스트 누락)/Low 1건(dead store) 반영 완료, Medium 2건은 기존 프로젝트 정책과 일관되게 수용(코드 변경 없음, 문서화)
QA: [docs/domain/schoolcamp/83-schoolcamp-waitlist-notification-QA.md](../blob/feat/%2383-schoolcamp-waitlist/docs/domain/schoolcamp/83-schoolcamp-waitlist-notification-QA.md) — 로컬 서버 실기동 + 실 HTTP E2E로 등록/중복/취소/재활성화/권한/알림 발송(및 `releaseQuietly` 무알림)까지 전부 확인, Critical/High/Medium/Low 없음

## 확인 사항
- [x] 로컬 빌드 통과 (`./gradlew build`)
- [x] Checkstyle 통과 (`./gradlew checkstyleMain`)
- [ ] CI(checkstyle, build-and-test) 통과 — 이 PR 생성 후 Actions에서 확인 예정
- [x] (해당 시) Notion 기능정의서/기획 문서 반영 — 머지 후(17단계) 반영 예정
- [x] (해당 시) 관련 도메인 라벨 지정 — `feature`, `domain:SCHOOLCAMP` 이미 지정됨

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added school-camp waitlist registration, cancellation, and current-status lookup.
  * Waitlist registrations are managed by month and can be reactivated after cancellation.
  * Sends notifications to active waitlisted applicants when a session becomes available.
  * Added clear responses and error handling for duplicate or unavailable registrations.

* **Documentation**
  * Added design specifications, code-review notes, and QA verification records.

* **Tests**
  * Added coverage for waitlist behavior, authorization, concurrency, cancellation, and notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->