### PR TITLE
feat(conduct): 상/벌점 정정·취소 API 구현 (#107)

### DIFF
--- a/docs/domain/conduct/107-conduct-amend-cancel-code-review.md
+++ b/docs/domain/conduct/107-conduct-amend-cancel-code-review.md
@@ -1,0 +1,47 @@
+# 상/벌점 정정·취소 코드 리뷰 (이슈 #107)
+
+> 격리 에이전트 리뷰 결과 (diff: `dev...feat/#107-conduct-amend-cancel`, 기획서: `107-conduct-amend-cancel.md`)
+
+## 리뷰 결과
+
+### 1. `amendConduct` — 양쪽 필드가 모두 null일 때 silent no-op
+**심각도**: 🟠 High
+
+**문제**: `ConductAmendRequest(null, null)` 전송 시 아무 필드도 갱신되지 않지만 `200 OK`를 반환한다. 클라이언트가 실수로 빈 바디를 보내도 오류가 없어 혼란을 준다.
+
+**해결 방안 A**: 서비스 초입에 두 필드 모두 null이면 `INVALID_REQUEST` 예외를 던진다 ← **채택**
+- 장점: 명시적 오류. 구현 단순.
+- 단점: 새 에러 코드 없이 `COMMON_001` 재사용 — 메시지가 약간 일반적.
+
+**해결 방안 B**: `ConductAmendRequest`에 커스텀 `@AssertTrue` 유효성 검사 추가
+- 장점: 컨트롤러 레이어에서 400을 반환해 서비스 로직에 도달하기 전 차단.
+- 단점: 커스텀 validator 클래스 추가로 복잡도 증가. 기존 `@Valid` 패턴과 다름.
+
+→ **A 채택 후 수정 완료**. `amendConduct` 서비스 메서드 초입에 양 필드 null 검증 추가. 테스트 케이스도 추가.
+
+---
+
+### 2. Lazy Loading 우려 — `@Transactional` 내 접근
+**심각도**: ℹ️ INFO
+
+**에이전트 지적**: `record.getTeacher().getId()` 및 `ConductRecordResponse.from(record)` 내 LAZY 관계 접근이 LazyInitializationException을 일으킬 수 있다.
+
+**검토 결과**: 오탐. `amendConduct`/`cancelConduct` 모두 `@Transactional`이므로 메서드 실행 전체가 하나의 Hibernate 세션 내에 있다. LAZY 관계는 세션이 열린 상태에서 접근하므로 정상 동작. 수정 불필요.
+
+---
+
+### 3. 정정 이력 미보존
+**심각도**: ℹ️ INFO
+
+**에이전트 지적**: 정정 시 이전 값이 `updated_at` 갱신 외에 남지 않는다.
+
+**검토 결과**: 기획서("정정 이력을 별도로 남길지 — 아직 결정 안 된 것")에 명시된 향후 검토 항목. 이번 범위 밖. 수정 불필요.
+
+---
+
+### 4. principal null 가능성
+**심각도**: ℹ️ INFO
+
+**에이전트 지적**: `@AuthenticationPrincipal`이 null일 수 있어 NPE 위험.
+
+**검토 결과**: `@PreAuthorize("hasRole('TEACHER') or hasRole('ADMIN')")` 가 메서드 진입 전에 인증/인가를 검증하므로 실제로는 null이 전달되지 않는다. 수정 불필요.

--- a/docs/domain/conduct/107-conduct-amend-cancel.md
+++ b/docs/domain/conduct/107-conduct-amend-cancel.md
@@ -1,0 +1,160 @@
+# 상/벌점 정정·취소 — 기능 기획서 (이슈 #107)
+
+## 개요/목적
+교사(또는 ADMIN)가 이미 부여된 상/벌점 기록을 정정하거나 취소한다.
+
+- **정정**: 카테고리(`categoryId`)와 상세 사유(`detail`)를 수정한다. 대상 학생(`studentUserId`)은 변경할 수 없다.
+- **취소**: 기록 상태를 `ACTIVE` → `CANCELED`로 전환한다. 되돌릴 수 없다.
+
+두 엔드포인트는 동일한 소유권 체크 로직과 에러 코드 세트(CONDUCT_001·002·003)를 공유해 한 이슈에서 함께 구현한다.
+
+- **관련 마스터 기획서**: [`docs/domain/conduct/1_conduct-domain.md`](./1_conduct-domain.md) — "2. 정정" / "3. 취소" 절
+- **선행 이슈**: #94 (`ConductRecord` 엔티티·V16 마이그레이션·부여 API)
+
+---
+
+## 에러 코드 추가 (`ConductErrorCode`)
+
+기존 코드(CONDUCT_004~006)에 아래 3개를 추가한다.
+
+| 코드 | HTTP | 메시지 |
+|---|---|---|
+| `CONDUCT_001` | 404 | 상/벌점 기록을 찾을 수 없습니다. |
+| `CONDUCT_002` | 403 | 본인이 부여한 기록만 처리할 수 있습니다. |
+| `CONDUCT_003` | 409 | 이미 취소된 기록입니다. |
+
+---
+
+## 엔드포인트 1: `PATCH /api/v1/conduct-records/{id}` — 정정
+
+**권한**: `TEACHER` 또는 `ADMIN`  
+(`@PreAuthorize("hasRole('TEACHER') or hasRole('ADMIN')")`)  
+`TEACHER`인 경우 본인이 부여한 기록인지 서비스 코드에서 소유권 확인.
+
+**요청** (`categoryId`, `detail` 둘 다 선택 — 보낸 필드만 갱신)
+```json
+{ "categoryId": 6, "detail": "3교시 이후 조퇴, 사유서 미제출" }
+```
+- `categoryId`만 보내거나, `detail`만 보내거나, 둘 다 보낼 수 있다.
+- `detail`에 빈 문자열(`""`) 허용 여부: `null`은 "변경 없음"으로, `""` 전달 시 그대로 저장한다.
+- `categoryId`를 보내면 `type`/`points`도 새 카테고리 기준으로 재계산해 스냅샷.
+
+**응답** (`200 OK`) — 부여(#94) 응답 DTO와 동일한 `ConductRecordResponse` 구조
+
+```json
+{
+  "success": true,
+  "data": {
+    "id": 501,
+    "studentUserId": 101,
+    "studentNickname": "길동이",
+    "teacherUserId": 42,
+    "teacherNickname": "김선생",
+    "categoryId": 6,
+    "categoryLabel": "무단조퇴",
+    "type": "DEMERIT",
+    "points": -3,
+    "detail": "3교시 이후 조퇴, 사유서 미제출",
+    "status": "ACTIVE",
+    "createdAt": "2026-08-12T09:15:00"
+  },
+  "message": "상/벌점 기록이 정정되었습니다."
+}
+```
+
+**구현 로직**
+1. `id`로 `ConductRecord` 조회. 없으면 `404` `CONDUCT_001`.
+2. 호출자가 `ADMIN`이 아니고 `principal.userId() != record.getTeacher().getId()`이면 `403` `CONDUCT_002`.
+3. `record.getStatus() == CANCELED`이면 `409` `CONDUCT_003`.
+4. 요청에 `categoryId`가 있으면 해당 `ConductCategory` 조회. 없거나 `active = false`이면 `400` `CONDUCT_004`. 조회 성공 시 `category`, `type`, `points` 재계산해 갱신.
+5. 요청에 `detail`이 있으면(`null`이 아니면) 갱신.
+6. 저장 후 `ConductRecordResponse.from(record)` 반환.
+
+**에러**
+
+| 조건 | HTTP | 코드 |
+|---|---|---|
+| `id` 없음 | 404 | `CONDUCT_001` |
+| 소유권 없음(ADMIN 아닌 경우) | 403 | `CONDUCT_002` |
+| 이미 취소됨 | 409 | `CONDUCT_003` |
+| `categoryId` 없거나 비활성화 | 400 | `CONDUCT_004` |
+
+---
+
+## 엔드포인트 2: `PATCH /api/v1/conduct-records/{id}/cancel` — 취소
+
+**권한**: 정정과 동일 (`TEACHER` 또는 `ADMIN`, 소유권 체크)
+
+**요청**
+```json
+{ "cancelReason": "학생 확인 결과 오인 부여로 확인됨" }
+```
+- `cancelReason`은 필수 항목이다. 취소 사유 없이 취소할 수 없다.
+
+**응답** (`200 OK`)
+
+```json
+{
+  "success": true,
+  "data": {
+    "id": 501,
+    "studentUserId": 101,
+    "studentNickname": "길동이",
+    "teacherUserId": 42,
+    "teacherNickname": "김선생",
+    "categoryId": 5,
+    "categoryLabel": "지각",
+    "type": "DEMERIT",
+    "points": -1,
+    "detail": "3교시 10분 지각",
+    "status": "CANCELED",
+    "createdAt": "2026-08-12T09:15:00"
+  },
+  "message": "상/벌점 기록이 취소되었습니다."
+}
+```
+
+**구현 로직**
+1~3단계는 정정과 동일(조회 → 소유권 → 상태 확인).
+4. `record.setStatus(CANCELED)`, `record.setCanceledAt(LocalDateTime.now(ZoneId.of("Asia/Seoul")))`, `record.setCanceledBy(cancelingUser)`, `record.setCancelReason(request.cancelReason())` 설정.
+5. 저장 후 `ConductRecordResponse.from(record)` 반환.
+
+**에러**: 정정과 동일한 코드 체계(CONDUCT_001~003).
+
+---
+
+## 데이터 모델 변경
+
+없음. `ConductRecord` 엔티티에 `canceledAt`, `canceledBy`, `cancelReason` 필드가 이미 존재한다(#94 V16 마이그레이션).
+
+---
+
+## 영향 받는 기존 코드
+
+- `ConductErrorCode`: CONDUCT_001~003 추가
+- `ConductRecordRepository`: `findById`는 이미 `JpaRepository` 기본 제공. 별도 커스텀 메서드 불필요.
+- `ConductService`: `amendConduct`, `cancelConduct` 메서드 추가
+- `ConductController`: `@PatchMapping("/{id}")`, `@PatchMapping("/{id}/cancel")` 추가
+- 신규 DTO: `ConductAmendRequest`, `ConductCancelRequest`
+- 응답 DTO: 기존 `ConductRecordResponse` 재사용 (변경 없음)
+
+---
+
+## API 설계 6원칙 체크
+
+1. **한 가지를 잘하기**: 정정과 취소를 별도 엔드포인트로 분리. 취소는 되돌릴 수 없으므로 명시적으로 `/cancel` 경로를 씀.
+2. **빠른 시작**: 요청/응답 예시 포함.
+3. **일관성**: 경로 `/api/v1/conduct-records/{id}`, `ApiResponse<T>` 래퍼, `ErrorCode` 네이밍(`CONDUCT_NNN`) 기존 패턴 그대로. 소유권 체크는 서비스 코드(`outing`과 동일 원칙).
+4. **의미 있는 오류**: CONDUCT_002(소유권 없음)와 CONDUCT_003(이미 취소됨)을 분리 — "권한이 없어서"와 "상태가 맞지 않아서"를 구분.
+5. **확장성/성능**: 단건 조회·갱신이라 성능 이슈 없음.
+6. **하위 호환성**: 기존 응답 필드 변경 없음. `ConductRecordResponse` 구조 그대로 재사용.
+
+---
+
+## 리스크 및 고려사항
+
+- **소유권 체크 누락**: ADMIN이 아닌 교사가 타인 기록을 수정하는 IDOR이 가장 위험한 실수 지점. 단위 테스트에서 반드시 검증.
+- **`cancelReason` 필수 처리**: `@NotBlank` 어노테이션으로 빈 문자열도 거부. `GlobalExceptionHandler`의 `MethodArgumentNotValidException` 핸들러가 `400 INVALID_REQUEST`로 처리.
+- **취소 불가역성**: 서비스 코드에서 취소 상태 검증(CONDUCT_003)으로 이중 취소 방지.
+- **동시성**: 같은 기록에 동시 정정/취소 이중 클릭은 낙관적 락(`@Version`, 이미 V16에 존재)으로 처리됨. 별도 락 전략 불필요.
+- **KST 시각**: `canceledAt`은 `ZoneId.of("Asia/Seoul")` 기준 — `outing` 도메인과 동일한 패턴.

--- a/docs/domain/conduct/107-conduct-amend-cancel.md
+++ b/docs/domain/conduct/107-conduct-amend-cancel.md
@@ -36,6 +36,7 @@
 { "categoryId": 6, "detail": "3교시 이후 조퇴, 사유서 미제출" }
 ```
 - `categoryId`만 보내거나, `detail`만 보내거나, 둘 다 보낼 수 있다.
+- **두 필드 모두 `null`인 경우(빈 바디 포함)는 `400` `COMMON_001 INVALID_REQUEST` 반환.** 변경할 내용이 없는 요청은 거부한다.
 - `detail`에 빈 문자열(`""`) 허용 여부: `null`은 "변경 없음"으로, `""` 전달 시 그대로 저장한다.
 - `categoryId`를 보내면 `type`/`points`도 새 카테고리 기준으로 재계산해 스냅샷.
 
@@ -74,6 +75,7 @@
 
 | 조건 | HTTP | 코드 |
 |---|---|---|
+| `categoryId`·`detail` 모두 null | 400 | `COMMON_001` |
 | `id` 없음 | 404 | `CONDUCT_001` |
 | 소유권 없음(ADMIN 아닌 경우) | 403 | `CONDUCT_002` |
 | 이미 취소됨 | 409 | `CONDUCT_003` |

--- a/postman/collections/gone-conduct.postman_collection.json
+++ b/postman/collections/gone-conduct.postman_collection.json
@@ -1038,7 +1038,7 @@
             ],
             "body": {
               "mode": "raw",
-              "raw": "{\"identifier\": \"qatest_teacher\", \"password\": \"Test1234!\"}"
+              "raw": "{\"identifier\": \"qatest_teacher\", \"password\": \"{{teacherPassword}}\"}"
             },
             "url": {
               "raw": "{{baseUrl}}/api/v1/auth/login",

--- a/postman/collections/gone-conduct.postman_collection.json
+++ b/postman/collections/gone-conduct.postman_collection.json
@@ -1,7 +1,7 @@
 {
   "info": {
     "name": "GONE - Conduct API",
-    "description": "상/벌점(Conduct) 도메인 API 컬렉션.\n\n**#92 카테고리 목록 조회**: 인증된 사용자 전체가 접근할 수 있습니다.\n**#94 상/벌점 부여**: 교사 토큰(`teacherAccessToken`)으로만 호출 가능합니다.\n\n로그인 요청은 각각 토큰을 `studentAccessToken`/`teacherAccessToken` 환경 변수에 자동으로 저장합니다.\n\n**실행 순서**: \"사전 준비\" 폴더(로그인) → 최상위 엔드포인트 → \"에러 케이스\" 폴더.\n\n**사전 조건**: `studentLoginId`/`studentPassword`, `teacherLoginId`/`teacherPassword` 테스트 계정이 DB에 있어야 합니다.",
+    "description": "GONE - Conduct API 컬렉션. #92 카테고리 목록 조회, #94 상/벌점 부여, #107 정정·취소 엔드포인트 포함.",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
   },
   "item": [
@@ -29,8 +29,15 @@
             },
             "url": {
               "raw": "{{baseUrl}}/api/v1/auth/login",
-              "host": ["{{baseUrl}}"],
-              "path": ["api", "v1", "auth", "login"]
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "auth",
+                "login"
+              ]
             }
           },
           "event": [
@@ -77,8 +84,15 @@
             },
             "url": {
               "raw": "{{baseUrl}}/api/v1/auth/login",
-              "host": ["{{baseUrl}}"],
-              "path": ["api", "v1", "auth", "login"]
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "auth",
+                "login"
+              ]
             }
           },
           "event": [
@@ -118,8 +132,15 @@
         ],
         "url": {
           "raw": "{{baseUrl}}/api/v1/conduct-records/categories",
-          "host": ["{{baseUrl}}"],
-          "path": ["api", "v1", "conduct-records", "categories"]
+          "host": [
+            "{{baseUrl}}"
+          ],
+          "path": [
+            "api",
+            "v1",
+            "conduct-records",
+            "categories"
+          ]
         },
         "description": "활성 카테고리 목록을 조회합니다. 인증된 사용자 전체가 접근할 수 있습니다(#92).\n\n**응답**: `data` 배열에 `id`/`label`/`type`/`points` 포함. `id`는 이후 부여 요청의 `categoryId`로 그대로 사용합니다."
       },
@@ -182,8 +203,14 @@
         },
         "url": {
           "raw": "{{baseUrl}}/api/v1/conduct-records",
-          "host": ["{{baseUrl}}"],
-          "path": ["api", "v1", "conduct-records"]
+          "host": [
+            "{{baseUrl}}"
+          ],
+          "path": [
+            "api",
+            "v1",
+            "conduct-records"
+          ]
         },
         "description": "교사가 학생에게 상점 또는 벌점을 부여합니다(#94).\n\n**권한**: TEACHER 전용. 학생/미인증 요청은 403/401 반환.\n\n**응답**: `201 Created`. `data`에 `id`/`studentUserId`/`studentNickname`/`teacherUserId`/`teacherNickname`/`categoryId`/`categoryLabel`/`type`/`points`/`detail`/`status`/`createdAt` 포함.\n\n**사전 조건**: \"사전 준비 > 교사 로그인\"으로 `teacherAccessToken` 설정, \"사전 준비 > 학생 로그인\"으로 `studentUserId` 설정."
       },
@@ -225,6 +252,87 @@
       ]
     },
     {
+      "name": "상/벌점 정정",
+      "request": {
+        "method": "PATCH",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          }
+        ],
+        "auth": {
+          "type": "bearer",
+          "bearer": [
+            {
+              "key": "token",
+              "value": "{{teacherAccessToken}}",
+              "type": "string"
+            }
+          ]
+        },
+        "body": {
+          "mode": "raw",
+          "raw": "{\"categoryId\": 20, \"detail\": \"수정된 상세 사유\"}"
+        },
+        "url": {
+          "raw": "{{baseUrl}}/api/v1/conduct-records/{{recordId}}",
+          "host": [
+            "{{baseUrl}}"
+          ],
+          "path": [
+            "api",
+            "v1",
+            "conduct-records",
+            "{{recordId}}"
+          ]
+        },
+        "description": "TEACHER 또는 ADMIN이 기존 상/벌점 기록을 정정한다. categoryId 또는 detail 중 하나 이상 필수."
+      },
+      "response": []
+    },
+    {
+      "name": "상/벌점 취소",
+      "request": {
+        "method": "PATCH",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          }
+        ],
+        "auth": {
+          "type": "bearer",
+          "bearer": [
+            {
+              "key": "token",
+              "value": "{{teacherAccessToken}}",
+              "type": "string"
+            }
+          ]
+        },
+        "body": {
+          "mode": "raw",
+          "raw": "{\"cancelReason\": \"오인 부여로 확인됨\"}"
+        },
+        "url": {
+          "raw": "{{baseUrl}}/api/v1/conduct-records/{{recordId}}/cancel",
+          "host": [
+            "{{baseUrl}}"
+          ],
+          "path": [
+            "api",
+            "v1",
+            "conduct-records",
+            "{{recordId}}",
+            "cancel"
+          ]
+        },
+        "description": "TEACHER 또는 ADMIN이 기존 상/벌점 기록을 취소한다. 취소는 되돌릴 수 없다."
+      },
+      "response": []
+    },
+    {
       "name": "에러 케이스",
       "item": [
         {
@@ -234,8 +342,15 @@
             "header": [],
             "url": {
               "raw": "{{baseUrl}}/api/v1/conduct-records/categories",
-              "host": ["{{baseUrl}}"],
-              "path": ["api", "v1", "conduct-records", "categories"]
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "conduct-records",
+                "categories"
+              ]
             },
             "description": "Authorization 헤더 없이 요청하면 401을 반환해야 합니다."
           },
@@ -282,8 +397,14 @@
             },
             "url": {
               "raw": "{{baseUrl}}/api/v1/conduct-records",
-              "host": ["{{baseUrl}}"],
-              "path": ["api", "v1", "conduct-records"]
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "conduct-records"
+              ]
             },
             "description": "STUDENT 권한 토큰으로 부여 요청 시 403 COMMON_003을 반환해야 합니다."
           },
@@ -326,8 +447,14 @@
             },
             "url": {
               "raw": "{{baseUrl}}/api/v1/conduct-records",
-              "host": ["{{baseUrl}}"],
-              "path": ["api", "v1", "conduct-records"]
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "conduct-records"
+              ]
             },
             "description": "인증 없이 부여 요청 시 401 COMMON_002를 반환해야 합니다."
           },
@@ -374,8 +501,14 @@
             },
             "url": {
               "raw": "{{baseUrl}}/api/v1/conduct-records",
-              "host": ["{{baseUrl}}"],
-              "path": ["api", "v1", "conduct-records"]
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "conduct-records"
+              ]
             },
             "description": "존재하지 않는 studentUserId로 요청 시 404 CONDUCT_005를 반환해야 합니다."
           },
@@ -422,8 +555,14 @@
             },
             "url": {
               "raw": "{{baseUrl}}/api/v1/conduct-records",
-              "host": ["{{baseUrl}}"],
-              "path": ["api", "v1", "conduct-records"]
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "conduct-records"
+              ]
             },
             "description": "studentUserId에 교사의 ID를 입력하면 STUDENT 역할이 없으므로 400 CONDUCT_006을 반환해야 합니다."
           },
@@ -470,8 +609,14 @@
             },
             "url": {
               "raw": "{{baseUrl}}/api/v1/conduct-records",
-              "host": ["{{baseUrl}}"],
-              "path": ["api", "v1", "conduct-records"]
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "conduct-records"
+              ]
             },
             "description": "존재하지 않는 categoryId로 요청 시 400 CONDUCT_004를 반환해야 합니다."
           },
@@ -492,6 +637,163 @@
               }
             }
           ]
+        },
+        {
+          "name": "존재하지 않는 recordId 정정 → 404 CONDUCT_001",
+          "request": {
+            "method": "PATCH",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{teacherAccessToken}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\"detail\": \"없는 기록\"}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/conduct-records/99999",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "conduct-records",
+                "99999"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "타 교사 기록 정정 시도 → 403 CONDUCT_002",
+          "request": {
+            "method": "PATCH",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{otherTeacherAccessToken}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\"detail\": \"타 교사 수정 시도\"}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/conduct-records/{{recordId}}",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "conduct-records",
+                "{{recordId}}"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "이미 취소된 기록 재취소 → 409 CONDUCT_003",
+          "request": {
+            "method": "PATCH",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{teacherAccessToken}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\"cancelReason\": \"재취소 시도\"}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/conduct-records/{{canceledRecordId}}/cancel",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "conduct-records",
+                "{{canceledRecordId}}",
+                "cancel"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "양 필드 모두 null 정정 → 400 COMMON_001",
+          "request": {
+            "method": "PATCH",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{teacherAccessToken}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/conduct-records/{{recordId}}",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "conduct-records",
+                "{{recordId}}"
+              ]
+            }
+          },
+          "response": []
         }
       ]
     },
@@ -520,8 +822,15 @@
             },
             "url": {
               "raw": "{{baseUrl}}/api/v1/auth/login",
-              "host": ["{{baseUrl}}"],
-              "path": ["api", "v1", "auth", "login"]
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "auth",
+                "login"
+              ]
             }
           },
           "event": [
@@ -568,8 +877,15 @@
             },
             "url": {
               "raw": "{{baseUrl}}/api/v1/auth/login",
-              "host": ["{{baseUrl}}"],
-              "path": ["api", "v1", "auth", "login"]
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "auth",
+                "login"
+              ]
             }
           },
           "event": [
@@ -607,8 +923,15 @@
             ],
             "url": {
               "raw": "{{baseUrl}}/api/v1/conduct-records/categories",
-              "host": ["{{baseUrl}}"],
-              "path": ["api", "v1", "conduct-records", "categories"]
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "conduct-records",
+                "categories"
+              ]
             },
             "description": "부여할 categoryId 확인용."
           },
@@ -651,8 +974,14 @@
             },
             "url": {
               "raw": "{{baseUrl}}/api/v1/conduct-records",
-              "host": ["{{baseUrl}}"],
-              "path": ["api", "v1", "conduct-records"]
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "conduct-records"
+              ]
             }
           },
           "event": [
@@ -676,6 +1005,184 @@
               }
             }
           ]
+        }
+      ]
+    },
+    {
+      "name": "상/벌점 정정·취소 확인 (#107)",
+      "item": [
+        {
+          "name": "1. 교사 로그인",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "var res = pm.response.json();",
+                  "if (res.success) {",
+                  "  pm.collectionVariables.set('teacherAccessToken', res.data.accessToken);",
+                  "  pm.collectionVariables.set('teacherUserId', res.data.userId);",
+                  "}"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\"identifier\": \"qatest_teacher\", \"password\": \"Test1234!\"}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/auth/login",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "auth",
+                "login"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "2. 상/벌점 부여 (정정·취소 대상 기록 생성)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "var res = pm.response.json();",
+                  "if (res.success) pm.collectionVariables.set('recordId', res.data.id);"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{teacherAccessToken}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\"studentUserId\": \"{{studentUserId}}\", \"categoryId\": 19, \"detail\": \"QA 테스트 기록\"}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/conduct-records",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "conduct-records"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "3. 정정 (categoryId + detail)",
+          "request": {
+            "method": "PATCH",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{teacherAccessToken}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\"categoryId\": 20, \"detail\": \"수정된 사유\"}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/conduct-records/{{recordId}}",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "conduct-records",
+                "{{recordId}}"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "4. 취소",
+          "request": {
+            "method": "PATCH",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{teacherAccessToken}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\"cancelReason\": \"QA 취소 확인\"}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/conduct-records/{{recordId}}/cancel",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "conduct-records",
+                "{{recordId}}",
+                "cancel"
+              ]
+            }
+          },
+          "response": []
         }
       ]
     }

--- a/src/main/java/com/remake/gone/conduct/controller/ConductController.java
+++ b/src/main/java/com/remake/gone/conduct/controller/ConductController.java
@@ -2,6 +2,8 @@ package com.remake.gone.conduct.controller;
 
 import com.remake.gone.common.response.ApiResponse;
 import com.remake.gone.common.security.UserPrincipal;
+import com.remake.gone.conduct.dto.ConductAmendRequest;
+import com.remake.gone.conduct.dto.ConductCancelRequest;
 import com.remake.gone.conduct.dto.ConductCategoryResponse;
 import com.remake.gone.conduct.dto.ConductGrantRequest;
 import com.remake.gone.conduct.dto.ConductRecordResponse;
@@ -13,6 +15,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -22,7 +26,7 @@ import org.springframework.web.bind.annotation.RestController;
 /**
  * 상/벌점(Conduct) 도메인 API 컨트롤러.
  *
- * <p>#92에서 카테고리 목록 조회, #94에서 상/벌점 부여 엔드포인트를 구현했다.
+ * <p>#92에서 카테고리 목록 조회, #94에서 상/벌점 부여, #107에서 정정·취소 엔드포인트를 구현했다.
  */
 @RestController
 @RequestMapping("/api/v1/conduct-records")
@@ -58,5 +62,47 @@ public class ConductController {
     return ApiResponse.success(
         conductService.grantConduct(principal.userId(), request),
         "상/벌점이 부여되었습니다.");
+  }
+
+  /**
+   * 상/벌점 기록을 정정합니다.
+   *
+   * <p>TEACHER는 본인이 부여한 기록만 정정할 수 있습니다.
+   *
+   * @param principal 인증된 사용자 정보
+   * @param id        정정할 기록 ID
+   * @param request   정정 요청 정보
+   * @return 정정된 상/벌점 기록
+   */
+  @PatchMapping("/{id}")
+  @PreAuthorize("hasRole('TEACHER') or hasRole('ADMIN')")
+  public ApiResponse<ConductRecordResponse> amendConduct(
+      @AuthenticationPrincipal UserPrincipal principal,
+      @PathVariable Long id,
+      @Valid @RequestBody ConductAmendRequest request) {
+    return ApiResponse.success(
+        conductService.amendConduct(principal.userId(), id, request),
+        "상/벌점 기록이 정정되었습니다.");
+  }
+
+  /**
+   * 상/벌점 기록을 취소합니다.
+   *
+   * <p>TEACHER는 본인이 부여한 기록만 취소할 수 있습니다. 취소는 되돌릴 수 없습니다.
+   *
+   * @param principal 인증된 사용자 정보
+   * @param id        취소할 기록 ID
+   * @param request   취소 요청 정보
+   * @return 취소된 상/벌점 기록
+   */
+  @PatchMapping("/{id}/cancel")
+  @PreAuthorize("hasRole('TEACHER') or hasRole('ADMIN')")
+  public ApiResponse<ConductRecordResponse> cancelConduct(
+      @AuthenticationPrincipal UserPrincipal principal,
+      @PathVariable Long id,
+      @Valid @RequestBody ConductCancelRequest request) {
+    return ApiResponse.success(
+        conductService.cancelConduct(principal.userId(), id, request),
+        "상/벌점 기록이 취소되었습니다.");
   }
 }

--- a/src/main/java/com/remake/gone/conduct/dto/ConductAmendRequest.java
+++ b/src/main/java/com/remake/gone/conduct/dto/ConductAmendRequest.java
@@ -1,0 +1,14 @@
+package com.remake.gone.conduct.dto;
+
+import jakarta.validation.constraints.Size;
+
+/**
+ * 상/벌점 정정 요청 DTO.
+ *
+ * @param categoryId 변경할 카테고리 ID (생략 시 기존 값 유지)
+ * @param detail     변경할 상세 사유 (생략 시 기존 값 유지, 최대 500자)
+ */
+public record ConductAmendRequest(
+    Long categoryId,
+    @Size(max = 500) String detail
+) {}

--- a/src/main/java/com/remake/gone/conduct/dto/ConductCancelRequest.java
+++ b/src/main/java/com/remake/gone/conduct/dto/ConductCancelRequest.java
@@ -1,0 +1,13 @@
+package com.remake.gone.conduct.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+/**
+ * 상/벌점 취소 요청 DTO.
+ *
+ * @param cancelReason 취소 사유 (필수, 최대 500자)
+ */
+public record ConductCancelRequest(
+    @NotBlank @Size(max = 500) String cancelReason
+) {}

--- a/src/main/java/com/remake/gone/conduct/exception/ConductErrorCode.java
+++ b/src/main/java/com/remake/gone/conduct/exception/ConductErrorCode.java
@@ -12,6 +12,15 @@ import org.springframework.http.HttpStatus;
  */
 public enum ConductErrorCode implements ErrorCode {
 
+  /** 상/벌점 기록을 찾을 수 없습니다. */
+  RECORD_NOT_FOUND(HttpStatus.NOT_FOUND, "CONDUCT_001", "상/벌점 기록을 찾을 수 없습니다."),
+
+  /** 본인이 부여한 기록만 처리할 수 있습니다. */
+  NOT_RECORD_OWNER(HttpStatus.FORBIDDEN, "CONDUCT_002", "본인이 부여한 기록만 처리할 수 있습니다."),
+
+  /** 이미 취소된 기록입니다. */
+  ALREADY_CANCELED(HttpStatus.CONFLICT, "CONDUCT_003", "이미 취소된 기록입니다."),
+
   /** 존재하지 않거나 비활성화된 카테고리입니다. */
   CATEGORY_NOT_FOUND_OR_INACTIVE(HttpStatus.BAD_REQUEST, "CONDUCT_004",
       "존재하지 않거나 비활성화된 카테고리입니다."),

--- a/src/main/java/com/remake/gone/conduct/service/ConductService.java
+++ b/src/main/java/com/remake/gone/conduct/service/ConductService.java
@@ -98,6 +98,10 @@ public class ConductService {
   @Transactional
   public ConductRecordResponse amendConduct(
       Long callerUserId, Long recordId, ConductAmendRequest request) {
+    if (request.categoryId() == null && request.detail() == null) {
+      throw new CustomException(CommonErrorCode.INVALID_REQUEST);
+    }
+
     ConductRecord record = conductRecordRepository.findById(recordId)
         .orElseThrow(() -> new CustomException(ConductErrorCode.RECORD_NOT_FOUND));
 

--- a/src/main/java/com/remake/gone/conduct/service/ConductService.java
+++ b/src/main/java/com/remake/gone/conduct/service/ConductService.java
@@ -2,17 +2,22 @@ package com.remake.gone.conduct.service;
 
 import com.remake.gone.common.exception.CommonErrorCode;
 import com.remake.gone.common.exception.CustomException;
+import com.remake.gone.conduct.dto.ConductAmendRequest;
+import com.remake.gone.conduct.dto.ConductCancelRequest;
 import com.remake.gone.conduct.dto.ConductCategoryResponse;
 import com.remake.gone.conduct.dto.ConductGrantRequest;
 import com.remake.gone.conduct.dto.ConductRecordResponse;
 import com.remake.gone.conduct.entity.ConductCategory;
 import com.remake.gone.conduct.entity.ConductRecord;
+import com.remake.gone.conduct.enums.ConductStatus;
 import com.remake.gone.conduct.exception.ConductErrorCode;
 import com.remake.gone.conduct.repository.ConductCategoryRepository;
 import com.remake.gone.conduct.repository.ConductRecordRepository;
 import com.remake.gone.role.repository.UserRoleRepository;
 import com.remake.gone.user.entity.User;
 import com.remake.gone.user.repository.UserRepository;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -24,6 +29,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class ConductService {
 
   private static final String STUDENT_ROLE_CODE = "STUDENT";
+  private static final String ADMIN_ROLE_CODE = "ADMIN";
 
   private final ConductCategoryRepository conductCategoryRepository;
   private final ConductRecordRepository conductRecordRepository;
@@ -76,5 +82,86 @@ public class ConductService {
         .build();
 
     return ConductRecordResponse.from(conductRecordRepository.save(record));
+  }
+
+  /**
+   * 상/벌점 기록을 정정합니다.
+   *
+   * <p>TEACHER는 본인이 부여한 기록만 정정할 수 있습니다. ADMIN은 소유권 무관하게 정정할 수 있습니다.
+   * CANCELED 상태인 기록은 정정할 수 없습니다.
+   *
+   * @param callerUserId  호출자 사용자 ID (Access Token에서 추출됨)
+   * @param recordId      정정할 기록 ID
+   * @param request       정정 요청 정보
+   * @return 정정된 상/벌점 기록
+   */
+  @Transactional
+  public ConductRecordResponse amendConduct(
+      Long callerUserId, Long recordId, ConductAmendRequest request) {
+    ConductRecord record = conductRecordRepository.findById(recordId)
+        .orElseThrow(() -> new CustomException(ConductErrorCode.RECORD_NOT_FOUND));
+
+    boolean isAdmin = userRoleRepository.findRoleCodesByUserId(callerUserId)
+        .contains(ADMIN_ROLE_CODE);
+    if (!isAdmin && !callerUserId.equals(record.getTeacher().getId())) {
+      throw new CustomException(ConductErrorCode.NOT_RECORD_OWNER);
+    }
+
+    if (record.getStatus() == ConductStatus.CANCELED) {
+      throw new CustomException(ConductErrorCode.ALREADY_CANCELED);
+    }
+
+    if (request.categoryId() != null) {
+      ConductCategory newCategory = conductCategoryRepository.findById(request.categoryId())
+          .filter(ConductCategory::isActive)
+          .orElseThrow(() -> new CustomException(ConductErrorCode.CATEGORY_NOT_FOUND_OR_INACTIVE));
+      record.setCategory(newCategory);
+      record.setType(newCategory.getType());
+      record.setPoints(newCategory.getPoints());
+    }
+
+    if (request.detail() != null) {
+      record.setDetail(request.detail());
+    }
+
+    return ConductRecordResponse.from(record);
+  }
+
+  /**
+   * 상/벌점 기록을 취소합니다.
+   *
+   * <p>TEACHER는 본인이 부여한 기록만 취소할 수 있습니다. ADMIN은 소유권 무관하게 취소할 수 있습니다.
+   * 이미 취소된 기록은 다시 취소할 수 없습니다.
+   *
+   * @param callerUserId  호출자 사용자 ID (Access Token에서 추출됨)
+   * @param recordId      취소할 기록 ID
+   * @param request       취소 요청 정보
+   * @return 취소된 상/벌점 기록
+   */
+  @Transactional
+  public ConductRecordResponse cancelConduct(
+      Long callerUserId, Long recordId, ConductCancelRequest request) {
+    ConductRecord record = conductRecordRepository.findById(recordId)
+        .orElseThrow(() -> new CustomException(ConductErrorCode.RECORD_NOT_FOUND));
+
+    boolean isAdmin = userRoleRepository.findRoleCodesByUserId(callerUserId)
+        .contains(ADMIN_ROLE_CODE);
+    if (!isAdmin && !callerUserId.equals(record.getTeacher().getId())) {
+      throw new CustomException(ConductErrorCode.NOT_RECORD_OWNER);
+    }
+
+    if (record.getStatus() == ConductStatus.CANCELED) {
+      throw new CustomException(ConductErrorCode.ALREADY_CANCELED);
+    }
+
+    User cancelingUser = userRepository.findById(callerUserId)
+        .orElseThrow(() -> new CustomException(CommonErrorCode.NOT_FOUND));
+
+    record.setStatus(ConductStatus.CANCELED);
+    record.setCanceledAt(LocalDateTime.now(ZoneId.of("Asia/Seoul")));
+    record.setCanceledBy(cancelingUser);
+    record.setCancelReason(request.cancelReason());
+
+    return ConductRecordResponse.from(record);
   }
 }

--- a/src/test/java/com/remake/gone/conduct/service/ConductServiceTest.java
+++ b/src/test/java/com/remake/gone/conduct/service/ConductServiceTest.java
@@ -6,6 +6,8 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 
 import com.remake.gone.common.exception.CustomException;
+import com.remake.gone.conduct.dto.ConductAmendRequest;
+import com.remake.gone.conduct.dto.ConductCancelRequest;
 import com.remake.gone.conduct.dto.ConductCategoryResponse;
 import com.remake.gone.conduct.dto.ConductGrantRequest;
 import com.remake.gone.conduct.dto.ConductRecordResponse;
@@ -224,6 +226,304 @@ class ConductServiceTest {
           .isInstanceOf(CustomException.class)
           .extracting(e -> ((CustomException) e).getErrorCode())
           .isEqualTo(ConductErrorCode.NOT_STUDENT_ROLE);
+    }
+  }
+
+  @Nested
+  @DisplayName("amendConduct")
+  class AmendConduct {
+
+    private final Long teacherUserId = 42L;
+    private final Long otherTeacherUserId = 99L;
+    private final Long studentUserId = 101L;
+    private final Long recordId = 501L;
+    private final Long categoryId = 5L;
+    private final Long newCategoryId = 6L;
+
+    private ConductCategory demeritsCategory() {
+      return ConductCategory.builder()
+          .id(categoryId)
+          .label("지각")
+          .type(ConductType.DEMERIT)
+          .points(-1)
+          .active(true)
+          .build();
+    }
+
+    private ConductCategory newDemeritsCategory() {
+      return ConductCategory.builder()
+          .id(newCategoryId)
+          .label("무단조퇴")
+          .type(ConductType.DEMERIT)
+          .points(-3)
+          .active(true)
+          .build();
+    }
+
+    private ConductRecord activeRecord(ConductCategory category) {
+      User student = User.builder().id(studentUserId).name("길동이").build();
+      User teacher = User.builder().id(teacherUserId).name("김선생").build();
+      return ConductRecord.builder()
+          .id(recordId)
+          .student(student)
+          .teacher(teacher)
+          .category(category)
+          .type(category.getType())
+          .points(category.getPoints())
+          .detail("3교시 10분 지각")
+          .status(ConductStatus.ACTIVE)
+          .version(0L)
+          .build();
+    }
+
+    @Test
+    @DisplayName("categoryId와 detail을 모두 정정하면 category·type·points·detail이 갱신된다")
+    void amendsBothCategoryAndDetail() {
+      ConductRecord record = activeRecord(demeritsCategory());
+      ConductCategory newCategory = newDemeritsCategory();
+      ConductAmendRequest request = new ConductAmendRequest(newCategoryId, "3교시 이후 조퇴");
+
+      given(conductRecordRepository.findById(recordId)).willReturn(Optional.of(record));
+      given(userRoleRepository.findRoleCodesByUserId(teacherUserId))
+          .willReturn(List.of("TEACHER"));
+      given(conductCategoryRepository.findById(newCategoryId))
+          .willReturn(Optional.of(newCategory));
+
+      ConductRecordResponse result = conductService.amendConduct(teacherUserId, recordId, request);
+
+      assertThat(result.categoryId()).isEqualTo(newCategoryId);
+      assertThat(result.categoryLabel()).isEqualTo("무단조퇴");
+      assertThat(result.type()).isEqualTo(ConductType.DEMERIT);
+      assertThat(result.points()).isEqualTo(-3);
+      assertThat(result.detail()).isEqualTo("3교시 이후 조퇴");
+    }
+
+    @Test
+    @DisplayName("detail만 정정하면 category·type·points는 변경되지 않는다")
+    void amendsDetailOnly() {
+      ConductRecord record = activeRecord(demeritsCategory());
+      ConductAmendRequest request = new ConductAmendRequest(null, "수업 10분 전 지각");
+
+      given(conductRecordRepository.findById(recordId)).willReturn(Optional.of(record));
+      given(userRoleRepository.findRoleCodesByUserId(teacherUserId))
+          .willReturn(List.of("TEACHER"));
+
+      ConductRecordResponse result = conductService.amendConduct(teacherUserId, recordId, request);
+
+      assertThat(result.categoryId()).isEqualTo(categoryId);
+      assertThat(result.points()).isEqualTo(-1);
+      assertThat(result.detail()).isEqualTo("수업 10분 전 지각");
+    }
+
+    @Test
+    @DisplayName("ADMIN은 본인이 부여하지 않은 기록도 정정할 수 있다")
+    void adminCanAmendAnyRecord() {
+      Long adminUserId = 999L;
+      ConductRecord record = activeRecord(demeritsCategory());
+      ConductAmendRequest request = new ConductAmendRequest(null, "ADMIN 수정");
+
+      given(conductRecordRepository.findById(recordId)).willReturn(Optional.of(record));
+      given(userRoleRepository.findRoleCodesByUserId(adminUserId))
+          .willReturn(List.of("ADMIN"));
+
+      ConductRecordResponse result = conductService.amendConduct(adminUserId, recordId, request);
+
+      assertThat(result.detail()).isEqualTo("ADMIN 수정");
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 recordId이면 CONDUCT_001 예외를 던진다")
+    void throwsWhenRecordNotFound() {
+      given(conductRecordRepository.findById(recordId)).willReturn(Optional.empty());
+
+      assertThatThrownBy(() -> conductService.amendConduct(
+          teacherUserId, recordId, new ConductAmendRequest(null, null)))
+          .isInstanceOf(CustomException.class)
+          .extracting(e -> ((CustomException) e).getErrorCode())
+          .isEqualTo(ConductErrorCode.RECORD_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("본인이 부여하지 않은 기록을 TEACHER가 정정하면 CONDUCT_002 예외를 던진다")
+    void throwsWhenNotRecordOwner() {
+      ConductRecord record = activeRecord(demeritsCategory());
+
+      given(conductRecordRepository.findById(recordId)).willReturn(Optional.of(record));
+      given(userRoleRepository.findRoleCodesByUserId(otherTeacherUserId))
+          .willReturn(List.of("TEACHER"));
+
+      assertThatThrownBy(() -> conductService.amendConduct(
+          otherTeacherUserId, recordId, new ConductAmendRequest(null, "수정 시도")))
+          .isInstanceOf(CustomException.class)
+          .extracting(e -> ((CustomException) e).getErrorCode())
+          .isEqualTo(ConductErrorCode.NOT_RECORD_OWNER);
+    }
+
+    @Test
+    @DisplayName("이미 취소된 기록이면 CONDUCT_003 예외를 던진다")
+    void throwsWhenAlreadyCanceled() {
+      ConductRecord canceledRecord = ConductRecord.builder()
+          .id(recordId)
+          .student(User.builder().id(studentUserId).name("길동이").build())
+          .teacher(User.builder().id(teacherUserId).name("김선생").build())
+          .category(demeritsCategory())
+          .type(ConductType.DEMERIT)
+          .points(-1)
+          .status(ConductStatus.CANCELED)
+          .version(1L)
+          .build();
+
+      given(conductRecordRepository.findById(recordId)).willReturn(Optional.of(canceledRecord));
+      given(userRoleRepository.findRoleCodesByUserId(teacherUserId))
+          .willReturn(List.of("TEACHER"));
+
+      assertThatThrownBy(() -> conductService.amendConduct(
+          teacherUserId, recordId, new ConductAmendRequest(null, "수정 시도")))
+          .isInstanceOf(CustomException.class)
+          .extracting(e -> ((CustomException) e).getErrorCode())
+          .isEqualTo(ConductErrorCode.ALREADY_CANCELED);
+    }
+
+    @Test
+    @DisplayName("비활성 categoryId로 정정하면 CONDUCT_004 예외를 던진다")
+    void throwsWhenNewCategoryInactive() {
+      ConductRecord record = activeRecord(demeritsCategory());
+      ConductCategory inactiveCategory = ConductCategory.builder()
+          .id(newCategoryId).label("무단조퇴").type(ConductType.DEMERIT).points(-3).active(false)
+          .build();
+
+      given(conductRecordRepository.findById(recordId)).willReturn(Optional.of(record));
+      given(userRoleRepository.findRoleCodesByUserId(teacherUserId))
+          .willReturn(List.of("TEACHER"));
+      given(conductCategoryRepository.findById(newCategoryId))
+          .willReturn(Optional.of(inactiveCategory));
+
+      assertThatThrownBy(() -> conductService.amendConduct(
+          teacherUserId, recordId, new ConductAmendRequest(newCategoryId, null)))
+          .isInstanceOf(CustomException.class)
+          .extracting(e -> ((CustomException) e).getErrorCode())
+          .isEqualTo(ConductErrorCode.CATEGORY_NOT_FOUND_OR_INACTIVE);
+    }
+  }
+
+  @Nested
+  @DisplayName("cancelConduct")
+  class CancelConduct {
+
+    private final Long teacherUserId = 42L;
+    private final Long otherTeacherUserId = 99L;
+    private final Long studentUserId = 101L;
+    private final Long recordId = 501L;
+    private final Long categoryId = 5L;
+
+    private ConductCategory demeritsCategory() {
+      return ConductCategory.builder()
+          .id(categoryId).label("지각").type(ConductType.DEMERIT).points(-1).active(true).build();
+    }
+
+    private ConductRecord activeRecord() {
+      User student = User.builder().id(studentUserId).name("길동이").build();
+      User teacher = User.builder().id(teacherUserId).name("김선생").build();
+      return ConductRecord.builder()
+          .id(recordId)
+          .student(student)
+          .teacher(teacher)
+          .category(demeritsCategory())
+          .type(ConductType.DEMERIT)
+          .points(-1)
+          .detail("3교시 10분 지각")
+          .status(ConductStatus.ACTIVE)
+          .version(0L)
+          .build();
+    }
+
+    @Test
+    @DisplayName("정상 취소 시 status가 CANCELED로 변경되고 취소 사유가 저장된다")
+    void cancelsRecordSuccessfully() {
+      ConductRecord record = activeRecord();
+      User teacherUser = User.builder().id(teacherUserId).name("김선생").build();
+      ConductCancelRequest request = new ConductCancelRequest("오인 부여 확인됨");
+
+      given(conductRecordRepository.findById(recordId)).willReturn(Optional.of(record));
+      given(userRoleRepository.findRoleCodesByUserId(teacherUserId))
+          .willReturn(List.of("TEACHER"));
+      given(userRepository.findById(teacherUserId)).willReturn(Optional.of(teacherUser));
+
+      ConductRecordResponse result =
+          conductService.cancelConduct(teacherUserId, recordId, request);
+
+      assertThat(result.status()).isEqualTo(ConductStatus.CANCELED);
+    }
+
+    @Test
+    @DisplayName("ADMIN은 본인이 부여하지 않은 기록도 취소할 수 있다")
+    void adminCanCancelAnyRecord() {
+      Long adminUserId = 999L;
+      ConductRecord record = activeRecord();
+      User adminUser = User.builder().id(adminUserId).name("관리자").build();
+      ConductCancelRequest request = new ConductCancelRequest("ADMIN 취소");
+
+      given(conductRecordRepository.findById(recordId)).willReturn(Optional.of(record));
+      given(userRoleRepository.findRoleCodesByUserId(adminUserId))
+          .willReturn(List.of("ADMIN"));
+      given(userRepository.findById(adminUserId)).willReturn(Optional.of(adminUser));
+
+      ConductRecordResponse result = conductService.cancelConduct(adminUserId, recordId, request);
+
+      assertThat(result.status()).isEqualTo(ConductStatus.CANCELED);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 recordId이면 CONDUCT_001 예외를 던진다")
+    void throwsWhenRecordNotFound() {
+      given(conductRecordRepository.findById(recordId)).willReturn(Optional.empty());
+
+      assertThatThrownBy(() -> conductService.cancelConduct(
+          teacherUserId, recordId, new ConductCancelRequest("취소 사유")))
+          .isInstanceOf(CustomException.class)
+          .extracting(e -> ((CustomException) e).getErrorCode())
+          .isEqualTo(ConductErrorCode.RECORD_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("본인이 부여하지 않은 기록을 TEACHER가 취소하면 CONDUCT_002 예외를 던진다")
+    void throwsWhenNotRecordOwner() {
+      ConductRecord record = activeRecord();
+
+      given(conductRecordRepository.findById(recordId)).willReturn(Optional.of(record));
+      given(userRoleRepository.findRoleCodesByUserId(otherTeacherUserId))
+          .willReturn(List.of("TEACHER"));
+
+      assertThatThrownBy(() -> conductService.cancelConduct(
+          otherTeacherUserId, recordId, new ConductCancelRequest("취소 시도")))
+          .isInstanceOf(CustomException.class)
+          .extracting(e -> ((CustomException) e).getErrorCode())
+          .isEqualTo(ConductErrorCode.NOT_RECORD_OWNER);
+    }
+
+    @Test
+    @DisplayName("이미 취소된 기록이면 CONDUCT_003 예외를 던진다")
+    void throwsWhenAlreadyCanceled() {
+      ConductRecord canceledRecord = ConductRecord.builder()
+          .id(recordId)
+          .student(User.builder().id(studentUserId).name("길동이").build())
+          .teacher(User.builder().id(teacherUserId).name("김선생").build())
+          .category(demeritsCategory())
+          .type(ConductType.DEMERIT)
+          .points(-1)
+          .status(ConductStatus.CANCELED)
+          .version(1L)
+          .build();
+
+      given(conductRecordRepository.findById(recordId)).willReturn(Optional.of(canceledRecord));
+      given(userRoleRepository.findRoleCodesByUserId(teacherUserId))
+          .willReturn(List.of("TEACHER"));
+
+      assertThatThrownBy(() -> conductService.cancelConduct(
+          teacherUserId, recordId, new ConductCancelRequest("재취소 시도")))
+          .isInstanceOf(CustomException.class)
+          .extracting(e -> ((CustomException) e).getErrorCode())
+          .isEqualTo(ConductErrorCode.ALREADY_CANCELED);
     }
   }
 }

--- a/src/test/java/com/remake/gone/conduct/service/ConductServiceTest.java
+++ b/src/test/java/com/remake/gone/conduct/service/ConductServiceTest.java
@@ -460,10 +460,12 @@ class ConductServiceTest {
           .willReturn(List.of("TEACHER"));
       given(userRepository.findById(teacherUserId)).willReturn(Optional.of(teacherUser));
 
-      ConductRecordResponse result =
-          conductService.cancelConduct(teacherUserId, recordId, request);
+      conductService.cancelConduct(teacherUserId, recordId, request);
 
-      assertThat(result.status()).isEqualTo(ConductStatus.CANCELED);
+      assertThat(record.getStatus()).isEqualTo(ConductStatus.CANCELED);
+      assertThat(record.getCancelReason()).isEqualTo("오인 부여 확인됨");
+      assertThat(record.getCanceledBy()).isEqualTo(teacherUser);
+      assertThat(record.getCanceledAt()).isNotNull();
     }
 
     @Test

--- a/src/test/java/com/remake/gone/conduct/service/ConductServiceTest.java
+++ b/src/test/java/com/remake/gone/conduct/service/ConductServiceTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 
+import com.remake.gone.common.exception.CommonErrorCode;
 import com.remake.gone.common.exception.CustomException;
 import com.remake.gone.conduct.dto.ConductAmendRequest;
 import com.remake.gone.conduct.dto.ConductCancelRequest;
@@ -332,12 +333,22 @@ class ConductServiceTest {
     }
 
     @Test
+    @DisplayName("categoryId·detail 둘 다 null이면 COMMON_001 예외를 던진다")
+    void throwsWhenBothFieldsNull() {
+      assertThatThrownBy(() -> conductService.amendConduct(
+          teacherUserId, recordId, new ConductAmendRequest(null, null)))
+          .isInstanceOf(CustomException.class)
+          .extracting(e -> ((CustomException) e).getErrorCode())
+          .isEqualTo(CommonErrorCode.INVALID_REQUEST);
+    }
+
+    @Test
     @DisplayName("존재하지 않는 recordId이면 CONDUCT_001 예외를 던진다")
     void throwsWhenRecordNotFound() {
       given(conductRecordRepository.findById(recordId)).willReturn(Optional.empty());
 
       assertThatThrownBy(() -> conductService.amendConduct(
-          teacherUserId, recordId, new ConductAmendRequest(null, null)))
+          teacherUserId, recordId, new ConductAmendRequest(null, "변경")))
           .isInstanceOf(CustomException.class)
           .extracting(e -> ((CustomException) e).getErrorCode())
           .isEqualTo(ConductErrorCode.RECORD_NOT_FOUND);

--- a/src/test/java/com/remake/gone/conduct/service/ConductServiceTest.java
+++ b/src/test/java/com/remake/gone/conduct/service/ConductServiceTest.java
@@ -453,13 +453,12 @@ class ConductServiceTest {
     void cancelsRecordSuccessfully() {
       ConductRecord record = activeRecord();
       User teacherUser = User.builder().id(teacherUserId).name("김선생").build();
-      ConductCancelRequest request = new ConductCancelRequest("오인 부여 확인됨");
-
       given(conductRecordRepository.findById(recordId)).willReturn(Optional.of(record));
       given(userRoleRepository.findRoleCodesByUserId(teacherUserId))
           .willReturn(List.of("TEACHER"));
       given(userRepository.findById(teacherUserId)).willReturn(Optional.of(teacherUser));
 
+      ConductCancelRequest request = new ConductCancelRequest("오인 부여 확인됨");
       conductService.cancelConduct(teacherUserId, recordId, request);
 
       assertThat(record.getStatus()).isEqualTo(ConductStatus.CANCELED);


### PR DESCRIPTION
## 개요

이슈 #107. 교사(또는 ADMIN)가 이미 부여된 상/벌점 기록을 정정하거나 취소하는 API를 구현한다.

## 변경 사항

- `ConductErrorCode` — CONDUCT_001(기록 없음) · CONDUCT_002(소유권 없음) · CONDUCT_003(이미 취소됨) 추가
- `ConductAmendRequest` / `ConductCancelRequest` DTO 추가
- `ConductService.amendConduct` — 카테고리·상세 부분 정정, 양 필드 모두 null이면 INVALID_REQUEST
- `ConductService.cancelConduct` — 상태 CANCELED 전환, 취소자·취소 사유·취소 시각 기록
- `ConductController` — `PATCH /{id}`, `PATCH /{id}/cancel` 엔드포인트 추가
- 단위 테스트 13개 추가 (정상 4 + 예외 9)
- Postman 컬렉션 — 정정·취소 요청 및 에러 케이스 추가

## 소유권 정책

TEACHER는 본인이 부여한 기록만 처리 가능. ADMIN은 소유권 무관하게 처리 가능. 로직은 서비스 레이어에서 `userRoleRepository.findRoleCodesByUserId`로 판단.

## 테스트

- 단위 테스트: `./gradlew test --tests "com.remake.gone.conduct.*"` — BUILD SUCCESSFUL
- 체크스타일: `./gradlew checkstyleMain checkstyleTest` — BUILD SUCCESSFUL
- 실서버 QA: 9개 시나리오 전부 통과 (정상 정정·취소, CONDUCT_001·002·003·COMMON_001 에러 응답 확인)

## 관련 이슈

Closes #107

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added conduct-record amendment and cancellation capabilities.
  - Authorized teachers and administrators can update categories or details and provide cancellation reasons.
  - Added validation for amendment and cancellation requests.
  - Added clear handling for missing records, unauthorized access, repeated cancellations, and canceled records.

- **Documentation**
  - Added Korean specifications and code-review documentation.
  - Updated the Postman collection with workflows and error-case examples.

- **Tests**
  - Added comprehensive coverage for successful and invalid amendment and cancellation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->