### PR TITLE
feat(outing): #96 외출증 실시간 목록 조회 API 추가

### DIFF
--- a/docs/domain/outing/96-outing-active-list-QA.md
+++ b/docs/domain/outing/96-outing-active-list-QA.md
@@ -1,0 +1,51 @@
+# #96 외출증 실시간 목록 조회 API — QA 결과
+
+관련 기획서: [96-outing-active-list.md](./96-outing-active-list.md)
+코드 리뷰 결과: [96-outing-active-list-code-review.md](./96-outing-active-list-code-review.md)
+
+## 검증 환경
+- 로컬 MySQL(`gone` 스키마, Flyway 마이그레이션 17개 정상 적용) + 로컬 Redis
+- `./gradlew bootRun --args='--spring.profiles.active=dev'`로 실서버 기동(포트 9090)
+- 인증은 `JwtProvider.createAccessToken`을 임시 테스트로 직접 호출해 역할별 토큰 발급
+  (로그인 플로우를 거치지 않음 — `@PreAuthorize`가 JWT의 `roles` 클레임을 보고, 단건
+  상세조회 인가는 `user_role` 테이블을 직접 조회하므로, 두 경로를 각각 검증하기 위해
+  실제 DB에 `user_role` 로우가 있는 사용자와 없는 사용자를 구분해서 테스트했다)
+- 검증에 사용한 임시 픽스처(외출증 1건, 학생/교사 계정 3건)는 검증 직후 삭제 완료,
+  임시 테스트 파일도 커밋하지 않고 삭제함
+
+## 로컬/CI 결과
+- `./gradlew build`(compileJava/Test, test, checkstyleMain/Test 포함) 통과
+- outing 패키지 테스트 148개 전부 통과(실 DB 기반 `OutingActiveListAuthorizationTest`,
+  `OutingDepartReturnOwnershipIntegrationTest` 등 `@SpringBootTest` 통합 테스트 포함)
+- GitHub Actions CI(PR #110): `checkstyle` pass(1m7s), `build-and-test` pass(2m9s)
+  (`build-and-push-image`/`deploy-staging`는 draft PR이라 skip — 정상)
+
+## 엔드포인트 실동작 검증 (`GET /api/v1/outings/active`)
+
+| 케이스 | 요청 | 기대 | 실제 |
+|---|---|---|---|
+| 인증 없음 | 토큰 없이 요청 | 401 | ✅ 401 |
+| 권한 없음 | STUDENT 토큰 | 403 | ✅ 403 |
+| 정상(빈 목록) | DISCIPLINE 토큰, 데이터 없음 | 200, `content: []` | ✅ `{"content":[],"totalElements":0,...}` |
+| `page` 음수 | `?page=-1` | 400 `OUTING_015` | ✅ `{"code":"OUTING_015","message":"페이지 파라미터가 올바르지 않습니다..."}` |
+| `size` 범위 초과 | `?size=200` | 400 `OUTING_015` | ✅ 동일 |
+| 정상(1건) | DISCIPLINE 토큰, `DEPARTED` 외출증 1건 존재 | 200, 기획서 응답 예시와 동일 필드 | ✅ 필드 순서/값 전부 일치(`code`/`studentNickname`/`studentProfileImageUrl`/`studentRealName`/`studentGrade`/`studentClassNo`/`reason`/`timeSlot`/`departedAt`/`endTime`) |
+
+## 단건 상세조회 인가 확장 검증 (`GET /outings/{code}`)
+- 담당 아닌 TEACHER 역할 사용자(실제 `user_role` 테이블에 TEACHER 로우 있음)로 조회 →
+  **200 정상 응답** 확인. 확장이 의도대로 동작한다.
+- (참고: 최초 시도 시 `user_role` 테이블에 역할 로우가 없는 가짜 사용자로 테스트해 403이
+  나왔는데, 이는 구현 버그가 아니라 QA 픽스처 설정 실수였다 — `validateDetailAccess`가
+  JWT 클레임이 아니라 DB `user_role` 조회 결과를 기준으로 판단하기 때문. 실제 역할이
+  부여된 사용자로 재검증해 정상 동작을 확인했다.)
+
+## 발견된 문제
+Critical/High/Medium/Low 없음 — 기획서에 정의된 정상/에러 케이스가 실제 서버에서 전부
+기획서대로 동작했다.
+
+코드 리뷰(9단계)에서 이미 지적된 **Medium 1건(Postman 컬렉션에 `GET /active` 미반영)**은
+QA 항목이 아니라 15단계에서 처리한다(코드 리뷰 문서 참고).
+
+## 남은 절차
+- 15단계: Postman 컬렉션에 `GET /active` 반영(이번 QA에서 검증한 요청 재사용)
+- 16단계: 보스 최종 확인 후 draft PR(#110)을 Ready for review로 전환

--- a/docs/domain/outing/96-outing-active-list-code-review.md
+++ b/docs/domain/outing/96-outing-active-list-code-review.md
@@ -1,7 +1,10 @@
 # #96 외출증 실시간 목록 조회 API — 코드 리뷰 결과
 
 관련 기획서: [96-outing-active-list.md](./96-outing-active-list.md)
-리뷰 대상: `git diff dev...feat/#96-outing-active-list` (커밋 `a15640f`~`3122129`, 7개)
+리뷰 대상: `git diff dev...3122129` (커밋 `a15640f`~`3122129`, 7개 — 브랜치 이름으로
+`git diff dev...feat/#96-outing-active-list`를 실행하면 이 리뷰 이후 추가된 커밋(이
+리뷰 결과 문서 자체, QA 문서 등 총 9개 커밋)까지 포함되어 재현되지 않으므로, 실제
+리뷰 시점의 커밋 SHA로 고정해 남긴다)
 
 ## 리뷰 범위/방법
 - 기획서(`96-outing-active-list.md`)에 기록된 설계 판단(DB 레벨 페이지네이션 전환,

--- a/docs/domain/outing/96-outing-active-list-code-review.md
+++ b/docs/domain/outing/96-outing-active-list-code-review.md
@@ -1,0 +1,77 @@
+# #96 외출증 실시간 목록 조회 API — 코드 리뷰 결과
+
+관련 기획서: [96-outing-active-list.md](./96-outing-active-list.md)
+리뷰 대상: `git diff dev...feat/#96-outing-active-list` (커밋 `a15640f`~`3122129`, 7개)
+
+## 리뷰 범위/방법
+- 기획서(`96-outing-active-list.md`)에 기록된 설계 판단(DB 레벨 페이지네이션 전환,
+  `departedAt`+`id` 정렬, 단건 상세조회 인가 확장, N+1/인덱스 이슈 보류)을 기준으로 삼아
+  diff 전체(`docs/domain/outing/96-outing-active-list.md`,
+  `common/response/PageResponse.java`, `outing/controller/OutingController.java`,
+  `outing/dto/OutingActiveResponse.java`, `outing/repository/OutingRepository.java`,
+  `outing/service/OutingService.java`, 관련 테스트 3개 파일)를 정적으로 읽었다.
+- 특히 신규 JPQL `findStudentRequestsPage`/`findTeacherReceivedPage`의 `statusEq`/
+  `wantExpired` 조건을, 제거된 in-memory 로직(`resolveEffectiveStatus` +
+  `OutingTimeUtils.isPastDeadline`)과 케이스별(필터 없음/APPROVED류 직접 매치/PENDING/
+  MISSED)로 1:1 대조해 동등성을 확인했다 — 동일하다고 판단했다(아래 "확인한 것" 참고).
+- `validateDetailAccess`의 `TEACHER` 전체 허용 확장은 기획서 "리스크 및 고려사항" 절의
+  근거(/active가 이미 전체 TEACHER에게 같은 데이터를 노출)와 일치하는지 확인했다.
+- N+1/인덱스 부재는 기획서에 이미 기록된 대로 `gh issue view 109`로 실제 이슈 등록 여부와
+  항목 일치 여부를 확인했다(등록 확인, 항목 일치).
+- 로컬 빌드/테스트/checkstyle은 재실행하지 않았다(이미 통과 확인됨, outing 패키지 148개
+  테스트 통과).
+
+## 확인한 것 (문제로 이어지지 않음)
+- `findStudentRequestsPage`/`findTeacherReceivedPage`의 `statusEq`/`wantExpired` 분기가
+  기존 `toFilteredResponses`+`resolveEffectiveStatus` 로직과 모든 `OutingQueryStatus` 값에
+  대해 동일한 결과를 낸다(PENDING → `statusEq=PENDING, wantExpired=false`, MISSED →
+  `statusEq=PENDING, wantExpired=true`, 그 외 → `statusEq=값, wantExpired=null`, 필터 없음 →
+  둘 다 `null`). `OutingServiceTest`도 이 다섯 케이스를 개별 검증하고 있다.
+- `PreAuthorize("hasAnyRole('DISCIPLINE', 'TEACHER', 'ADMIN')")`가 기획서 문구와 정확히
+  일치하고, `OutingActiveListAuthorizationTest`가 4개 역할(무인증/STUDENT/DISCIPLINE·
+  TEACHER·ADMIN)을 실제 필터 체인으로 검증한다.
+- `OutingActiveResponse` 필드 순서/타입이 기획서 응답 예시(JSON)와 정확히 일치한다.
+- `PageResponse.of(List, page, size)`(기존)와 `of(Page<T>)`(신규) 둘 다 실제로 쓰이고 있다
+  (`SchoolCampService`는 여전히 전자, `OutingService` 3개 메서드는 모두 후자) — 기획서의
+  "기존 팩토리는 그대로 둔다"는 판단이 실제로 지켜졌다.
+- 제거된 `toFilteredResponses`가 다른 곳에서 참조되지 않는다(죽은 코드 없음).
+- `findByStatus(OutingStatus)`(#42 스케줄러용, List 반환)와 신규
+  `findByStatus(OutingStatus, Pageable)`(Page 반환)이 공존해도 Spring Data 파생 쿼리
+  규칙상 문제없다(트레일링 `Pageable`은 쿼리 프로퍼티에 포함되지 않음).
+- N+1 쿼리·`status` 컬럼 인덱스 부재는 `#109`(`외출 도메인 성능 최적화 백로그`, OPEN)에
+  실제로 등록되어 있고, 이슈 본문의 두 항목이 기획서에 적힌 내용과 일치한다.
+- diff에 포함된 파일 9개 전부가 outing 도메인 또는 그 도메인이 의존하는 공용
+  `PageResponse`뿐이며(기획서에 "이번 이슈 범위를 넘는 리팩토링"으로 명시적으로 승인된
+  범위), 기획서 범위를 벗어난 변경은 없었다.
+
+## 발견 사항
+
+### 1. 🟡 Medium — 기획서에 명시된 완료 조건("Postman 컬렉션 반영")이 diff에 반영되지 않음
+
+**문제**: `docs/domain/outing/96-outing-active-list.md:206-209`의 "완료 조건(Definition of
+Done)"은 "로컬 빌드/테스트 통과", "CI 통과"와 나란히 "Postman 컬렉션 반영"을 명시한다.
+그런데 이번 diff(`git diff dev...feat/#96-outing-active-list --name-only`)에는
+`postman/collections/gone-outing.postman_collection.json`이 포함되어 있지 않고, 실제로 그
+파일을 열어봐도 `active`를 포함한 요청 항목이 없다(`grep -i active
+postman/collections/gone-outing.postman_collection.json` 결과 없음). 그 파일의 마지막 커밋
+시각(`2026-08-24 14:59`)도 이 브랜치의 첫 커밋(`a15640f`, `2026-08-25 09:27`)보다 이전이라,
+Postman 워크스페이스에 API 호출로 직접 반영했다 하더라도 로컬 컬렉션 파일과는 최소한 싱크가
+안 맞는 상태다. 지금 PR을 올리면 프론트/QA가 Postman에서 `GET /active`를 찾을 수 없다.
+
+**해결 방안**:
+1. `postman/collections/gone-outing.postman_collection.json`에 `GET /active` 요청을 직접
+   추가하고 커밋에 포함한다 — 가장 확실하고 저장소 히스토리에 남지만, 기존 다른 요청
+   항목과 필드 구조(쿼리 파라미터 프리셋, 테스트 스크립트 등)를 맞춰야 하는 수작업 비용이
+   든다.
+2. Postman API로 워크스페이스에 이미 반영했다면, 로컬 `.json` 파일을 워크스페이스에서
+   다시 pull해 diff에 포함시킨다(보스 메모에 있는 "REST API로 push, git 폴더 동기화는
+   지양" 방식과 일관됨) — 비용은 낮지만, 이미 워크스페이스에 반영됐는지부터 확인이
+   필요하고 이 코드 리뷰만으로는 확인할 수 없다(로컬 리포에서 Postman API 키/네트워크
+   접근 불가).
+3. 완료 조건 자체를 "PR 머지 전까지"로 미루고 이번 코드 리뷰 단계에서는 지적만 남긴 채
+   다음 QA(10단계) 단계에서 처리한다 — 코드 자체의 정확성과는 무관한 항목이라 이번
+   코드 리뷰를 막을 필요는 없지만, PR을 올리기 전에 반드시 처리해야 한다(기획서 스스로
+   정한 완료 조건이므로).
+
+## 요약
+Critical/High 없음. Medium 1건(Postman 컬렉션 미반영), Low 없음.

--- a/docs/domain/outing/96-outing-active-list.md
+++ b/docs/domain/outing/96-outing-active-list.md
@@ -57,7 +57,7 @@
 **권한**: `DISCIPLINE`, `TEACHER`, `ADMIN` 중 하나(`@PreAuthorize`)
 
 **요청**
-```
+```http
 GET /api/v1/outings/active?page=0&size=20
 ```
 - `page`: 선택, 기본값 `0`

--- a/docs/domain/outing/96-outing-active-list.md
+++ b/docs/domain/outing/96-outing-active-list.md
@@ -1,0 +1,151 @@
+# #96 외출증 실시간 목록 조회 API — 기획서
+
+관련 이슈: [#96 외출증 실시간 목록 조회 API (지금 외출 중인 학생)](https://github.com/GBSW-ReMake/GONE-server-V1/issues/96)
+마스터 기획서: [1_outing-domain.md](./1_outing-domain.md) (8번 엔드포인트)
+선행 코드: [`OutingController`](../../../src/main/java/com/remake/gone/outing/controller/OutingController.java)/
+[`OutingService`](../../../src/main/java/com/remake/gone/outing/service/OutingService.java)/
+[`OutingRepository`](../../../src/main/java/com/remake/gone/outing/repository/OutingRepository.java)
+
+## 개요/목적
+`DEPARTED` 상태는 #43에서 실제로 생기기 시작했지만, "지금 외출 중인 학생이 누구인지"를
+한눈에 보여주는 목록 엔드포인트가 아직 없다. 예전에 선도부가 카톡방으로 수동 공유하던
+정보를 대체하는 이 도메인의 핵심 "가시성" 기능이다.
+
+## 마스터 기획서 재검토 (api-design.md "마스터 기획서 재검토" 원칙 적용)
+- **권한 체크 방식**: 마스터 기획서 작성 당시엔 서비스 코드에서 역할을 직접 검사하는
+  방식을 가정했을 수 있으나, #30 이후 이 컨트롤러의 모든 형제 엔드포인트가
+  `@PreAuthorize`를 쓰고 있다. 이번에도 동일하게 `@PreAuthorize("hasAnyRole('DISCIPLINE',
+  'TEACHER', 'ADMIN')")`를 컨트롤러에 붙인다. `ADMIN`은 "공통 전제로 항상 접근 가능"이라는
+  이 프로젝트의 일반 원칙이 있지만, 실제로 이미 구현된 형제 엔드포인트(`SchoolCampController`
+  의 `hasAnyRole('STUDENT', 'TEACHER')` 등)를 확인해보면 `hasAnyRole`에 명시적으로 나열되지
+  않은 역할은 자동으로 통과되지 않는다 — 그래서 `ADMIN`을 반드시 목록에 명시적으로 포함한다.
+- **페이지네이션 — 마스터 기획서와 다르게 간다(추가한다)**: 마스터 기획서는 페이지네이션
+  없이 단순 배열로 응답하도록 가정했다("시계열 데이터량이 크지 않다"는 9번 엔드포인트의
+  근거를 8번에도 암묵적으로 적용한 것으로 보인다). 하지만 재검토 결과 이 가정은 근거가
+  약하다:
+  1. 마스터 기획서 자체가 "`DEPARTED` 상태가 자정을 넘어도 자동으로 정리되지 않는다"는
+     미해결 리스크를 명시하고 있다(8번 절 하단 콜아웃). 도착 보고를 안 하고 방치되는
+     외출증을 자동으로 정리하는 스케줄러가 아직 없으므로, 이 목록이 이론상 무제한으로
+     누적될 수 있다.
+  2. #41 이후 이 도메인의 다른 목록 엔드포인트(`GET /me/requests`, `GET /me/received`)는
+     전부 `PageResponse<T>` 페이지네이션을 쓰고 있어, 이 엔드포인트만 단순 배열로 응답하면
+     같은 컨트롤러 안에서 패턴이 어긋난다(api-design.md "직관적 일관성" 원칙).
+
+  따라서 `GET /me/received`와 동일한 `page`/`size` 파라미터 + `PageResponse<T>` 응답으로
+  구현한다. "위 DEPARTED 무제한 누적 리스크 자체"는 이 이슈에서 해결하지 않는다(스케줄러
+  신설은 별도 이슈 — 아래 "리스크 및 고려사항" 참고) — 페이지네이션은 그 리스크가 실제로
+  터졌을 때 응답이 무한정 커지는 것만 막아주는 방어선이다.
+- **응답 DTO**: 마스터 기획서는 `OutingResponse`를 재사용하지 않고 전용의 더 좁은 필드
+  집합(`code`/`studentNickname`/`studentProfileImageUrl`/`studentRealName`/`studentGrade`/
+  `studentClassNo`/`reason`/`timeSlot`/`departedAt`/`endTime`)을 제시했다 — `teacherName`,
+  `startTime`, `outingDate`, `status`, `rejectedReason`, `returnedAt`, `offSchedule`은
+  뺀다. 이 판단을 그대로 따른다: 이 목록은 "지금 누가 밖에 있고 언제까지 들어와야 하는지"만
+  빠르게 훑어보는 화면이라 필요 이상의 필드를 넣지 않는 게 api-design.md "한 가지를 잘하기"
+  원칙에 맞는다. 새 응답 타입 `OutingActiveResponse`를 만든다(기존 `OutingResponse`는
+  변경하지 않음 — 하위 호환성 영향 없음).
+
+## 엔드포인트
+
+### `GET /api/v1/outings/active` — 지금 외출 중인 학생 목록
+**권한**: `DISCIPLINE`, `TEACHER`, `ADMIN` 중 하나(`@PreAuthorize`)
+
+**요청**
+```
+GET /api/v1/outings/active?page=0&size=20
+```
+- `page`: 선택, 기본값 `0`
+- `size`: 선택, 기본값 `20`, `1~100`
+
+**응답** (`200 OK`)
+```json
+{
+  "success": true,
+  "data": {
+    "content": [
+      {
+        "code": "8A1zx9202n",
+        "studentNickname": "길동이",
+        "studentProfileImageUrl": "https://.../profile/1/abc.jpg?X-Amz-...",
+        "studentRealName": "홍길동",
+        "studentGrade": 3,
+        "studentClassNo": 4,
+        "reason": "치과 진료",
+        "timeSlot": "LUNCH",
+        "departedAt": "2026-08-14T12:31:05",
+        "endTime": "13:40"
+      }
+    ],
+    "page": 0,
+    "size": 20,
+    "totalElements": 1,
+    "totalPages": 1,
+    "hasNext": false
+  },
+  "message": "현재 외출 중인 학생 목록입니다.",
+  "code": null
+}
+```
+
+**구현 로직** (`OutingService.getActiveOutings`)
+1. `page`/`size` 검증 — 기존 `validatePageParams`(`OutingErrorCode.INVALID_PAGE_PARAMS`,
+   `OUTING_015`) 그대로 재사용
+2. `outingRepository.findByStatusOrderByDepartedAtAsc(OutingStatus.DEPARTED)` 조회
+   (신규 메서드 — 아래 참고)
+3. `departedAt` 오름차순 정렬(가장 오래 나가 있는 학생이 먼저 보이도록 — 선도부가 우선
+   확인해야 할 대상을 목록 위쪽에 두기 위함). 리포지토리가 정렬까지 처리하므로 서비스
+   코드에서 별도 정렬은 하지 않는다.
+4. `OutingActiveResponse` 리스트로 변환(`R2FileService.generateDownloadUrl`로
+   프로필 이미지 URL 생성, 기존 `toResponse`와 동일한 패턴)
+5. `PageResponse.of(...)`로 페이지네이션 적용해 반환
+
+**에러**
+- 401 `COMMON_002` UNAUTHORIZED — 인증 안 됨
+- 403 `COMMON_003` FORBIDDEN — `DISCIPLINE`/`TEACHER`/`ADMIN` 중 어느 것도 아님
+- 400 `OUTING_015` INVALID_PAGE_PARAMS — `page` 음수 또는 `size`가 `1~100` 범위 밖
+
+## 데이터 모델 변경
+없음(엔티티/마이그레이션 불필요). `OutingRepository`에 파생 쿼리 메서드
+`findByStatusOrderByDepartedAtAsc(OutingStatus status)`만 새로 추가한다 — 기존
+`findByStatus`(#42, `OutingMissedScheduler`가 `PENDING` 조회에 사용)는 건드리지 않고
+그대로 둔다.
+
+## 영향 받는 기존 코드/테스트
+- 신규: `outing.dto.OutingActiveResponse`, `OutingController.getActiveOutings`,
+  `OutingService.getActiveOutings`, `OutingRepository.findByStatusOrderByDepartedAtAsc`
+- 변경 없음: `Outing` 엔티티, 기존 `OutingResponse`, `OutingRepository.findByStatus`,
+  기존 다른 엔드포인트
+
+## 리스크 및 고려사항
+- **API 설계 6원칙**:
+  1. 한 가지를 잘하기: 좁은 전용 응답 DTO, 위치 좌표 제외(#97에서 별도 권한으로 제공) —
+     원칙에 부합.
+  4. 의미 있는 오류: 기존 `OUTING_015`/`COMMON_002`/`COMMON_003` 재사용, 새 에러 코드
+     불필요.
+  5. 확장성/성능: 위 "마스터 기획서 재검토" 절에서 페이지네이션 추가로 이미 반영.
+  6. 하위 호환성: 새 엔드포인트 + 새 DTO라 기존 응답에 영향 없음.
+- **`DEPARTED` 무제한 누적 리스크(마스터 기획서 기존 리스크, 이번 이슈에서 해결 안 함)**:
+  도착 보고 없이 방치된 외출증을 자동으로 `MISSED`(또는 별도 상태)로 정리하는 스케줄러가
+  아직 없다. 페이지네이션으로 응답 크기 폭증은 막지만, "며칠 전에 나간 걸로 표시된
+  학생"이 계속 이 목록에 남아있는 근본 문제는 그대로다 — #102(승인됐지만 미출발 마감
+  처리)와 같은 성격의 상태 모델 빈틈이므로, 이번 구현 완료 후 별도 백로그 이슈로
+  분리 제안한다.
+- **정렬 기준**: `departedAt` 오름차순(가장 오래 나가 있는 학생 우선)으로 확정했다 —
+  마스터 기획서에는 정렬 기준이 명시돼 있지 않아 이번에 새로 정한다.
+
+## 테스트
+- `OutingServiceTest.GetActiveOutings`(신규 `@Nested`):
+  - `DEPARTED` 외출증이 여러 건일 때 `departedAt` 오름차순으로 반환
+  - `DEPARTED`가 아닌 외출증(`PENDING`/`APPROVED`/`RETURNED`/`REJECTED`/`MISSED`)은
+    제외
+  - 결과 없을 때 `content: []`(200, `null` 아님)
+  - `page`/`size` 페이지네이션 동작(#41의 기존 테스트 패턴 재사용)
+  - `page`가 음수이거나 `size`가 범위 밖이면 `OUTING_015`
+- `OutingControllerTest.GetActiveOutings`(신규 `@Nested`): 정상 요청 위임 확인
+- `OutingActiveListAuthorizationTest`(신규): `DISCIPLINE`/`TEACHER`/`ADMIN` 각각 200,
+  `STUDENT`로 요청 시 403, 인증 없이 요청 시 401(기존
+  `OutingApproveAuthorizationTest` 등과 동일한 패턴)
+
+## 완료 조건 (Definition of Done)
+- 로컬 빌드/테스트 통과
+- CI 통과
+- Postman 컬렉션 반영

--- a/docs/domain/outing/96-outing-active-list.md
+++ b/docs/domain/outing/96-outing-active-list.md
@@ -19,10 +19,10 @@
   이 프로젝트의 일반 원칙이 있지만, 실제로 이미 구현된 형제 엔드포인트(`SchoolCampController`
   의 `hasAnyRole('STUDENT', 'TEACHER')` 등)를 확인해보면 `hasAnyRole`에 명시적으로 나열되지
   않은 역할은 자동으로 통과되지 않는다 — 그래서 `ADMIN`을 반드시 목록에 명시적으로 포함한다.
-- **페이지네이션 — 마스터 기획서와 다르게 간다(추가한다)**: 마스터 기획서는 페이지네이션
-  없이 단순 배열로 응답하도록 가정했다("시계열 데이터량이 크지 않다"는 9번 엔드포인트의
-  근거를 8번에도 암묵적으로 적용한 것으로 보인다). 하지만 재검토 결과 이 가정은 근거가
-  약하다:
+- **페이지네이션 — 마스터 기획서와 다르게 간다(추가한다), 방식은 코드 리뷰에서 재확정**:
+  마스터 기획서는 페이지네이션 없이 단순 배열로 응답하도록 가정했다("시계열 데이터량이
+  크지 않다"는 9번 엔드포인트의 근거를 8번에도 암묵적으로 적용한 것으로 보인다). 재검토
+  결과 이 가정은 근거가 약했다:
   1. 마스터 기획서 자체가 "`DEPARTED` 상태가 자정을 넘어도 자동으로 정리되지 않는다"는
      미해결 리스크를 명시하고 있다(8번 절 하단 콜아웃). 도착 보고를 안 하고 방치되는
      외출증을 자동으로 정리하는 스케줄러가 아직 없으므로, 이 목록이 이론상 무제한으로
@@ -31,10 +31,17 @@
      전부 `PageResponse<T>` 페이지네이션을 쓰고 있어, 이 엔드포인트만 단순 배열로 응답하면
      같은 컨트롤러 안에서 패턴이 어긋난다(api-design.md "직관적 일관성" 원칙).
 
-  따라서 `GET /me/received`와 동일한 `page`/`size` 파라미터 + `PageResponse<T>` 응답으로
-  구현한다. "위 DEPARTED 무제한 누적 리스크 자체"는 이 이슈에서 해결하지 않는다(스케줄러
-  신설은 별도 이슈 — 아래 "리스크 및 고려사항" 참고) — 페이지네이션은 그 리스크가 실제로
-  터졌을 때 응답이 무한정 커지는 것만 막아주는 방어선이다.
+  페이지네이션을 추가하기로 한 최초 판단은 유효했지만, **구현 착수 전 코드 리뷰에서
+  "어떻게 페이지네이션할 것인가"가 잘못 설계됐다는 게 드러났다**: 기존 `PageResponse.of(List,
+  page, size)`는 이미 메모리에 올라온 전체 리스트를 `subList`로 자르기만 하는 in-memory
+  방식이다(`/me/requests`, `/me/received`는 기간 필터로 결과 건수가 원래 작아 이 방식이
+  괜찮았다). `/active`는 날짜 필터가 없는 엔드포인트라 이 전제가 성립하지 않아, in-memory
+  방식을 그대로 썼다면 "무제한 누적을 막는 방어선"이라는 페이지네이션의 목적 자체가
+  무력화됐을 것이다. 그래서 **DB 레벨 페이지네이션(`LIMIT/OFFSET`, Spring Data
+  `Page<T>`)으로 방식을 바꾸고, 이미 있던 `/me/requests`/`/me/received`도 이번에 같이
+  전환했다(보스 확정, 2026-08-25)** — 아래 "데이터 모델 변경"/"영향 받는 기존 코드" 절
+  참고. `PageResponse`에 `of(Page<T>)` 팩토리를 추가했고, 기존 `of(List, page, size)`는
+  다른 도메인(SchoolCamp)이 계속 쓰므로 그대로 둔다.
 - **응답 DTO**: 마스터 기획서는 `OutingResponse`를 재사용하지 않고 전용의 더 좁은 필드
   집합(`code`/`studentNickname`/`studentProfileImageUrl`/`studentRealName`/`studentGrade`/
   `studentClassNo`/`reason`/`timeSlot`/`departedAt`/`endTime`)을 제시했다 — `teacherName`,
@@ -89,14 +96,16 @@ GET /api/v1/outings/active?page=0&size=20
 **구현 로직** (`OutingService.getActiveOutings`)
 1. `page`/`size` 검증 — 기존 `validatePageParams`(`OutingErrorCode.INVALID_PAGE_PARAMS`,
    `OUTING_015`) 그대로 재사용
-2. `outingRepository.findByStatusOrderByDepartedAtAsc(OutingStatus.DEPARTED)` 조회
-   (신규 메서드 — 아래 참고)
-3. `departedAt` 오름차순 정렬(가장 오래 나가 있는 학생이 먼저 보이도록 — 선도부가 우선
-   확인해야 할 대상을 목록 위쪽에 두기 위함). 리포지토리가 정렬까지 처리하므로 서비스
-   코드에서 별도 정렬은 하지 않는다.
-4. `OutingActiveResponse` 리스트로 변환(`R2FileService.generateDownloadUrl`로
-   프로필 이미지 URL 생성, 기존 `toResponse`와 동일한 패턴)
-5. `PageResponse.of(...)`로 페이지네이션 적용해 반환
+2. `Pageable`을 `departedAt` 오름차순 + `id` 오름차순(보조 정렬 키) 정렬로 구성
+3. `outingRepository.findByStatus(OutingStatus.DEPARTED, pageable)` 조회 — DB가
+   `LIMIT/OFFSET`으로 이미 페이지 단위로 잘라서 반환한다(신규 메서드, `Page<Outing>` 반환)
+4. `Page<Outing>.map(...)`으로 `OutingActiveResponse`로 변환(`R2FileService.
+   generateDownloadUrl`로 프로필 이미지 URL 생성, 기존 `toResponse`와 동일한 패턴)
+5. `PageResponse.of(Page<T>)`(신규 팩토리)로 감싸 반환
+
+`departedAt` 오름차순만으로는 안정 정렬이 보장되지 않는다 — 컬럼이 초 단위 정밀도라
+점심시간처럼 여러 학생이 같은 초에 출발하면 페이지 경계에서 학생이 누락될 수 있어, `id`를
+보조 정렬 키로 추가했다(코드 리뷰에서 확인, 보스 확정).
 
 **에러**
 - 401 `COMMON_002` UNAUTHORIZED — 인증 안 됨
@@ -104,16 +113,40 @@ GET /api/v1/outings/active?page=0&size=20
 - 400 `OUTING_015` INVALID_PAGE_PARAMS — `page` 음수 또는 `size`가 `1~100` 범위 밖
 
 ## 데이터 모델 변경
-없음(엔티티/마이그레이션 불필요). `OutingRepository`에 파생 쿼리 메서드
-`findByStatusOrderByDepartedAtAsc(OutingStatus status)`만 새로 추가한다 — 기존
-`findByStatus`(#42, `OutingMissedScheduler`가 `PENDING` 조회에 사용)는 건드리지 않고
-그대로 둔다.
+없음(엔티티/마이그레이션 불필요). `status` 컬럼 인덱스 부재는 인지하고 있으나 이번
+범위에서 넣지 않고 #109(성능 백로그)로 미룬다 — 현재 데이터량에서 체감 영향이 없고,
+인덱스는 나중에 무중단으로 추가할 수 있다(코드 리뷰, 보스 확정).
+
+`OutingRepository`에 다음을 추가/변경한다(모두 DB 레벨 페이지네이션 전환의 일부,
+"마스터 기획서 재검토" 절 참고):
+- 신규: `findByStatus(OutingStatus status, Pageable pageable)` — `/active` 조회용,
+  `Page<Outing>` 반환
+- 신규: `findStudentRequestsPage(...)`, `findTeacherReceivedPage(...)` — 기존
+  `findByStudentIdAndOutingDateBetweenOrderByOutingDateAscStartTimeAsc`/
+  `findByTeacherIdAndOutingDateBetweenOrderByOutingDateAscStartTimeAsc`(List 반환,
+  #41)를 대체. `@Query` JPQL로 날짜 범위 + "유효 상태" 필터(`statusEq`/`wantExpired`
+  두 파라미터로 표현 — `PENDING`이 마감을 넘겨도 DB 값은 그대로 `PENDING`이라 단일 컬럼
+  비교로 MISSED 여부를 가릴 수 없어서)까지 DB에서 처리하고 `Page<Outing>`을 반환한다
+- 변경 없음: `findByStatus(OutingStatus status)`(List 반환, #42
+  `OutingMissedScheduler` 전용 — 스케줄러는 페이지네이션 없이 대상 전체를 훑어야 해서
+  그대로 둔다)
+
+`common.response.PageResponse`에 `of(Page<T> page)` 팩토리를 추가한다. 기존
+`of(List<T>, page, size)`는 SchoolCamp 도메인이 계속 쓰므로 그대로 둔다.
 
 ## 영향 받는 기존 코드/테스트
 - 신규: `outing.dto.OutingActiveResponse`, `OutingController.getActiveOutings`,
-  `OutingService.getActiveOutings`, `OutingRepository.findByStatusOrderByDepartedAtAsc`
-- 변경 없음: `Outing` 엔티티, 기존 `OutingResponse`, `OutingRepository.findByStatus`,
-  기존 다른 엔드포인트
+  `OutingService.getActiveOutings`, `OutingRepository.findByStatus(status, Pageable)`,
+  `PageResponse.of(Page<T>)`
+- **변경(#96 범위를 넘는 리팩토링, 보스 확정)**: `OutingService.getMyRequests`/
+  `getReceivedOutings`(#41)가 기존 in-memory 페이지네이션에서 DB 레벨 페이지네이션으로
+  바뀐다. 응답 계약(요청 파라미터, 응답 스키마, 필터링 결과)은 동일하게 유지되고 내부
+  구현 방식만 바뀐다 — `OutingControllerTest`/`OutingActiveListAuthorizationTest` 등
+  기존 인가/계약 테스트는 변경 없이 통과해야 한다.
+- **변경**: `OutingService.validateDetailAccess`(#41) — 담당 여부와 무관하게 `TEACHER`
+  역할이면 단건 상세조회(`GET /{code}`)를 허용하도록 확장(아래 "리스크 및 고려사항" 참고)
+- 변경 없음: `Outing` 엔티티, 기존 `OutingResponse`, `findByStatus(OutingStatus)`(#42
+  스케줄러용), 그 외 엔드포인트
 
 ## 리스크 및 고려사항
 - **API 설계 6원칙**:
@@ -123,27 +156,52 @@ GET /api/v1/outings/active?page=0&size=20
      불필요.
   5. 확장성/성능: 위 "마스터 기획서 재검토" 절에서 페이지네이션 추가로 이미 반영.
   6. 하위 호환성: 새 엔드포인트 + 새 DTO라 기존 응답에 영향 없음.
-- **`DEPARTED` 무제한 누적 리스크(마스터 기획서 기존 리스크, 이번 이슈에서 해결 안 함)**:
-  도착 보고 없이 방치된 외출증을 자동으로 `MISSED`(또는 별도 상태)로 정리하는 스케줄러가
-  아직 없다. 페이지네이션으로 응답 크기 폭증은 막지만, "며칠 전에 나간 걸로 표시된
-  학생"이 계속 이 목록에 남아있는 근본 문제는 그대로다 — #102(승인됐지만 미출발 마감
-  처리)와 같은 성격의 상태 모델 빈틈이므로, 이번 구현 완료 후 별도 백로그 이슈로
-  분리 제안한다.
-- **정렬 기준**: `departedAt` 오름차순(가장 오래 나가 있는 학생 우선)으로 확정했다 —
-  마스터 기획서에는 정렬 기준이 명시돼 있지 않아 이번에 새로 정한다.
+- **`DEPARTED` 무제한 누적(유령 데이터) — 날짜 필터로 가리지 않기로 확정(보스 확정,
+  2026-08-25)**: 도착 보고 없이 방치된 외출증을 자동으로 정리하는 스케줄러가 아직 없어,
+  "며칠 전에 나간 걸로 표시된 학생"이 계속 이 목록에 남을 수 있다. `departedAt >= 오늘
+  00:00` 같은 날짜 필터로 이런 유령 데이터를 감출 수도 있었지만 **의도적으로 넣지
+  않는다** — 이 프로젝트는 "시스템이 1차로 느슨하게 거르고, 선도부/선생님이 2차로 실제
+  판단한다"는 원칙([[feedback_outing_loose_restrictions]] 참고)을 따르는데, 방치된
+  외출증은 숨겨야 할 노이즈가 아니라 **선도부가 확인 전화를 걸어야 할 이상 신호**다.
+  숨기면 자정을 넘겨 아직 안 들어온 진짜 외출 중인 학생까지 같이 사라질 위험도 있다.
+  이미 정한 `departedAt` 오름차순 정렬(아래)이 사실상 이 문제의 답이다 — 가장 오래
+  방치된 항목이 목록 맨 위로 올라와 선도부 눈에 먼저 띄는 구조이므로, 날짜 필터로
+  가리면 오히려 이 정렬의 목적과 충돌한다. 근본적인 자동 정리는 이번 이슈 범위 밖이며
+  #102(승인됐지만 미출발 마감 처리)와 같은 성격의 후속 과제로 남긴다.
+- **정렬 기준**: `departedAt` 오름차순(가장 오래 나가 있는 학생 우선) + `id` 오름차순
+  보조 정렬로 확정했다 — 마스터 기획서에는 정렬 기준이 명시돼 있지 않아 이번에 새로
+  정했고, `id` 보조 정렬은 착수 후 코드 리뷰에서 "`departedAt`이 초 단위 정밀도라 동률
+  시 페이지 경계에서 학생이 누락될 수 있다"는 지적을 반영해 추가했다.
+- **단건 상세조회(`GET /{code}`) 인가 범위 확장(보스 확정)**: 기존 `validateDetailAccess`
+  는 `DISCIPLINE`/`ADMIN` 또는 담당으로 지정된 `TEACHER`만 통과시켰다. `/active`가 이미
+  전체 `TEACHER`에게 전교생의 실시간 외출 현황(실명/학년/반 포함)을 보여주는데, 단건
+  조회만 담당 선생님으로 좁혀두면 인가 정책이 자기모순이라는 게 코드 리뷰에서 지적됐다.
+  전 교사에게 전교생 현황을 여는 쪽으로 통일하기로 확정하고, 담당 여부와 무관하게
+  `TEACHER` 역할이면 단건 조회도 허용하도록 이번 이슈에서 같이 반영한다.
+- **N+1 쿼리 / `status` 컬럼 인덱스 부재**: 코드 리뷰에서 확인했지만 지금 당장 고치지
+  않고 #109(외출 도메인 성능 최적화 백로그)로 미룬다. 현재 데이터량에서는 체감 영향이
+  없다.
 
 ## 테스트
 - `OutingServiceTest.GetActiveOutings`(신규 `@Nested`):
-  - `DEPARTED` 외출증이 여러 건일 때 `departedAt` 오름차순으로 반환
-  - `DEPARTED`가 아닌 외출증(`PENDING`/`APPROVED`/`RETURNED`/`REJECTED`/`MISSED`)은
-    제외
+  - `departedAt` 오름차순 + `id` 보조 정렬로 리포지토리를 호출하는지 확인(`DEPARTED`
+    필터는 리포지토리 메서드 시그니처 자체가 강제하므로 별도 케이스 불필요)
   - 결과 없을 때 `content: []`(200, `null` 아님)
-  - `page`/`size` 페이지네이션 동작(#41의 기존 테스트 패턴 재사용)
+  - 프로필 이미지 키가 없으면 URL `null`, 있으면 presigned URL 생성
+  - 리포지토리가 돌려준 `Page` 메타데이터(`totalElements`/`totalPages`/`hasNext`)를
+    그대로 응답에 반영
   - `page`가 음수이거나 `size`가 범위 밖이면 `OUTING_015`
-- `OutingControllerTest.GetActiveOutings`(신규 `@Nested`): 정상 요청 위임 확인
-- `OutingActiveListAuthorizationTest`(신규): `DISCIPLINE`/`TEACHER`/`ADMIN` 각각 200,
-  `STUDENT`로 요청 시 403, 인증 없이 요청 시 401(기존
-  `OutingApproveAuthorizationTest` 등과 동일한 패턴)
+- `OutingServiceTest.GetMyRequests`/`GetReceivedOutings`(기존, DB 페이지네이션 전환에
+  맞춰 갱신): `statusFilter`가 `statusEq`/`wantExpired` 파라미터로 올바르게 변환되는지
+  (PENDING/MISSED/직접 매치 상태 각각), 리포지토리가 돌려준 Page 메타데이터를 그대로
+  옮기는지 검증
+- `OutingServiceTest.GetOutingDetail`(기존, 신규 케이스 추가): 담당 아닌 `TEACHER`
+  역할도 조회 가능한지(`allowsAnyTeacherRole`)
+- `OutingControllerTest.GetActiveOutings`(신규 `@Nested`): 쿼리 파라미터 위임, 기본값
+  적용 확인
+- `OutingActiveListAuthorizationTest`(신규, `@SpringBootTest` 실 DB 기반):
+  `DISCIPLINE`/`TEACHER`/`ADMIN` 각각 200, `STUDENT`로 요청 시 403, 인증 없이 요청 시
+  401(기존 `OutingReceivedAuthorizationTest`와 동일한 패턴)
 
 ## 완료 조건 (Definition of Done)
 - 로컬 빌드/테스트 통과

--- a/src/main/java/com/remake/gone/common/response/PageResponse.java
+++ b/src/main/java/com/remake/gone/common/response/PageResponse.java
@@ -1,6 +1,7 @@
 package com.remake.gone.common.response;
 
 import java.util.List;
+import org.springframework.data.domain.Page;
 
 /**
  * 페이지네이션된 목록 응답 포맷(#41에서 최초 도입).
@@ -49,5 +50,20 @@ public record PageResponse<T>(
     List<T> content = allContent.subList(fromIndex, toIndex);
     boolean hasNext = (page + 1L) < totalPages;
     return new PageResponse<>(content, page, size, totalElements, totalPages, hasNext);
+  }
+
+  /**
+   * Spring Data {@link Page}를 이 프로젝트의 응답 포맷으로 변환합니다(#96). {@link
+   * #of(List, int, int)}와 달리 DB가 이미 페이지 단위로 잘라 조회한 결과를 그대로 감싸는
+   * 용도라, 자르는 계산을 다시 하지 않는다.
+   *
+   * @param <T>  목록 항목의 타입
+   * @param page DB에서 이미 페이지 단위로 조회한 결과
+   * @return 변환된 {@link PageResponse}
+   */
+  public static <T> PageResponse<T> of(Page<T> page) {
+    return new PageResponse<>(
+        page.getContent(), page.getNumber(), page.getSize(),
+        page.getTotalElements(), page.getTotalPages(), page.hasNext());
   }
 }

--- a/src/main/java/com/remake/gone/outing/controller/OutingController.java
+++ b/src/main/java/com/remake/gone/outing/controller/OutingController.java
@@ -3,6 +3,7 @@ package com.remake.gone.outing.controller;
 import com.remake.gone.common.response.ApiResponse;
 import com.remake.gone.common.response.PageResponse;
 import com.remake.gone.common.security.UserPrincipal;
+import com.remake.gone.outing.dto.OutingActiveResponse;
 import com.remake.gone.outing.dto.OutingApplyRequest;
 import com.remake.gone.outing.dto.OutingLocationRequest;
 import com.remake.gone.outing.dto.OutingRejectRequest;
@@ -210,6 +211,24 @@ public class OutingController {
         principal.userId(), period, dateFrom, dateTo, status, page, size,
         now.toLocalDate(), now.toLocalTime());
     return ApiResponse.success(response, "외출증 목록을 조회했습니다.");
+  }
+
+  /**
+   * 지금 외출 중(DEPARTED)인 학생 목록을 조회합니다. {@code DISCIPLINE}/{@code TEACHER}/
+   * {@code ADMIN} 역할이 필요합니다(#96).
+   *
+   * @param page 페이지 번호(0부터 시작, 생략 시 0)
+   * @param size 페이지 크기(1~100, 생략 시 20)
+   * @return 지금 외출 중인 학생 목록의 페이지네이션된 결과({@code departedAt} 오름차순)
+   */
+  @GetMapping("/active")
+  @PreAuthorize("hasAnyRole('DISCIPLINE', 'TEACHER', 'ADMIN')")
+  public ApiResponse<PageResponse<OutingActiveResponse>> getActiveOutings(
+      @RequestParam(defaultValue = "0") int page,
+      @RequestParam(defaultValue = "20") int size
+  ) {
+    PageResponse<OutingActiveResponse> response = outingService.getActiveOutings(page, size);
+    return ApiResponse.success(response, "현재 외출 중인 학생 목록입니다.");
   }
 
   /**

--- a/src/main/java/com/remake/gone/outing/dto/OutingActiveResponse.java
+++ b/src/main/java/com/remake/gone/outing/dto/OutingActiveResponse.java
@@ -1,0 +1,31 @@
+package com.remake.gone.outing.dto;
+
+import com.remake.gone.outing.enums.OutingTimeSlot;
+import java.time.LocalDateTime;
+
+/**
+ * 지금 외출 중인 학생 목록 응답 DTO(#96).
+ *
+ * @param code                   외부 식별자 코드(내부 PK가 아니라 프론트에 표시할 코드)
+ * @param studentNickname        학생 별명({@code User.name})
+ * @param studentProfileImageUrl 학생 프로필 사진 presigned URL. 없으면 {@code null}
+ * @param studentRealName        학생 실명({@code Gbsw.name})
+ * @param studentGrade           학생 학년
+ * @param studentClassNo         학생 반
+ * @param reason                 외출 사유
+ * @param timeSlot               외출 시간대
+ * @param departedAt             출발 보고 시각
+ * @param endTime                예정 종료 시각({@code HH:mm})
+ */
+public record OutingActiveResponse(
+    String code,
+    String studentNickname,
+    String studentProfileImageUrl,
+    String studentRealName,
+    Integer studentGrade,
+    Integer studentClassNo,
+    String reason,
+    OutingTimeSlot timeSlot,
+    LocalDateTime departedAt,
+    String endTime
+) {}

--- a/src/main/java/com/remake/gone/outing/repository/OutingRepository.java
+++ b/src/main/java/com/remake/gone/outing/repository/OutingRepository.java
@@ -3,10 +3,15 @@ package com.remake.gone.outing.repository;
 import com.remake.gone.outing.entity.Outing;
 import com.remake.gone.outing.enums.OutingStatus;
 import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 /**
  * {@link Outing} 리포지토리.
@@ -34,30 +39,103 @@ public interface OutingRepository extends JpaRepository<Outing, Long> {
       Long studentId, LocalDate outingDate, Collection<OutingStatus> statuses);
 
   /**
-   * 특정 학생이 신청한, 주어진 날짜 범위(양 끝 포함) 안의 외출증을 조회합니다(#41).
+   * 학생 본인이 신청한, 주어진 날짜 범위(양 끝 포함) 안의 외출증을 DB 페이지네이션으로
+   * 조회합니다(#41 도입, #96에서 in-memory 슬라이싱 대신 DB {@code LIMIT/OFFSET}으로 전환).
    *
-   * @param studentId 학생 사용자 ID
-   * @param dateFrom  범위 시작일
-   * @param dateTo    범위 종료일
-   * @return 조건에 맞는 외출증 목록, 날짜/시작 시각 오름차순
+   * <p>{@code statusEq}/{@code wantExpired} 두 파라미터로 "유효 상태" 필터를 표현한다 — 이
+   * 도메인은 {@code PENDING}이 마감을 넘기면 DB 값은 그대로 둔 채 조회 시점에만
+   * {@code MISSED}로 표시하므로({@link OutingStatus} Javadoc 참고), 응답 DTO의 상태값과
+   * WHERE절이 직접 비교할 수 있는 단일 컬럼이 없다:
+   * <ul>
+   *   <li>{@code statusFilter}가 없으면 {@code statusEq=null}, {@code wantExpired=null}
+   *       (둘 다 무시, 전체 반환)</li>
+   *   <li>{@code APPROVED}/{@code REJECTED}/{@code DEPARTED}/{@code RETURNED}면
+   *       {@code statusEq}=그 값, {@code wantExpired=null}(무시)</li>
+   *   <li>{@code PENDING}(마감 전만)이면 {@code statusEq=PENDING},
+   *       {@code wantExpired=false}</li>
+   *   <li>{@code MISSED}(마감 지난 PENDING만)면 {@code statusEq=PENDING},
+   *       {@code wantExpired=true}</li>
+   * </ul>
+   * 마감 판정 조건({@code outingDate}/{@code startTime} vs {@code today}/{@code now})은
+   * {@link com.remake.gone.outing.utils.OutingTimeUtils#isPastDeadline}과 동일한 규칙을
+   * SQL로 옮긴 것이므로, 그 메서드의 판정 기준이 바뀌면 이 쿼리도 같이 바꿔야 한다.
+   *
+   * @param studentId   학생 사용자 ID
+   * @param dateFrom    범위 시작일
+   * @param dateTo      범위 종료일
+   * @param statusEq    {@code status} 컬럼과 직접 비교할 값. {@code null}이면 무시
+   * @param wantExpired {@code statusEq=PENDING}일 때만 의미 있음 — {@code true}면 마감 지난
+   *                    건만, {@code false}면 마감 전인 건만. {@code null}이면 무시
+   * @param today       "오늘" 날짜(KST) — 마감 판정 기준
+   * @param now         "지금" 시각(KST) — 마감 판정 기준
+   * @param pageable    페이지 번호/크기/정렬
+   * @return 조건에 맞는 외출증의 페이지
    */
-  List<Outing> findByStudentIdAndOutingDateBetweenOrderByOutingDateAscStartTimeAsc(
-      Long studentId, LocalDate dateFrom, LocalDate dateTo);
+  @Query("""
+      SELECT o FROM Outing o
+      WHERE o.student.id = :studentId
+        AND o.outingDate BETWEEN :dateFrom AND :dateTo
+        AND (:statusEq IS NULL OR o.status = :statusEq)
+        AND (:wantExpired IS NULL
+             OR (:wantExpired = TRUE
+                 AND (o.outingDate < :today
+                      OR (o.outingDate = :today AND o.startTime <= :now)))
+             OR (:wantExpired = FALSE
+                 AND (o.outingDate > :today
+                      OR (o.outingDate = :today AND o.startTime > :now))))
+      """)
+  Page<Outing> findStudentRequestsPage(
+      @Param("studentId") Long studentId,
+      @Param("dateFrom") LocalDate dateFrom,
+      @Param("dateTo") LocalDate dateTo,
+      @Param("statusEq") OutingStatus statusEq,
+      @Param("wantExpired") Boolean wantExpired,
+      @Param("today") LocalDate today,
+      @Param("now") LocalTime now,
+      Pageable pageable);
 
   /**
-   * 특정 선생님에게 담당으로 지정된, 주어진 날짜 범위(양 끝 포함) 안의 외출증을 조회합니다(#41).
+   * 담당 선생님에게 지정된, 주어진 날짜 범위(양 끝 포함) 안의 외출증을 DB 페이지네이션으로
+   * 조회합니다(#41 도입, #96에서 전환). 필터 파라미터 의미는
+   * {@link #findStudentRequestsPage}와 동일하다.
    *
-   * @param teacherId 선생님 사용자 ID
-   * @param dateFrom  범위 시작일
-   * @param dateTo    범위 종료일
-   * @return 조건에 맞는 외출증 목록, 날짜/시작 시각 오름차순
+   * @param teacherId   선생님 사용자 ID
+   * @param dateFrom    범위 시작일
+   * @param dateTo      범위 종료일
+   * @param statusEq    {@code status} 컬럼과 직접 비교할 값. {@code null}이면 무시
+   * @param wantExpired {@code statusEq=PENDING}일 때만 의미 있음. {@code null}이면 무시
+   * @param today       "오늘" 날짜(KST) — 마감 판정 기준
+   * @param now         "지금" 시각(KST) — 마감 판정 기준
+   * @param pageable    페이지 번호/크기/정렬
+   * @return 조건에 맞는 외출증의 페이지
    */
-  List<Outing> findByTeacherIdAndOutingDateBetweenOrderByOutingDateAscStartTimeAsc(
-      Long teacherId, LocalDate dateFrom, LocalDate dateTo);
+  @Query("""
+      SELECT o FROM Outing o
+      WHERE o.teacher.id = :teacherId
+        AND o.outingDate BETWEEN :dateFrom AND :dateTo
+        AND (:statusEq IS NULL OR o.status = :statusEq)
+        AND (:wantExpired IS NULL
+             OR (:wantExpired = TRUE
+                 AND (o.outingDate < :today
+                      OR (o.outingDate = :today AND o.startTime <= :now)))
+             OR (:wantExpired = FALSE
+                 AND (o.outingDate > :today
+                      OR (o.outingDate = :today AND o.startTime > :now))))
+      """)
+  Page<Outing> findTeacherReceivedPage(
+      @Param("teacherId") Long teacherId,
+      @Param("dateFrom") LocalDate dateFrom,
+      @Param("dateTo") LocalDate dateTo,
+      @Param("statusEq") OutingStatus statusEq,
+      @Param("wantExpired") Boolean wantExpired,
+      @Param("today") LocalDate today,
+      @Param("now") LocalTime now,
+      Pageable pageable);
 
   /**
    * 주어진 상태에 해당하는 외출증을 전부 조회합니다(#42, {@code MISSED} 반영 스케줄러 대상
-   * 조회).
+   * 조회). 스케줄러는 페이지네이션 없이 대상 전체를 훑어야 하므로 {@link List}를 반환하는
+   * 이 메서드를 그대로 둔다.
    *
    * @param status 조회할 상태
    * @return 조건에 맞는 외출증 목록
@@ -65,11 +143,14 @@ public interface OutingRepository extends JpaRepository<Outing, Long> {
   List<Outing> findByStatus(OutingStatus status);
 
   /**
-   * 주어진 상태에 해당하는 외출증을 {@code departedAt} 오름차순으로 조회합니다(#96, 지금 외출
-   * 중인 학생 목록 — 가장 오래 나가 있는 학생이 먼저 보이도록 정렬).
+   * 주어진 상태에 해당하는 외출증을 DB 페이지네이션으로 조회합니다(#96, 지금 외출 중인 학생
+   * 목록). 정렬은 호출부가 {@code pageable}의 {@link org.springframework.data.domain.Sort}로
+   * 지정한다({@code departedAt} 오름차순 + {@code id} 보조 정렬 — 가장 오래 나가 있는 학생이
+   * 먼저 보이고, {@code departedAt}이 같은 초에 몰려도 페이지 경계에서 순서가 흔들리지 않도록).
    *
-   * @param status 조회할 상태
-   * @return 조건에 맞는 외출증 목록, {@code departedAt} 오름차순
+   * @param status   조회할 상태
+   * @param pageable 페이지 번호/크기/정렬
+   * @return 조건에 맞는 외출증의 페이지
    */
-  List<Outing> findByStatusOrderByDepartedAtAsc(OutingStatus status);
+  Page<Outing> findByStatus(OutingStatus status, Pageable pageable);
 }

--- a/src/main/java/com/remake/gone/outing/repository/OutingRepository.java
+++ b/src/main/java/com/remake/gone/outing/repository/OutingRepository.java
@@ -63,4 +63,13 @@ public interface OutingRepository extends JpaRepository<Outing, Long> {
    * @return 조건에 맞는 외출증 목록
    */
   List<Outing> findByStatus(OutingStatus status);
+
+  /**
+   * 주어진 상태에 해당하는 외출증을 {@code departedAt} 오름차순으로 조회합니다(#96, 지금 외출
+   * 중인 학생 목록 — 가장 오래 나가 있는 학생이 먼저 보이도록 정렬).
+   *
+   * @param status 조회할 상태
+   * @return 조건에 맞는 외출증 목록, {@code departedAt} 오름차순
+   */
+  List<Outing> findByStatusOrderByDepartedAtAsc(OutingStatus status);
 }

--- a/src/main/java/com/remake/gone/outing/service/OutingService.java
+++ b/src/main/java/com/remake/gone/outing/service/OutingService.java
@@ -7,6 +7,7 @@ import com.remake.gone.file.service.R2FileService;
 import com.remake.gone.gbsw.entity.Gbsw;
 import com.remake.gone.gbsw.exception.GbswErrorCode;
 import com.remake.gone.outing.config.OutingProperties;
+import com.remake.gone.outing.dto.OutingActiveResponse;
 import com.remake.gone.outing.dto.OutingApplyRequest;
 import com.remake.gone.outing.dto.OutingLocationRequest;
 import com.remake.gone.outing.dto.OutingResponse;
@@ -37,6 +38,10 @@ import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -63,6 +68,18 @@ public class OutingService {
   private static final int MAX_CODE_GENERATION_ATTEMPTS = 5;
   private static final int MIN_PAGE_SIZE = 1;
   private static final int MAX_PAGE_SIZE = 100;
+
+  // getMyRequests/getReceivedOutings 조회 정렬 기준(#41 도입, #96에서 DB 페이지네이션으로
+  // 전환하며 id를 보조 정렬 키로 추가) — outingDate/startTime이 같은 두 건이 존재할 수 있어
+  // (예: 거절된 뒤 같은 시간대로 재신청) 페이지 경계에서 순서가 흔들리지 않도록 한다.
+  private static final Sort LIST_QUERY_SORT = Sort.by(
+      Sort.Order.asc("outingDate"), Sort.Order.asc("startTime"), Sort.Order.asc("id"));
+
+  // getActiveOutings(#96) 정렬 기준 — 가장 오래 나가 있는 학생이 먼저 보이도록 departedAt
+  // 오름차순, departedAt이 초 단위 정밀도라 같은 초에 여러 학생이 출발할 수 있어 id를 보조
+  // 정렬 키로 추가한다(동률 시 페이지 경계에서 학생이 누락되는 것을 방지).
+  private static final Sort ACTIVE_LIST_SORT =
+      Sort.by(Sort.Order.asc("departedAt"), Sort.Order.asc("id"));
 
   private final OutingRepository outingRepository;
   private final UserRepository userRepository;
@@ -191,11 +208,14 @@ public class OutingService {
 
     validatePageParams(page, size);
     OutingDateRange range = resolveQueryRange(period, dateFrom, dateTo, today);
-    List<Outing> outings = outingRepository
-        .findByStudentIdAndOutingDateBetweenOrderByOutingDateAscStartTimeAsc(
-            studentUserId, range.from(), range.to());
-    List<OutingResponse> filtered = toFilteredResponses(outings, statusFilter, today, now);
-    return PageResponse.of(filtered, page, size);
+    StatusFilterParams filter = resolveStatusFilterParams(statusFilter);
+    Pageable pageable = PageRequest.of(page, size, LIST_QUERY_SORT);
+    Page<Outing> outings = outingRepository.findStudentRequestsPage(
+        studentUserId, range.from(), range.to(),
+        filter.statusEq(), filter.wantExpired(), today, now, pageable);
+    Page<OutingResponse> responses = outings.map(
+        outing -> toResponse(outing, outing.getStudent(), outing.getTeacher(), today, now));
+    return PageResponse.of(responses);
   }
 
   /**
@@ -218,11 +238,78 @@ public class OutingService {
       OutingQueryStatus statusFilter, int page, int size, LocalDate today, LocalTime now) {
     validatePageParams(page, size);
     OutingDateRange range = resolveQueryRange(period, dateFrom, dateTo, today);
-    List<Outing> outings = outingRepository
-        .findByTeacherIdAndOutingDateBetweenOrderByOutingDateAscStartTimeAsc(
-            teacherUserId, range.from(), range.to());
-    List<OutingResponse> filtered = toFilteredResponses(outings, statusFilter, today, now);
-    return PageResponse.of(filtered, page, size);
+    StatusFilterParams filter = resolveStatusFilterParams(statusFilter);
+    Pageable pageable = PageRequest.of(page, size, LIST_QUERY_SORT);
+    Page<Outing> outings = outingRepository.findTeacherReceivedPage(
+        teacherUserId, range.from(), range.to(),
+        filter.statusEq(), filter.wantExpired(), today, now, pageable);
+    Page<OutingResponse> responses = outings.map(
+        outing -> toResponse(outing, outing.getStudent(), outing.getTeacher(), today, now));
+    return PageResponse.of(responses);
+  }
+
+  /**
+   * {@code statusFilter}(응답에 노출되는 유효 상태 기준)를 {@code status} 컬럼과 직접 비교
+   * 가능한 값({@code statusEq}) + 마감 여부 플래그({@code wantExpired})로 변환한다(#96). 이
+   * 변환이 필요한 이유는 {@link OutingRepository#findStudentRequestsPage}의 Javadoc 참고 —
+   * {@code PENDING}이 마감을 넘겨도 DB 값은 그대로 {@code PENDING}이라 단일 컬럼 비교로는
+   * "마감 전 PENDING만"과 "마감 지난 PENDING(MISSED로 표시)만"을 구분할 수 없다.
+   */
+  private StatusFilterParams resolveStatusFilterParams(OutingQueryStatus statusFilter) {
+    if (statusFilter == null) {
+      return new StatusFilterParams(null, null);
+    }
+    if (statusFilter == OutingQueryStatus.PENDING) {
+      return new StatusFilterParams(OutingStatus.PENDING, false);
+    }
+    if (statusFilter == OutingQueryStatus.MISSED) {
+      return new StatusFilterParams(OutingStatus.PENDING, true);
+    }
+    return new StatusFilterParams(statusFilter.toOutingStatus(), null);
+  }
+
+  private record StatusFilterParams(OutingStatus statusEq, Boolean wantExpired) {}
+
+  /**
+   * 지금 외출 중(DEPARTED)인 학생 목록을 조회합니다(#96). 선도부/선생님이 별도 위치 정보 없이
+   * "누가 지금 밖에 있는지"만 빠르게 훑어보는 용도라 좌표는 응답에 포함하지 않는다(위치는
+   * #97에서 더 좁은 권한으로 제공).
+   *
+   * <p>도착 보고 없이 방치된 외출증(자정을 넘겨도 자동 정리되지 않는 기존 리스크)을 날짜
+   * 필터로 가리지 않는다 — 오래 방치된 건일수록 선도부가 확인해야 할 이상 신호이므로, 숨기는
+   * 대신 {@code departedAt} 오름차순 정렬로 목록 맨 위에 노출한다(보스 확정, 2026-08-25).
+   * 근본적인 자동 정리는 이 이슈 범위 밖이며 #102에서 다룬다.
+   *
+   * @param page 페이지 번호(0부터 시작)
+   * @param size 페이지 크기(1~100)
+   * @return 지금 외출 중인 학생 목록의 페이지네이션된 결과({@code departedAt} 오름차순 —
+   *         가장 오래 나가 있는 학생이 먼저 보임)
+   */
+  @Transactional(readOnly = true)
+  public PageResponse<OutingActiveResponse> getActiveOutings(int page, int size) {
+    validatePageParams(page, size);
+    Pageable pageable = PageRequest.of(page, size, ACTIVE_LIST_SORT);
+    Page<Outing> outings = outingRepository.findByStatus(OutingStatus.DEPARTED, pageable);
+    return PageResponse.of(outings.map(this::toActiveResponse));
+  }
+
+  private OutingActiveResponse toActiveResponse(Outing outing) {
+    User student = outing.getStudent();
+    String studentProfileImageUrl = student.getProfileImageKey() != null
+        ? r2FileService.generateDownloadUrl(student.getProfileImageKey())
+        : null;
+    Gbsw studentGbsw = student.getGbsw();
+    return new OutingActiveResponse(
+        outing.getCode(),
+        student.getName(),
+        studentProfileImageUrl,
+        studentGbsw.getName(),
+        studentGbsw.getGrade(),
+        studentGbsw.getClassNo(),
+        outing.getReason(),
+        outing.getTimeSlot(),
+        outing.getDepartedAt(),
+        outing.getEndTime().format(HM_FORMATTER));
   }
 
   /**
@@ -638,15 +725,14 @@ public class OutingService {
     }
   }
 
-  private List<OutingResponse> toFilteredResponses(
-      List<Outing> outings, OutingQueryStatus statusFilter, LocalDate today, LocalTime now) {
-    OutingStatus effectiveFilter = statusFilter == null ? null : statusFilter.toOutingStatus();
-    return outings.stream()
-        .map(outing -> toResponse(outing, outing.getStudent(), outing.getTeacher(), today, now))
-        .filter(response -> effectiveFilter == null || response.status() == effectiveFilter)
-        .toList();
-  }
-
+  /**
+   * 외출증 단건 상세 조회 접근 권한을 검증합니다(#41 도입, #96에서 범위 확장). 신청 학생
+   * 본인, 지정된 담당 선생님은 항상 통과한다. 그 외에는 {@code DISCIPLINE}/{@code ADMIN}
+   * 또는 (담당 여부와 무관하게) {@code TEACHER} 역할이면 통과한다 — {@code /active}
+   * 목록이 이미 전체 {@code TEACHER}에게 지금 외출 중인 전교생 현황을 보여주는 것과 인가
+   * 범위를 맞추기 위해, 단건 조회도 담당 선생님으로 한정하지 않기로 확정했다(보스 확정,
+   * 2026-08-25).
+   */
   private void validateDetailAccess(Long callerUserId, Outing outing) {
     boolean isRelated = outing.getStudent().getId().equals(callerUserId)
         || outing.getTeacher().getId().equals(callerUserId);
@@ -654,7 +740,9 @@ public class OutingService {
       return;
     }
     List<String> roles = userRoleRepository.findRoleCodesByUserId(callerUserId);
-    if (roles.contains(DISCIPLINE_ROLE_CODE) || roles.contains(ADMIN_ROLE_CODE)) {
+    if (roles.contains(DISCIPLINE_ROLE_CODE)
+        || roles.contains(ADMIN_ROLE_CODE)
+        || roles.contains(TEACHER_ROLE_CODE)) {
       return;
     }
     throw new CustomException(OutingErrorCode.ACCESS_DENIED);

--- a/src/test/java/com/remake/gone/outing/controller/OutingActiveListAuthorizationTest.java
+++ b/src/test/java/com/remake/gone/outing/controller/OutingActiveListAuthorizationTest.java
@@ -1,0 +1,78 @@
+package com.remake.gone.outing.controller;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.remake.gone.common.security.JwtProvider;
+import java.util.Set;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.test.web.servlet.MockMvc;
+
+/**
+ * {@code GET /api/v1/outings/active}의 인가(@PreAuthorize) 통합 테스트(#96).
+ *
+ * <p>{@code OutingReceivedAuthorizationTest}와 같은 이유로, {@code @WebMvcTest} 슬라이스가 아니라
+ * 실제 필터 체인(+ {@code @EnableMethodSecurity})을 통해 검증한다. {@code DISCIPLINE}/
+ * {@code TEACHER}/{@code ADMIN}은 통과(200), 그 외 역할은 차단(403)되는지 함께 확인한다.
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+class OutingActiveListAuthorizationTest {
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @Autowired
+  private JwtProvider jwtProvider;
+
+  @Test
+  @DisplayName("인증 없이 요청하면 401을 반환한다")
+  void returns401WithoutToken() throws Exception {
+    mockMvc.perform(get("/api/v1/outings/active"))
+        .andExpect(status().isUnauthorized());
+  }
+
+  @Test
+  @DisplayName("STUDENT 역할로 요청하면 403을 반환한다")
+  void returns403ForStudentRole() throws Exception {
+    String token = jwtProvider.createAccessToken(1L, Set.of("STUDENT"));
+
+    mockMvc.perform(get("/api/v1/outings/active")
+            .header("Authorization", "Bearer " + token))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
+  @DisplayName("DISCIPLINE 역할로 요청하면 200을 반환한다")
+  void returns200ForDisciplineRole() throws Exception {
+    String token = jwtProvider.createAccessToken(1L, Set.of("DISCIPLINE"));
+
+    mockMvc.perform(get("/api/v1/outings/active")
+            .header("Authorization", "Bearer " + token))
+        .andExpect(status().isOk());
+  }
+
+  @Test
+  @DisplayName("TEACHER 역할로 요청하면 200을 반환한다")
+  void returns200ForTeacherRole() throws Exception {
+    String token = jwtProvider.createAccessToken(1L, Set.of("TEACHER"));
+
+    mockMvc.perform(get("/api/v1/outings/active")
+            .header("Authorization", "Bearer " + token))
+        .andExpect(status().isOk());
+  }
+
+  @Test
+  @DisplayName("ADMIN 역할로 요청하면 200을 반환한다")
+  void returns200ForAdminRole() throws Exception {
+    String token = jwtProvider.createAccessToken(1L, Set.of("ADMIN"));
+
+    mockMvc.perform(get("/api/v1/outings/active")
+            .header("Authorization", "Bearer " + token))
+        .andExpect(status().isOk());
+  }
+}

--- a/src/test/java/com/remake/gone/outing/controller/OutingControllerTest.java
+++ b/src/test/java/com/remake/gone/outing/controller/OutingControllerTest.java
@@ -13,6 +13,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.remake.gone.common.response.ApiResponse;
 import com.remake.gone.common.response.PageResponse;
 import com.remake.gone.common.security.UserPrincipal;
+import com.remake.gone.outing.dto.OutingActiveResponse;
 import com.remake.gone.outing.dto.OutingApplyRequest;
 import com.remake.gone.outing.dto.OutingLocationRequest;
 import com.remake.gone.outing.dto.OutingRejectRequest;
@@ -421,6 +422,37 @@ class OutingControllerTest {
 
       assertThat(response.success()).isTrue();
       assertThat(response.data().content()).isEmpty();
+    }
+  }
+
+  @Nested
+  @DisplayName("GET /api/v1/outings/active")
+  class GetActiveOutings {
+
+    @Test
+    @DisplayName("쿼리 파라미터를 그대로 서비스에 전달한다")
+    void passesParamsToService() {
+      OutingActiveResponse expected = new OutingActiveResponse(
+          "8A1zx9202n", "길동이", null, "홍길동", 3, 4,
+          "치과 진료", OutingTimeSlot.LUNCH, LocalDateTime.of(2026, 8, 14, 12, 31), "13:40");
+      given(outingService.getActiveOutings(0, 20))
+          .willReturn(PageResponse.of(List.of(expected), 0, 20));
+
+      ApiResponse<PageResponse<OutingActiveResponse>> response =
+          controller().getActiveOutings(0, 20);
+
+      assertThat(response.success()).isTrue();
+      assertThat(response.data().content()).containsExactly(expected);
+    }
+
+    @Test
+    @DisplayName("page/size를 생략하면 기본값(0, 20)이 적용된다")
+    void defaultsPageAndSize() throws Exception {
+      given(outingService.getActiveOutings(0, 20))
+          .willReturn(PageResponse.of(List.of(), 0, 20));
+
+      mockMvc.perform(get("/api/v1/outings/active"))
+          .andExpect(status().isOk());
     }
   }
 

--- a/src/test/java/com/remake/gone/outing/service/OutingServiceTest.java
+++ b/src/test/java/com/remake/gone/outing/service/OutingServiceTest.java
@@ -3,6 +3,8 @@ package com.remake.gone.outing.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -14,6 +16,7 @@ import com.remake.gone.gbsw.entity.Gbsw;
 import com.remake.gone.gbsw.enums.GbswType;
 import com.remake.gone.gbsw.exception.GbswErrorCode;
 import com.remake.gone.outing.config.OutingProperties;
+import com.remake.gone.outing.dto.OutingActiveResponse;
 import com.remake.gone.outing.dto.OutingApplyRequest;
 import com.remake.gone.outing.dto.OutingLocationRequest;
 import com.remake.gone.outing.dto.OutingResponse;
@@ -36,10 +39,15 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.orm.ObjectOptimisticLockingFailureException;
 
 /**
@@ -1076,9 +1084,10 @@ class OutingServiceTest {
     @DisplayName("period=THIS_WEEK면 TODAY가 속한 주(월~일)로 조회한다")
     void resolvesThisWeekRangeFromToday() {
       // TODAY = 2026-08-10(월) → 이번 주는 2026-08-10(월)~2026-08-16(일)
-      given(outingRepository.findByStudentIdAndOutingDateBetweenOrderByOutingDateAscStartTimeAsc(
-          STUDENT_ID, LocalDate.of(2026, 8, 10), LocalDate.of(2026, 8, 16)))
-          .willReturn(List.of());
+      given(outingRepository.findStudentRequestsPage(
+          eq(STUDENT_ID), eq(LocalDate.of(2026, 8, 10)), eq(LocalDate.of(2026, 8, 16)),
+          isNull(), isNull(), eq(TODAY), eq(NOW), any(Pageable.class)))
+          .willReturn(new PageImpl<>(List.of(), PageRequest.of(0, 20), 0));
 
       PageResponse<OutingResponse> response = outingService.getMyRequests(
           STUDENT_ID, OutingQueryPeriod.THIS_WEEK, null, null, null, 0, 20, TODAY, NOW);
@@ -1089,9 +1098,10 @@ class OutingServiceTest {
     @Test
     @DisplayName("범위 안에 신청한 게 없으면 빈 배열을 반환한다(null 아님)")
     void returnsEmptyListNotNullWhenNoResults() {
-      given(outingRepository.findByStudentIdAndOutingDateBetweenOrderByOutingDateAscStartTimeAsc(
-          STUDENT_ID, TODAY, TODAY))
-          .willReturn(List.of());
+      given(outingRepository.findStudentRequestsPage(
+          eq(STUDENT_ID), eq(TODAY), eq(TODAY), isNull(), isNull(), eq(TODAY), eq(NOW),
+          any(Pageable.class)))
+          .willReturn(new PageImpl<>(List.of(), PageRequest.of(0, 20), 0));
 
       PageResponse<OutingResponse> response = outingService.getMyRequests(
           STUDENT_ID, OutingQueryPeriod.TODAY,
@@ -1104,9 +1114,10 @@ class OutingServiceTest {
     @DisplayName("PENDING이고 마감이 지난 건은 MISSED로 표시한다(DB 값은 그대로 PENDING)")
     void showsMissedForExpiredPending() {
       Outing pastDeadline = outingWithStatus(OutingStatus.PENDING, TODAY, LocalTime.of(8, 0));
-      given(outingRepository.findByStudentIdAndOutingDateBetweenOrderByOutingDateAscStartTimeAsc(
-          STUDENT_ID, TODAY, TODAY))
-          .willReturn(List.of(pastDeadline));
+      given(outingRepository.findStudentRequestsPage(
+          eq(STUDENT_ID), eq(TODAY), eq(TODAY), isNull(), isNull(), eq(TODAY), eq(NOW),
+          any(Pageable.class)))
+          .willReturn(new PageImpl<>(List.of(pastDeadline), PageRequest.of(0, 20), 1));
 
       PageResponse<OutingResponse> response = outingService.getMyRequests(
           STUDENT_ID, OutingQueryPeriod.TODAY,
@@ -1118,13 +1129,13 @@ class OutingServiceTest {
     }
 
     @Test
-    @DisplayName("status=PENDING으로 필터링하면 마감 지난 건(MISSED)은 빠진다")
-    void statusFilterExcludesMissedWhenFilteringPending() {
-      Outing pastDeadline = outingWithStatus(OutingStatus.PENDING, TODAY, LocalTime.of(8, 0));
+    @DisplayName("status=PENDING으로 필터링하면 statusEq=PENDING, wantExpired=false로 조회한다")
+    void statusFilterPendingResolvesToNotExpired() {
       Outing stillPending = outingWithStatus(OutingStatus.PENDING, TODAY, LocalTime.of(18, 0));
-      given(outingRepository.findByStudentIdAndOutingDateBetweenOrderByOutingDateAscStartTimeAsc(
-          STUDENT_ID, TODAY, TODAY))
-          .willReturn(List.of(pastDeadline, stillPending));
+      given(outingRepository.findStudentRequestsPage(
+          eq(STUDENT_ID), eq(TODAY), eq(TODAY), eq(OutingStatus.PENDING), eq(false),
+          eq(TODAY), eq(NOW), any(Pageable.class)))
+          .willReturn(new PageImpl<>(List.of(stillPending), PageRequest.of(0, 20), 1));
 
       PageResponse<OutingResponse> response = outingService.getMyRequests(
           STUDENT_ID, OutingQueryPeriod.TODAY,
@@ -1135,13 +1146,13 @@ class OutingServiceTest {
     }
 
     @Test
-    @DisplayName("status=MISSED로 필터링하면 마감 지난 건만 나온다")
-    void statusFilterReturnsOnlyMissed() {
+    @DisplayName("status=MISSED로 필터링하면 statusEq=PENDING, wantExpired=true로 조회한다")
+    void statusFilterMissedResolvesToExpired() {
       Outing pastDeadline = outingWithStatus(OutingStatus.PENDING, TODAY, LocalTime.of(8, 0));
-      Outing stillPending = outingWithStatus(OutingStatus.PENDING, TODAY, LocalTime.of(18, 0));
-      given(outingRepository.findByStudentIdAndOutingDateBetweenOrderByOutingDateAscStartTimeAsc(
-          STUDENT_ID, TODAY, TODAY))
-          .willReturn(List.of(pastDeadline, stillPending));
+      given(outingRepository.findStudentRequestsPage(
+          eq(STUDENT_ID), eq(TODAY), eq(TODAY), eq(OutingStatus.PENDING), eq(true),
+          eq(TODAY), eq(NOW), any(Pageable.class)))
+          .willReturn(new PageImpl<>(List.of(pastDeadline), PageRequest.of(0, 20), 1));
 
       PageResponse<OutingResponse> response = outingService.getMyRequests(
           STUDENT_ID, OutingQueryPeriod.TODAY,
@@ -1149,6 +1160,23 @@ class OutingServiceTest {
 
       assertThat(response.content()).hasSize(1);
       assertThat(response.content().get(0).status()).isEqualTo(OutingStatus.MISSED);
+    }
+
+    @Test
+    @DisplayName("status=DEPARTED로 필터링하면 statusEq=DEPARTED, wantExpired=null로 조회한다")
+    void statusFilterDepartedResolvesToDirectMatch() {
+      Outing departed = outingWithStatus(OutingStatus.DEPARTED, TODAY, LocalTime.of(8, 0));
+      given(outingRepository.findStudentRequestsPage(
+          eq(STUDENT_ID), eq(TODAY), eq(TODAY), eq(OutingStatus.DEPARTED), isNull(),
+          eq(TODAY), eq(NOW), any(Pageable.class)))
+          .willReturn(new PageImpl<>(List.of(departed), PageRequest.of(0, 20), 1));
+
+      PageResponse<OutingResponse> response = outingService.getMyRequests(
+          STUDENT_ID, OutingQueryPeriod.TODAY,
+          null, null, OutingQueryStatus.DEPARTED, 0, 20, TODAY, NOW);
+
+      assertThat(response.content()).hasSize(1);
+      assertThat(response.content().get(0).status()).isEqualTo(OutingStatus.DEPARTED);
     }
 
     @Test
@@ -1237,9 +1265,10 @@ class OutingServiceTest {
           .endTime(LocalTime.of(13, 40))
           .status(OutingStatus.PENDING)
           .build();
-      given(outingRepository.findByTeacherIdAndOutingDateBetweenOrderByOutingDateAscStartTimeAsc(
-          TEACHER_ID, TODAY, TODAY))
-          .willReturn(List.of(pending));
+      given(outingRepository.findTeacherReceivedPage(
+          eq(TEACHER_ID), eq(TODAY), eq(TODAY), isNull(), isNull(), eq(TODAY), eq(NOW),
+          any(Pageable.class)))
+          .willReturn(new PageImpl<>(List.of(pending), PageRequest.of(0, 20), 1));
 
       PageResponse<OutingResponse> response = outingService.getReceivedOutings(
           TEACHER_ID, OutingQueryPeriod.TODAY,
@@ -1250,11 +1279,11 @@ class OutingServiceTest {
     }
 
     @Test
-    @DisplayName("size보다 결과가 많으면 요청한 size만큼만 반환하고 hasNext는 true다")
-    void paginatesAndReportsHasNext() {
-      List<Outing> outings = new java.util.ArrayList<>();
-      for (int i = 0; i < 3; i++) {
-        outings.add(Outing.builder()
+    @DisplayName("리포지토리가 돌려준 Page 메타데이터를 그대로 응답에 담는다")
+    void reflectsRepositoryPageMetadata() {
+      List<Outing> pageContent = new java.util.ArrayList<>();
+      for (int i = 0; i < 2; i++) {
+        pageContent.add(Outing.builder()
             .id(800L + i)
             .code("PAGECODE" + i)
             .student(student())
@@ -1267,9 +1296,12 @@ class OutingServiceTest {
             .status(OutingStatus.PENDING)
             .build());
       }
-      given(outingRepository.findByTeacherIdAndOutingDateBetweenOrderByOutingDateAscStartTimeAsc(
-          TEACHER_ID, TODAY, TODAY))
-          .willReturn(outings);
+      // DB가 size=2로 이미 자른 3건 중 첫 페이지라고 가정 — 슬라이싱 자체는 이제 DB 책임이라
+      // 서비스는 Page가 돌려준 메타데이터를 그대로 옮기기만 하는지 검증한다.
+      given(outingRepository.findTeacherReceivedPage(
+          eq(TEACHER_ID), eq(TODAY), eq(TODAY), isNull(), isNull(), eq(TODAY), eq(NOW),
+          any(Pageable.class)))
+          .willReturn(new PageImpl<>(pageContent, PageRequest.of(0, 2), 3));
 
       PageResponse<OutingResponse> response = outingService.getReceivedOutings(
           TEACHER_ID, OutingQueryPeriod.TODAY,
@@ -1279,6 +1311,135 @@ class OutingServiceTest {
       assertThat(response.totalElements()).isEqualTo(3);
       assertThat(response.totalPages()).isEqualTo(2);
       assertThat(response.hasNext()).isTrue();
+    }
+  }
+
+  @Nested
+  @DisplayName("getActiveOutings")
+  class GetActiveOutings {
+
+    private Outing departedOuting(Long id, LocalDateTime departedAt, String profileImageKey) {
+      User departedStudent = User.builder()
+          .id(STUDENT_ID)
+          .gbsw(Gbsw.builder()
+              .type(GbswType.STUDENT)
+              .name("홍길동")
+              .phoneNumber("01011112222")
+              .grade(3)
+              .classNo(4)
+              .number(12)
+              .build())
+          .loginId("student1")
+          .passwordHash("hash")
+          .name("길동이")
+          .phoneNumber("01011112222")
+          .profileImageKey(profileImageKey)
+          .build();
+      return Outing.builder()
+          .id(id)
+          .code("ACTIVECODE" + id)
+          .student(departedStudent)
+          .teacher(teacher())
+          .reason("치과 진료")
+          .outingDate(TODAY)
+          .timeSlot(OutingTimeSlot.LUNCH)
+          .startTime(LocalTime.of(12, 30))
+          .endTime(LocalTime.of(13, 40))
+          .status(OutingStatus.DEPARTED)
+          .departedAt(departedAt)
+          .build();
+    }
+
+    @Test
+    @DisplayName("DEPARTED 상태만 조회하고, departedAt 오름차순 + id 보조 정렬을 요청한다")
+    void queriesDepartedStatusWithDepartedAtAndIdSort() {
+      Outing outing = departedOuting(900L, LocalDateTime.of(2026, 8, 10, 12, 31), null);
+      ArgumentCaptor<Pageable> pageableCaptor = ArgumentCaptor.forClass(Pageable.class);
+      given(outingRepository.findByStatus(eq(OutingStatus.DEPARTED), pageableCaptor.capture()))
+          .willReturn(new PageImpl<>(List.of(outing), PageRequest.of(0, 20), 1));
+
+      PageResponse<OutingActiveResponse> response = outingService.getActiveOutings(0, 20);
+
+      assertThat(response.content()).hasSize(1);
+      assertThat(response.content().get(0).code()).isEqualTo("ACTIVECODE900");
+      List<org.springframework.data.domain.Sort.Order> orders =
+          pageableCaptor.getValue().getSort().stream().toList();
+      assertThat(orders).extracting(org.springframework.data.domain.Sort.Order::getProperty)
+          .containsExactly("departedAt", "id");
+    }
+
+    @Test
+    @DisplayName("결과 없을 때 빈 배열을 반환한다(null 아님)")
+    void returnsEmptyListNotNullWhenNoActiveOutings() {
+      given(outingRepository.findByStatus(eq(OutingStatus.DEPARTED), any(Pageable.class)))
+          .willReturn(new PageImpl<>(List.of(), PageRequest.of(0, 20), 0));
+
+      PageResponse<OutingActiveResponse> response = outingService.getActiveOutings(0, 20);
+
+      assertThat(response.content()).isNotNull().isEmpty();
+    }
+
+    @Test
+    @DisplayName("프로필 이미지 키가 없으면 studentProfileImageUrl은 null이다")
+    void nullProfileImageUrlWhenKeyMissing() {
+      Outing outing = departedOuting(901L, LocalDateTime.of(2026, 8, 10, 12, 31), null);
+      given(outingRepository.findByStatus(eq(OutingStatus.DEPARTED), any(Pageable.class)))
+          .willReturn(new PageImpl<>(List.of(outing), PageRequest.of(0, 20), 1));
+
+      PageResponse<OutingActiveResponse> response = outingService.getActiveOutings(0, 20);
+
+      assertThat(response.content().get(0).studentProfileImageUrl()).isNull();
+    }
+
+    @Test
+    @DisplayName("프로필 이미지 키가 있으면 presigned URL을 생성한다")
+    void generatesProfileImageUrlWhenKeyPresent() {
+      Outing outing =
+          departedOuting(902L, LocalDateTime.of(2026, 8, 10, 12, 31), "profile/1/abc.jpg");
+      given(outingRepository.findByStatus(eq(OutingStatus.DEPARTED), any(Pageable.class)))
+          .willReturn(new PageImpl<>(List.of(outing), PageRequest.of(0, 20), 1));
+      given(r2FileService.generateDownloadUrl("profile/1/abc.jpg"))
+          .willReturn("https://r2.example.com/profile/1/abc.jpg?X-Amz-Signature=...");
+
+      PageResponse<OutingActiveResponse> response = outingService.getActiveOutings(0, 20);
+
+      assertThat(response.content().get(0).studentProfileImageUrl())
+          .isEqualTo("https://r2.example.com/profile/1/abc.jpg?X-Amz-Signature=...");
+    }
+
+    @Test
+    @DisplayName("리포지토리가 돌려준 Page 메타데이터를 그대로 응답에 담는다")
+    void reflectsRepositoryPageMetadata() {
+      List<Outing> pageContent = List.of(
+          departedOuting(903L, LocalDateTime.of(2026, 8, 10, 8, 0), null),
+          departedOuting(904L, LocalDateTime.of(2026, 8, 10, 8, 30), null));
+      given(outingRepository.findByStatus(eq(OutingStatus.DEPARTED), any(Pageable.class)))
+          .willReturn(new PageImpl<>(pageContent, PageRequest.of(0, 2), 3));
+
+      PageResponse<OutingActiveResponse> response = outingService.getActiveOutings(0, 2);
+
+      assertThat(response.content()).hasSize(2);
+      assertThat(response.totalElements()).isEqualTo(3);
+      assertThat(response.totalPages()).isEqualTo(2);
+      assertThat(response.hasNext()).isTrue();
+    }
+
+    @Test
+    @DisplayName("page가 음수면 거부한다")
+    void rejectsWhenPageNegative() {
+      assertThatThrownBy(() -> outingService.getActiveOutings(-1, 20))
+          .isInstanceOf(CustomException.class)
+          .extracting(e -> ((CustomException) e).getErrorCode())
+          .isEqualTo(OutingErrorCode.INVALID_PAGE_PARAMS);
+    }
+
+    @Test
+    @DisplayName("size가 100을 초과하면 거부한다")
+    void rejectsWhenSizeTooLarge() {
+      assertThatThrownBy(() -> outingService.getActiveOutings(0, 101))
+          .isInstanceOf(CustomException.class)
+          .extracting(e -> ((CustomException) e).getErrorCode())
+          .isEqualTo(OutingErrorCode.INVALID_PAGE_PARAMS);
     }
   }
 
@@ -1361,6 +1522,20 @@ class OutingServiceTest {
 
       OutingResponse response =
           outingService.getOutingDetail(adminUserId, OUTING_CODE, TODAY, NOW);
+
+      assertThat(response.code()).isEqualTo(OUTING_CODE);
+    }
+
+    @Test
+    @DisplayName("TEACHER 역할이면 담당 아니어도 조회할 수 있다(#96)")
+    void allowsAnyTeacherRole() {
+      Long otherTeacherUserId = 66L;
+      given(outingRepository.findByCode(OUTING_CODE)).willReturn(Optional.of(outing()));
+      given(userRoleRepository.findRoleCodesByUserId(otherTeacherUserId))
+          .willReturn(List.of("TEACHER"));
+
+      OutingResponse response =
+          outingService.getOutingDetail(otherTeacherUserId, OUTING_CODE, TODAY, NOW);
 
       assertThat(response.code()).isEqualTo(OUTING_CODE);
     }


### PR DESCRIPTION
## 관련 이슈
closes #96

## 작업 내용
지금 외출 중(`DEPARTED`)인 학생 목록을 선도부/선생님/관리자가 조회하는
`GET /api/v1/outings/active`를 추가한다. 구현 착수 전 코드 리뷰에서 페이지네이션 방식
문제가 드러나, 이번 이슈 범위를 넓혀 `PageResponse`를 DB 레벨 페이지네이션으로 전환하고
기존 `/me/requests`/`/me/received`(#41)도 같이 옮겼다.

> ⚠️ 아직 draft 상태 — QA/코드 리뷰/Postman 컬렉션 정리까지 전부 끝났고 CI도 통과했다.
> 보스 최종 확인 후 Ready for review로 전환한다.

## 변경 사항 상세
- `GET /api/v1/outings/active` 추가: `DISCIPLINE`/`TEACHER`/`ADMIN` 권한,
  `departedAt` 오름차순 + `id` 보조 정렬, 페이지네이션(`page`/`size`)
- `OutingActiveResponse` 신규 응답 DTO(좌표 미포함 — 위치는 #97에서 별도 제공)
- `PageResponse`에 `of(Page<T>)` 팩토리 추가(기존 `of(List, page, size)`는 SchoolCamp가
  계속 사용하므로 유지)
- `OutingRepository`: `findByStatus(status, Pageable)`, `findStudentRequestsPage`,
  `findTeacherReceivedPage` 신규 — 기존 `findByStudentIdAndOutingDateBetween...`/
  `findByTeacherIdAndOutingDateBetween...`(List 반환)를 대체
- `OutingService.getMyRequests`/`getReceivedOutings`(#41)를 DB 레벨 페이지네이션으로
  전환 — 응답 계약은 동일, 내부 구현만 변경
- `OutingService.validateDetailAccess`(`GET /{code}`) 확장 — 담당 여부와 무관하게
  `TEACHER` 역할이면 조회 가능(`/active`와 인가 범위 통일, 기획서 "리스크 및 고려사항"
  절 참고)
- N+1 쿼리 / `status` 컬럼 인덱스 부재는 이번 범위에서 보류하고 성능 백로그 이슈(#109)로
  분리

기획서: `docs/domain/outing/96-outing-active-list.md`
코드 리뷰 결과: `docs/domain/outing/96-outing-active-list-code-review.md`(Critical/High
0건, Medium 1건 해결됨)
QA 결과: `docs/domain/outing/96-outing-active-list-QA.md`(실서버 검증, 문제 없음)

## 확인 사항
- [x] 로컬 빌드 통과 (`./gradlew build`)
- [x] Checkstyle 통과 (`./gradlew checkstyleMain`)
- [x] CI(checkstyle, build-and-test) 통과
- [ ] (해당 시) Notion 기능정의서/기획 문서 반영 — `dev` 머지 후 진행(17단계)
- [x] (해당 시) 관련 도메인 라벨 지정 — `domain:OUTING`, `feature`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a paginated active-outing list showing students currently away, including outing details and expected return times.
  * Added role-based access for discipline staff, teachers, and administrators.
  * Expanded teachers’ access to outing detail information.
  * Improved pagination for existing outing lists.

* **Documentation**
  * Added planning, code-review, and QA documentation for the active-outing list.

* **Tests**
  * Added coverage for authorization, pagination, sorting, empty results, validation, and response details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
