### PR TITLE
chore(outing): #96 Postman 컬렉션 반영 누락분 후속 처리

### DIFF
--- a/docs/domain/outing/96-outing-active-list-code-review.md
+++ b/docs/domain/outing/96-outing-active-list-code-review.md
@@ -49,7 +49,7 @@
 
 ## 발견 사항
 
-### 1. 🟡 Medium — 기획서에 명시된 완료 조건("Postman 컬렉션 반영")이 diff에 반영되지 않음
+### 1. 🟡 Medium — 기획서에 명시된 완료 조건("Postman 컬렉션 반영")이 diff에 반영되지 않음 (해결됨, 커밋 `a8db99a`)
 
 **문제**: `docs/domain/outing/96-outing-active-list.md:206-209`의 "완료 조건(Definition of
 Done)"은 "로컬 빌드/테스트 통과", "CI 통과"와 나란히 "Postman 컬렉션 반영"을 명시한다.
@@ -76,5 +76,10 @@ Postman 워크스페이스에 API 호출로 직접 반영했다 하더라도 로
    코드 리뷰를 막을 필요는 없지만, PR을 올리기 전에 반드시 처리해야 한다(기획서 스스로
    정한 완료 조건이므로).
 
+**반영 결과(15단계, 커밋 `a8db99a`)**: 방안 1을 택해 최상위에 `GET /active` 요청, 에러
+케이스 4건(401/403/page 400/size 400), `#96 실시간 목록 조회 확인` 검증 폴더(신청→승인→
+출발→목록 확인→도착→재조회)를 직접 추가했다. newman으로 로컬 실서버 대상 end-to-end
+실행해 13개 assertion 전부 통과를 확인한 뒤 Postman 워크스페이스에 API로 push했다.
+
 ## 요약
-Critical/High 없음. Medium 1건(Postman 컬렉션 미반영), Low 없음.
+Critical/High 없음. Medium 1건(Postman 컬렉션 미반영 — 해결됨), Low 없음.

--- a/postman/collections/gone-outing.postman_collection.json
+++ b/postman/collections/gone-outing.postman_collection.json
@@ -924,6 +924,57 @@
       "response": []
     },
     {
+      "name": "외출증 실시간 목록 조회",
+      "request": {
+        "method": "GET",
+        "header": [
+          {
+            "key": "Authorization",
+            "value": "Bearer {{teacherAccessToken}}"
+          }
+        ],
+        "url": {
+          "raw": "{{baseUrl}}/api/v1/outings/active",
+          "host": [
+            "{{baseUrl}}"
+          ],
+          "path": [
+            "api",
+            "v1",
+            "outings",
+            "active"
+          ],
+          "query": [
+            {
+              "key": "page",
+              "value": "0",
+              "disabled": true
+            },
+            {
+              "key": "size",
+              "value": "20",
+              "disabled": true
+            }
+          ]
+        },
+        "description": "지금 외출 중(DEPARTED)인 학생 목록을 조회합니다(#96). DISCIPLINE/TEACHER/ADMIN 역할이 필요하며, 아래 예시는 선생님 토큰 기준입니다."
+      },
+      "response": [],
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "type": "text/javascript",
+            "exec": [
+              "pm.test(\"200 응답 확인\", function () {",
+              "    pm.response.to.have.status(200);",
+              "});"
+            ]
+          }
+        }
+      ]
+    },
+    {
       "name": "에러 케이스",
       "item": [
         {
@@ -2300,6 +2351,176 @@
             }
           ],
           "response": []
+        },
+        {
+          "name": "실시간 목록: 인증 없이 시도 → 401",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/outings/active",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "outings",
+                "active"
+              ],
+              "query": []
+            }
+          },
+          "response": [],
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test(\"401 Unauthorized\", function () {",
+                  "    pm.response.to.have.status(401);",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "실시간 목록: STUDENT로 조회 시도 → 403",
+          "request": {
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{studentAccessToken}}"
+              }
+            ],
+            "method": "GET",
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/outings/active",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "outings",
+                "active"
+              ],
+              "query": []
+            }
+          },
+          "response": [],
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test(\"403 Forbidden\", function () {",
+                  "    pm.response.to.have.status(403);",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "실시간 목록: page=-1 → 400",
+          "request": {
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{teacherAccessToken}}"
+              }
+            ],
+            "method": "GET",
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/outings/active?page=-1",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "outings",
+                "active"
+              ],
+              "query": [
+                {
+                  "key": "page",
+                  "value": "-1",
+                  "disabled": false
+                }
+              ]
+            }
+          },
+          "response": [],
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test(\"400 Bad Request\", function () {",
+                  "    pm.response.to.have.status(400);",
+                  "});",
+                  "",
+                  "pm.test(\"OUTING_015\", function () {",
+                  "    pm.expect(pm.response.json().code).to.eql(\"OUTING_015\");",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "실시간 목록: size=101 → 400",
+          "request": {
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{teacherAccessToken}}"
+              }
+            ],
+            "method": "GET",
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/outings/active?size=101",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "outings",
+                "active"
+              ],
+              "query": [
+                {
+                  "key": "size",
+                  "value": "101",
+                  "disabled": false
+                }
+              ]
+            }
+          },
+          "response": [],
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test(\"400 Bad Request\", function () {",
+                  "    pm.response.to.have.status(400);",
+                  "});",
+                  "",
+                  "pm.test(\"OUTING_015\", function () {",
+                  "    pm.expect(pm.response.json().code).to.eql(\"OUTING_015\");",
+                  "});"
+                ]
+              }
+            }
+          ]
         }
       ]
     },
@@ -3481,6 +3702,428 @@
                   "    pm.expect(target).to.not.be.undefined;",
                   "    pm.expect(target.departedAt).to.not.be.null;",
                   "    pm.expect(target.returnedAt).to.not.be.null;",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "response": []
+        }
+      ]
+    },
+    {
+      "name": "#96 실시간 목록 조회 확인",
+      "item": [
+        {
+          "name": "1. 학생 로그인",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"identifier\": \"{{studentLoginId}}\",\n  \"password\": \"{{studentPassword}}\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/auth/login",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "auth",
+                "login"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test(\"200 OK\", function () {",
+                  "    pm.response.to.have.status(200);",
+                  "});",
+                  "",
+                  "if (pm.response.code === 200) {",
+                  "    const body = pm.response.json();",
+                  "    if (body.success && body.data) {",
+                  "        pm.environment.set(\"studentAccessToken\", body.data.accessToken);",
+                  "        const payload = JSON.parse(atob(body.data.accessToken.split('.')[1].replace(/-/g,'+').replace(/_/g,'/')));",
+                  "        pm.environment.set(\"studentUserId\", payload.sub);",
+                  "    }",
+                  "}"
+                ]
+              }
+            }
+          ],
+          "response": []
+        },
+        {
+          "name": "2. 선생님 로그인",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"identifier\": \"{{teacherLoginId}}\",\n  \"password\": \"{{teacherPassword}}\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/auth/login",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "auth",
+                "login"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test(\"200 OK\", function () {",
+                  "    pm.response.to.have.status(200);",
+                  "});",
+                  "",
+                  "if (pm.response.code === 200) {",
+                  "    const body = pm.response.json();",
+                  "    if (body.success && body.data) {",
+                  "        pm.environment.set(\"teacherAccessToken\", body.data.accessToken);",
+                  "        const payload = JSON.parse(atob(body.data.accessToken.split('.')[1].replace(/-/g,'+').replace(/_/g,'/')));",
+                  "        pm.environment.set(\"teacherUserId\", payload.sub);",
+                  "    }",
+                  "}"
+                ]
+              }
+            }
+          ],
+          "response": []
+        },
+        {
+          "name": "3. 외출증 신청 (실시간 목록 확인 대상 생성)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{studentAccessToken}}"
+              },
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"reason\": \"#96 QA - 실시간 목록 확인\",\n  \"outingDate\": \"{{outingDate}}\",\n  \"timeSlot\": \"LUNCH\",\n  \"teacherUserId\": {{teacherUserId}}\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/outings",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "outings"
+              ]
+            },
+            "description": "응답의 `data.code`를 환경 변수 `qa96Code`에 저장합니다(이어지는 승인/출발/도착에 사용)."
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test(\"201 Created\", function () {",
+                  "    pm.response.to.have.status(201);",
+                  "});",
+                  "",
+                  "if (pm.response.code === 201) {",
+                  "    const body = pm.response.json();",
+                  "    if (body.success && body.data && body.data.code) {",
+                  "        pm.environment.set(\"qa96Code\", body.data.code);",
+                  "    }",
+                  "}"
+                ]
+              }
+            }
+          ],
+          "response": []
+        },
+        {
+          "name": "4. 외출증 승인",
+          "request": {
+            "method": "PATCH",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{teacherAccessToken}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/outings/{{qa96Code}}/approve",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "outings",
+                "{{qa96Code}}",
+                "approve"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test(\"200 OK\", function () {",
+                  "    pm.response.to.have.status(200);",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "response": []
+        },
+        {
+          "name": "5. 출발 보고 (학교 반경 안)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{studentAccessToken}}"
+              },
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"latitude\": {{outingLatitude}},\n  \"longitude\": {{outingLongitude}}\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/outings/{{qa96Code}}/depart",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "outings",
+                "{{qa96Code}}",
+                "depart"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test(\"200 OK\", function () {",
+                  "    pm.response.to.have.status(200);",
+                  "});",
+                  "",
+                  "pm.test(\"status는 DEPARTED\", function () {",
+                  "    pm.expect(pm.response.json().data.status).to.eql(\"DEPARTED\");",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "response": []
+        },
+        {
+          "name": "6. 실시간 목록 조회 (방금 출발한 건이 보이는지)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{teacherAccessToken}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/outings/active",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "outings",
+                "active"
+              ]
+            },
+            "description": "기획서 응답 필드(code/studentNickname/studentProfileImageUrl/studentRealName/studentGrade/studentClassNo/reason/timeSlot/departedAt/endTime)를 확인합니다."
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test(\"200 응답 확인\", function () {",
+                  "    pm.response.to.have.status(200);",
+                  "});",
+                  "",
+                  "pm.test(\"방금 출발한 qa96Code가 목록에 있다\", function () {",
+                  "    const body = pm.response.json();",
+                  "    const codes = body.data.content.map(o => o.code);",
+                  "    pm.expect(codes).to.include(pm.environment.get(\"qa96Code\"));",
+                  "});",
+                  "",
+                  "pm.test(\"응답에 좌표가 포함되지 않는다\", function () {",
+                  "    const body = pm.response.json();",
+                  "    const found = body.data.content.find(o => o.code === pm.environment.get(\"qa96Code\"));",
+                  "    pm.expect(found).to.not.have.property(\"latitude\");",
+                  "    pm.expect(found).to.not.have.property(\"longitude\");",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "response": []
+        },
+        {
+          "name": "7. 도착 보고 (학교 반경 안)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{studentAccessToken}}"
+              },
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"latitude\": {{outingLatitude}},\n  \"longitude\": {{outingLongitude}}\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/outings/{{qa96Code}}/return",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "outings",
+                "{{qa96Code}}",
+                "return"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test(\"200 OK\", function () {",
+                  "    pm.response.to.have.status(200);",
+                  "});",
+                  "",
+                  "pm.test(\"status는 RETURNED\", function () {",
+                  "    pm.expect(pm.response.json().data.status).to.eql(\"RETURNED\");",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "response": []
+        },
+        {
+          "name": "8. 실시간 목록 재조회 (도착 완료한 건은 더 이상 안 보임)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{teacherAccessToken}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/outings/active",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "outings",
+                "active"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test(\"200 응답 확인\", function () {",
+                  "    pm.response.to.have.status(200);",
+                  "});",
+                  "",
+                  "pm.test(\"도착 완료한 qa96Code는 목록에서 빠진다\", function () {",
+                  "    const body = pm.response.json();",
+                  "    const codes = body.data.content.map(o => o.code);",
+                  "    pm.expect(codes).to.not.include(pm.environment.get(\"qa96Code\"));",
                   "});"
                 ]
               }

--- a/postman/environments/gone-local-dev.postman_environment.json
+++ b/postman/environments/gone-local-dev.postman_environment.json
@@ -182,6 +182,12 @@
       "enabled": true
     },
     {
+      "key": "qa96Code",
+      "value": "",
+      "type": "default",
+      "enabled": true
+    },
+    {
       "key": "campDate1",
       "value": "20260504",
       "type": "default",


### PR DESCRIPTION
## 관련 이슈
관련: #96

## 작업 내용
PR #110(#96 외출증 실시간 목록 조회 API)이 15단계(Postman 컬렉션 정리) 완료 전에
머지되어, 그 이후 커밋 2개가 `dev`에 반영되지 않았다. 이 PR로 마저 반영한다.

## 변경 사항 상세
- `postman/collections/gone-outing.postman_collection.json`,
  `postman/environments/gone-local-dev.postman_environment.json`: `GET /active`
  최상위 요청, 에러 케이스 4건(401/403/page 400/size 400), `#96 실시간 목록 조회 확인`
  검증 폴더 추가(newman으로 실서버 대상 end-to-end 검증, 13개 assertion 통과 후 반영)
- `docs/domain/outing/96-outing-active-list-code-review.md`: Medium 지적사항(Postman
  미반영) 해결 표시

코드 변경 없음(문서/Postman 컬렉션만).

## 확인 사항
- [x] 로컬 빌드 통과 (`./gradlew build`)
- [x] Checkstyle 통과 (`./gradlew checkstyleMain`)
- [ ] CI(checkstyle, build-and-test) 통과
- [x] (해당 시) 관련 도메인 라벨 지정 — `domain:OUTING`, `chore`
