### PR TITLE
feat(conduct): 학생 본인 상/벌점 조회 구현 (#111)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,6 +172,9 @@ jobs:
       OUTING_SCHOOL_LATITUDE: '0.0'
       OUTING_SCHOOL_LONGITUDE: '0.0'
       OUTING_SCHOOL_RADIUS_METERS: '200'
+      # ConductProperties(@NotNull @Positive) 검증을 통과시키기 위한 더미 값.
+      # contextLoads()는 실제 임계치 판정을 수행하지 않는다(#111).
+      CONDUCT_DEMERIT_THRESHOLD: '10'
 
     steps:
       - name: Code Checkout(코드 체크아웃)

--- a/docs/domain/conduct/111-conduct-student-query-QA.md
+++ b/docs/domain/conduct/111-conduct-student-query-QA.md
@@ -1,0 +1,42 @@
+# 상/벌점 학생 본인 조회 QA 결과 (이슈 #111)
+
+> 환경: `application-dev.yml` (MySQL localhost:3307, Redis localhost:6379, server:9090)
+> 로컬 빌드: `./gradlew build` — BUILD SUCCESSFUL
+> 단위 테스트: 전체 통과
+> CI: PR 생성 시 트리거 예정 (브랜치 push 완료, PR 미생성 상태)
+
+---
+
+## QA 시나리오 결과
+
+| # | 시나리오 | 기대 결과 | 실제 결과 | 판정 |
+|---|---|---|---|---|
+| 1 | `GET /me/summary` — STUDENT 토큰 | `200` totalMeritPoints=0, totalDemeritPoints=-5, netScore=-5 | `200` 동일 | ✅ |
+| 2 | `GET /me` — 파라미터 없음 | `200` ACTIVE + CANCELED 기록 모두 포함 | `200` 2건 (ACTIVE·CANCELED 각 1건) | ✅ |
+| 3 | `GET /me?type=MERIT` | `200` 빈 목록 (상점 기록 없음) | `200` content: [] | ✅ |
+| 4 | `GET /me?type=DEMERIT` | `200` 벌점 2건 | `200` 2건 반환 | ✅ |
+| 5 | `GET /me?dateFrom=20260824&dateTo=20260824` | `200` 해당 일 기록 2건 | `200` 2건 반환 | ✅ |
+| 6 | `GET /me?page=-1` | `400` CONDUCT_007 | `400` CONDUCT_007 | ✅ |
+| 7 | `GET /me?size=0` | `400` CONDUCT_007 | `400` CONDUCT_007 | ✅ |
+| 8 | `GET /me?size=101` | `400` CONDUCT_007 | `400` CONDUCT_007 | ✅ |
+| 9 | `GET /me?dateFrom=20260824` (dateTo 누락) | `400` CONDUCT_008 | `400` CONDUCT_008 | ✅ |
+| 10 | `GET /me?dateFrom=20260831&dateTo=20260801` (역순) | `400` CONDUCT_008 | `400` CONDUCT_008 | ✅ |
+| 11 | `GET /me/summary` — 인증 없음 | `401` COMMON_002 | `401` COMMON_002 | ✅ |
+| 12 | `GET /me/summary` — TEACHER 토큰 | `403` COMMON_003 | `403` COMMON_003 | ✅ |
+| 13 | `GET /me?page=0&size=1` — 페이지네이션 | `200` 1건, hasNext=true, totalElements=2 | `200` 동일 | ✅ |
+
+---
+
+## 발견 문제
+
+없음. Critical/High/Medium/Low 전 항목 통과.
+
+코드 리뷰(9단계)에서 발견된 N+1 쿼리 수정(`LEFT JOIN FETCH r.teacher LEFT JOIN FETCH r.category`) 후 서버 기동 정상 확인.
+
+---
+
+## 비고
+
+- `overDemeritThreshold`: 현재 테스트 학생 벌점 절댓값 5 < 임계치 10 → `false` 정상 반환
+- 취소된 기록(status: CANCELED)이 이력 조회에 포함됨 — 기획서 명시 동작 확인
+- `dateTo`만 제공한 경우(dateFrom 누락)도 CONDUCT_008 반환 확인 — ✅ 통과

--- a/docs/domain/conduct/111-conduct-student-query-code-review.md
+++ b/docs/domain/conduct/111-conduct-student-query-code-review.md
@@ -1,0 +1,38 @@
+# 상/벌점 학생 본인 조회 코드 리뷰 (이슈 #111)
+
+> 격리 에이전트 리뷰 결과 (diff: `dev...feat/#111-conduct-student-query`, 기획서: `111-conduct-student-query.md`)
+
+## 리뷰 결과
+
+### 1. N+1 쿼리 — `getStudentRecords` 페이지 조회 시 teacher·category 지연 로딩
+**심각도**: 🔴 Critical
+
+**문제**: `ConductRecordRepository.findByStudentWithFilters`가 반환하는 `Page<ConductRecord>`에서 `teacher`·`category` 관계가 `FetchType.LAZY`로 선언되어 있다. `ConductStudentRecordResponse.from(record)` 변환 시 `record.getTeacher().getId()`·`record.getCategory().getId()`를 호출하면, 항목당 teacher 1건·category 1건 추가 쿼리가 발생한다. `size=100` 요청 시 1(목록) + 100(teacher) + 100(category) = 최대 201개 쿼리가 발생하며, 기획서의 "DB 레벨 페이지네이션" 의도와 역배된다.
+
+**해결 방안 A**: JPQL에 `LEFT JOIN FETCH` 추가 ← **채택**
+- 장점: 단일 쿼리로 해결. `ManyToOne`이므로 행 수 팽창 없어 `Pageable`과 충돌 없음.
+- 단점: 쿼리 문자열이 길어진다.
+
+**해결 방안 B**: `@EntityGraph(attributePaths = {"teacher", "category"})` 추가
+- 장점: 선언적 방식으로 간결.
+- 단점: `@Query`와 함께 쓰는 경우 Spring Data 버전에 따라 동작 차이 있음. 커스텀 JPQL과 함께 사용 시 검증이 더 필요하다.
+
+→ **A 채택 후 수정 완료**. 쿼리에 `LEFT JOIN FETCH r.teacher LEFT JOIN FETCH r.category` 추가.
+
+---
+
+### 2. LazyInitializationException 위험 — 트랜잭션 내 DTO 변환
+**심각도**: ℹ️ INFO
+
+**에이전트 지적**: Controller에서 변환 시도 시 트랜잭션 외에서 Lazy 로딩 예외가 발생할 수 있다.
+
+**검토 결과**: 오탐. `getStudentRecords`가 `@Transactional(readOnly = true)` 범위 내에서 완전히 변환된 `PageResponse<ConductStudentRecordResponse>`를 반환한다. Controller는 변환 로직 없이 결과를 그대로 `ApiResponse.success`에 넘긴다. 수정 불필요.
+
+---
+
+### 3. 날짜 형식 오류 응답
+**심각도**: ℹ️ INFO
+
+**에이전트 지적**: `dateFrom`에 `2026-08-01`처럼 형식 오류 값이 오면 `CONDUCT_008`이 아니라 공통 `DateTimeParseException` 400으로 처리된다.
+
+**검토 결과**: 기획서에서 형식 오류와 범위 오류를 구분하지 않으며, 두 경우 모두 `400`을 반환한다는 점에서 동작은 올바르다. 메시지 차이가 필요하면 별도 이슈에서 `@InitBinder` 커스텀 처리를 검토한다. 이번 범위 밖. 수정 불필요.

--- a/docs/domain/conduct/111-conduct-student-query-code-review.md
+++ b/docs/domain/conduct/111-conduct-student-query-code-review.md
@@ -4,8 +4,7 @@
 
 ## 리뷰 결과
 
-### 1. N+1 쿼리 — `getStudentRecords` 페이지 조회 시 teacher·category 지연 로딩
-**심각도**: 🔴 Critical
+### 1. 🔴 Critical — `getStudentRecords` 페이지 조회 시 teacher·category N+1 쿼리
 
 **문제**: `ConductRecordRepository.findByStudentWithFilters`가 반환하는 `Page<ConductRecord>`에서 `teacher`·`category` 관계가 `FetchType.LAZY`로 선언되어 있다. `ConductStudentRecordResponse.from(record)` 변환 시 `record.getTeacher().getId()`·`record.getCategory().getId()`를 호출하면, 항목당 teacher 1건·category 1건 추가 쿼리가 발생한다. `size=100` 요청 시 1(목록) + 100(teacher) + 100(category) = 최대 201개 쿼리가 발생하며, 기획서의 "DB 레벨 페이지네이션" 의도와 역배된다.
 
@@ -21,8 +20,7 @@
 
 ---
 
-### 2. LazyInitializationException 위험 — 트랜잭션 내 DTO 변환
-**심각도**: ℹ️ INFO
+### 2. ℹ️ INFO — LazyInitializationException 위험 — 트랜잭션 내 DTO 변환
 
 **에이전트 지적**: Controller에서 변환 시도 시 트랜잭션 외에서 Lazy 로딩 예외가 발생할 수 있다.
 
@@ -30,8 +28,7 @@
 
 ---
 
-### 3. 날짜 형식 오류 응답
-**심각도**: ℹ️ INFO
+### 3. ℹ️ INFO — 날짜 형식 오류 응답
 
 **에이전트 지적**: `dateFrom`에 `2026-08-01`처럼 형식 오류 값이 오면 `CONDUCT_008`이 아니라 공통 `DateTimeParseException` 400으로 처리된다.
 

--- a/docs/domain/conduct/111-conduct-student-query.md
+++ b/docs/domain/conduct/111-conduct-student-query.md
@@ -1,0 +1,248 @@
+# 상/벌점 학생 본인 조회 — 기능 기획서 (이슈 #111)
+
+## 개요/목적
+상/벌점(Conduct) 도메인 네 번째 단계. 학생이 본인의 누적 상/벌점 요약과 이력을 조회하는 API를 만든다.
+
+- **요약 조회** (`GET /api/v1/conduct-records/me/summary`): 전체 기간 기준 총 상점·벌점·순 점수, 벌점 임계치 초과 여부
+- **이력 조회** (`GET /api/v1/conduct-records/me`): `type`·기간 필터 + 페이지네이션을 지원하는 이력 목록
+
+두 엔드포인트 모두 `STUDENT` 전용이며, 본인 데이터만 노출한다. `userId`는 Access Token에서 추출하므로 요청 파라미터로 받지 않는다.
+
+- **관련 마스터 기획서**: [`docs/domain/conduct/1_conduct-domain.md`](./1_conduct-domain.md) — "5. `GET /me/summary`" / "6. `GET /me`" 절
+- **선행 이슈**: #107 (`amendConduct`, `cancelConduct` 구현)
+
+---
+
+## 에러 코드 추가 (`ConductErrorCode`)
+
+현재 마지막 코드는 `CONDUCT_006`. 아래 2개를 추가한다.
+
+| 코드 | HTTP | 메시지 |
+|---|---|---|
+| `CONDUCT_007` | 400 | 페이지 파라미터가 유효하지 않습니다. |
+| `CONDUCT_008` | 400 | 날짜 범위 파라미터가 유효하지 않습니다. |
+
+---
+
+## 신규 컴포넌트
+
+### `ConductProperties` (`@ConfigurationProperties(prefix = "conduct")`)
+
+`OutingProperties`와 동일한 패턴. 누적 벌점 임계치를 설정으로 관리한다.
+
+```java
+@ConfigurationProperties(prefix = "conduct")
+@Validated
+public record ConductProperties(
+    @NotNull @Positive Integer demeritThreshold
+) {}
+```
+
+`application-dev.yml`에 `conduct.demerit-threshold: 10` 추가. `GoneServerV1Application`에 `@ConfigurationPropertiesScan`이 이미 선언되어 있으므로 별도 등록 코드 없이 자동으로 빈 등록된다.
+
+### `ConductSummaryResponse` DTO
+
+```java
+public record ConductSummaryResponse(
+    int totalMeritPoints,
+    int totalDemeritPoints,
+    int netScore,
+    int demeritThreshold,
+    boolean overDemeritThreshold
+) {}
+```
+
+### `ConductStudentRecordResponse` DTO
+
+학생 본인 조회 전용 응답. `ConductRecordResponse`(부여·정정·취소용)에서 `studentUserId`·`studentNickname`을 제외한 축약형이다 — 학생 본인 이력에서 자기 userId를 항목마다 반복 노출할 필요가 없다.
+
+```java
+public record ConductStudentRecordResponse(
+    Long id,
+    Long teacherUserId,
+    String teacherNickname,
+    Long categoryId,
+    String categoryLabel,
+    ConductType type,
+    int points,
+    String detail,
+    ConductStatus status,
+    LocalDateTime createdAt
+) {
+  public static ConductStudentRecordResponse from(ConductRecord record) { ... }
+}
+```
+
+---
+
+## 엔드포인트 1: `GET /api/v1/conduct-records/me/summary` — 요약
+
+**권한**: `STUDENT` (`@PreAuthorize("hasRole('STUDENT')")`)
+
+**요청**: 쿼리 파라미터 없음. 항상 전체 기간 기준이다.
+
+**응답** (`200 OK`)
+```json
+{
+  "success": true,
+  "data": {
+    "totalMeritPoints": 6,
+    "totalDemeritPoints": -4,
+    "netScore": 2,
+    "demeritThreshold": 10,
+    "overDemeritThreshold": false
+  },
+  "message": "누적 점수를 조회했습니다."
+}
+```
+
+**구현 로직**
+1. `conductRecordRepository.sumPointsByStudentAndType(studentUserId, MERIT, ACTIVE)`로 `totalMeritPoints` 집계(결과 없으면 `0`)
+2. `conductRecordRepository.sumPointsByStudentAndType(studentUserId, DEMERIT, ACTIVE)`로 `totalDemeritPoints` 집계(결과 없으면 `0`)
+3. `netScore = totalMeritPoints + totalDemeritPoints`(`totalDemeritPoints`는 음수로 저장되므로 그대로 더한다)
+4. `overDemeritThreshold = Math.abs(totalDemeritPoints) >= conductProperties.demeritThreshold()`
+
+**에러**: 없음. 인증·역할 오류는 공통 인프라가 처리한다.
+
+---
+
+## 엔드포인트 2: `GET /api/v1/conduct-records/me` — 이력
+
+**권한**: 1번과 동일 (`STUDENT`, 본인 것만)
+
+**요청** (쿼리, 전부 선택)
+
+| 파라미터 | 타입 | 기본값 | 설명 |
+|---|---|---|---|
+| `type` | `MERIT` / `DEMERIT` | 생략 시 둘 다 | 상점 또는 벌점만 필터 |
+| `dateFrom` | `yyyyMMdd` | 없으면 전체 기간 | 조회 시작일(포함). `dateTo`와 반드시 함께 써야 한다 |
+| `dateTo` | `yyyyMMdd` | 없으면 전체 기간 | 조회 종료일(포함). `dateFrom`과 반드시 함께 써야 한다 |
+| `page` | 정수 | `0` | 페이지 번호(0부터 시작) |
+| `size` | 정수 | `20` | 페이지 크기(1~100) |
+
+**날짜 파라미터 규칙 (엄격 모드)**
+- `dateFrom`·`dateTo` 모두 생략 → 전체 기간 조회
+- `dateFrom`·`dateTo` 모두 제공 → 해당 기간으로 필터
+- 하나만 제공 → `400` `CONDUCT_008`
+- `dateFrom > dateTo` → `400` `CONDUCT_008`
+
+**페이지 파라미터 규칙**
+- `page < 0` 또는 `size < 1` 또는 `size > 100` → `400` `CONDUCT_007`
+
+**응답** (`200 OK`)
+```json
+{
+  "success": true,
+  "data": {
+    "content": [
+      {
+        "id": 501,
+        "teacherUserId": 42,
+        "teacherNickname": "김선생",
+        "categoryId": 5,
+        "categoryLabel": "지각",
+        "type": "DEMERIT",
+        "points": -1,
+        "detail": "3교시 10분 지각",
+        "status": "ACTIVE",
+        "createdAt": "2026-08-12T09:15:00"
+      }
+    ],
+    "page": 0,
+    "size": 20,
+    "totalElements": 1,
+    "totalPages": 1,
+    "hasNext": false
+  },
+  "message": "상/벌점 이력을 조회했습니다."
+}
+```
+
+**구현 로직**
+1. `page`/`size` 검증 — 범위 밖이면 `400` `CONDUCT_007`
+2. `dateFrom`/`dateTo` 검증 — 하나만 오거나 `dateFrom > dateTo`이면 `400` `CONDUCT_008`
+3. `ConductRecordRepository`에 커스텀 JPQL 쿼리 추가:
+   - `studentUserId`, `type`(nullable), `dateFrom`(nullable), `dateTo`(nullable), `Pageable` 파라미터
+   - `WHERE student.id = :studentUserId AND (:type IS NULL OR r.type = :type) AND (:dateFrom IS NULL OR DATE(r.createdAt) >= :dateFrom) AND (:dateTo IS NULL OR DATE(r.createdAt) <= :dateTo)`
+4. `Page<ConductRecord>`를 `PageResponse<ConductStudentRecordResponse>`로 변환해 반환
+5. 취소된 기록(`CANCELED`)도 포함한다 — 학생이 과거 이력을 볼 때 취소된 기록도 보여야 한다(`status` 필드로 구분)
+
+**에러**
+
+| 조건 | HTTP | 코드 |
+|---|---|---|
+| `page < 0` / `size` 범위 밖 | 400 | `CONDUCT_007` |
+| `dateFrom`·`dateTo` 중 하나만 | 400 | `CONDUCT_008` |
+| `dateFrom > dateTo` | 400 | `CONDUCT_008` |
+
+---
+
+## 데이터 모델 변경
+
+### `ConductRecordRepository` 추가 메서드
+
+```java
+// 요약용 집계 쿼리
+@Query("SELECT COALESCE(SUM(r.points), 0) FROM ConductRecord r "
+    + "WHERE r.student.id = :studentUserId AND r.type = :type AND r.status = :status")
+int sumPointsByStudentAndType(
+    @Param("studentUserId") Long studentUserId,
+    @Param("type") ConductType type,
+    @Param("status") ConductStatus status);
+
+// 이력 페이지 조회 쿼리
+@Query("SELECT r FROM ConductRecord r "
+    + "WHERE r.student.id = :studentUserId "
+    + "AND (:type IS NULL OR r.type = :type) "
+    + "AND (:dateFrom IS NULL OR CAST(r.createdAt AS LocalDate) >= :dateFrom) "
+    + "AND (:dateTo IS NULL OR CAST(r.createdAt AS LocalDate) <= :dateTo) "
+    + "ORDER BY r.createdAt DESC")
+Page<ConductRecord> findByStudentWithFilters(
+    @Param("studentUserId") Long studentUserId,
+    @Param("type") ConductType type,
+    @Param("dateFrom") LocalDate dateFrom,
+    @Param("dateTo") LocalDate dateTo,
+    Pageable pageable);
+```
+
+### `application-dev.yml` 추가
+
+```yaml
+conduct:
+  demerit-threshold: 10
+```
+
+### Flyway 마이그레이션
+
+없음. 기존 `conduct_record` 테이블 변경 없음.
+
+---
+
+## 영향 받는 기존 코드
+
+- `ConductErrorCode`: `CONDUCT_007`, `CONDUCT_008` 추가
+- `ConductRecordRepository`: 집계·페이지 조회 쿼리 메서드 추가
+- `ConductService`: `getStudentSummary`, `getStudentRecords` 메서드 추가
+- `ConductController`: `GET /me/summary`, `GET /me` 엔드포인트 추가
+- 신규 DTO: `ConductSummaryResponse`, `ConductStudentRecordResponse`
+- 신규 config: `ConductProperties`
+
+---
+
+## API 설계 6원칙 체크
+
+1. **한 가지를 잘하기**: 요약(집계)과 이력(목록)을 분리한 엔드포인트로 구현. 집계에 날짜 필터를 넣으면 "이 기간의 순 점수"와 "전체 누적 순 점수"가 혼재되어 의미가 흐려지므로 분리가 적합하다.
+2. **빠른 시작**: 요청·응답 예시 포함.
+3. **일관성**: 경로 `/api/v1/conduct-records/me/*`, `ApiResponse<T>` 래퍼, `CONDUCT_NNN` 에러 코드 네이밍, `PageResponse<T>` 페이지 포맷 — outing 도메인(#41) 및 기존 conduct 엔드포인트 패턴 그대로.
+4. **의미 있는 오류**: 페이지 범위 위반(`CONDUCT_007`)과 날짜 범위 모순(`CONDUCT_008`)을 분리. `dateFrom > dateTo`와 "하나만 옴"을 같은 코드로 묶었으나 메시지로 구분한다.
+5. **확장성·성능**: `ConductRecordRepository.findByStudentWithFilters`는 DB 레벨 페이지네이션(`Pageable`). 학생 한 명의 기록은 학기 단위로 수십~수백 건 예상 — 인덱스(`student_user_id`, `created_at`) 존재 여부를 구현 중 확인한다.
+6. **하위 호환성**: 기존 `ConductRecordResponse` 변경 없음. 신규 DTO만 추가.
+
+---
+
+## 리스크 및 고려사항
+
+- **`ConductStudentRecordResponse` vs `ConductRecordResponse` 재사용**: 학생 본인 이력에 `studentUserId`/`studentNickname`을 포함하면 기존 DTO를 그대로 쓸 수 있지만, 마스터 기획서 응답 스펙(해당 필드 없음)과 어긋난다. 신규 DTO를 만들면 유지 비용이 생기지만 스펙에 정확히 맞다 — **신규 DTO 채택.**
+- **날짜 필터 기준**: `createdAt`(부여 일시)의 날짜 부분을 KST 기준으로 비교해야 한다. JPQL의 `CAST(r.createdAt AS LocalDate)`가 MySQL 시간대를 따르므로, DB 서버 시간대가 KST(`Asia/Seoul`)로 설정되어 있는지 확인해야 한다(dev 환경 JDBC URL에 `serverTimezone=Asia/Seoul` 있음 — 호환).
+- **`COALESCE(SUM(...), 0)`**: 기록이 없으면 `SUM`이 `null`을 반환한다. `COALESCE`로 `0`으로 처리한다.
+- **인덱스**: V16 마이그레이션에 `idx_conduct_record_student_created (student_user_id, created_at)` 복합 인덱스가 이미 존재한다. 신규 마이그레이션 불필요.

--- a/postman/collections/gone-conduct.postman_collection.json
+++ b/postman/collections/gone-conduct.postman_collection.json
@@ -333,6 +333,77 @@
       "response": []
     },
     {
+      "name": "학생 본인 누적 점수 요약 조회",
+      "request": {
+        "method": "GET",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          },
+          {
+            "key": "Authorization",
+            "value": "Bearer {{studentAccessToken}}"
+          }
+        ],
+        "url": {
+          "raw": "{{baseUrl}}/api/v1/conduct-records/me/summary",
+          "host": [
+            "{{baseUrl}}"
+          ],
+          "path": [
+            "api",
+            "v1",
+            "conduct-records",
+            "me",
+            "summary"
+          ]
+        }
+      }
+    },
+    {
+      "name": "학생 본인 이력 조회",
+      "request": {
+        "method": "GET",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          },
+          {
+            "key": "Authorization",
+            "value": "Bearer {{studentAccessToken}}"
+          }
+        ],
+        "url": {
+          "raw": "{{baseUrl}}/api/v1/conduct-records/me?type=DEMERIT&page=0&size=20",
+          "host": [
+            "{{baseUrl}}"
+          ],
+          "path": [
+            "api",
+            "v1",
+            "conduct-records",
+            "me"
+          ],
+          "query": [
+            {
+              "key": "type",
+              "value": "DEMERIT"
+            },
+            {
+              "key": "page",
+              "value": "0"
+            },
+            {
+              "key": "size",
+              "value": "20"
+            }
+          ]
+        }
+      }
+    },
+    {
       "name": "에러 케이스",
       "item": [
         {
@@ -794,6 +865,175 @@
             }
           },
           "response": []
+        },
+        {
+          "name": "page=-1 → 400 CONDUCT_007",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{studentAccessToken}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/conduct-records/me?page=-1",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "conduct-records",
+                "me"
+              ],
+              "query": [
+                {
+                  "key": "page",
+                  "value": "-1"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "size=101 → 400 CONDUCT_007",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{studentAccessToken}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/conduct-records/me?size=101",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "conduct-records",
+                "me"
+              ],
+              "query": [
+                {
+                  "key": "size",
+                  "value": "101"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "dateFrom만 제공 → 400 CONDUCT_008",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{studentAccessToken}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/conduct-records/me?dateFrom=20260824",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "conduct-records",
+                "me"
+              ],
+              "query": [
+                {
+                  "key": "dateFrom",
+                  "value": "20260824"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "dateFrom > dateTo → 400 CONDUCT_008",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{studentAccessToken}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/conduct-records/me?dateFrom=20260831&dateTo=20260801",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "conduct-records",
+                "me"
+              ],
+              "query": [
+                {
+                  "key": "dateFrom",
+                  "value": "20260831"
+                },
+                {
+                  "key": "dateTo",
+                  "value": "20260801"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "교사 토큰으로 /me/summary → 403 COMMON_003",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{teacherAccessToken}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/conduct-records/me/summary",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "conduct-records",
+                "me",
+                "summary"
+              ]
+            }
+          }
         }
       ]
     },
@@ -1183,6 +1423,194 @@
             }
           },
           "response": []
+        }
+      ]
+    },
+    {
+      "name": "학생 본인 조회 확인 (#111)",
+      "item": [
+        {
+          "name": "1. 학생 로그인",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\"identifier\": \"qatest_student\", \"password\": \"{{studentPassword}}\"}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/auth/login",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "auth",
+                "login"
+              ]
+            }
+          }
+        },
+        {
+          "name": "2. 누적 점수 요약 조회",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{studentAccessToken}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/conduct-records/me/summary",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "conduct-records",
+                "me",
+                "summary"
+              ]
+            }
+          }
+        },
+        {
+          "name": "3. 이력 전체 조회 (필터 없음)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{studentAccessToken}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/conduct-records/me?page=0&size=20",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "conduct-records",
+                "me"
+              ],
+              "query": [
+                {
+                  "key": "page",
+                  "value": "0"
+                },
+                {
+                  "key": "size",
+                  "value": "20"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "4. 벌점만 필터 조회",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{studentAccessToken}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/conduct-records/me?type=DEMERIT&page=0&size=20",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "conduct-records",
+                "me"
+              ],
+              "query": [
+                {
+                  "key": "type",
+                  "value": "DEMERIT"
+                },
+                {
+                  "key": "page",
+                  "value": "0"
+                },
+                {
+                  "key": "size",
+                  "value": "20"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "5. 날짜 범위 필터 조회",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{studentAccessToken}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/conduct-records/me?dateFrom=20260824&dateTo=20260824&page=0&size=20",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "conduct-records",
+                "me"
+              ],
+              "query": [
+                {
+                  "key": "dateFrom",
+                  "value": "20260824"
+                },
+                {
+                  "key": "dateTo",
+                  "value": "20260824"
+                },
+                {
+                  "key": "page",
+                  "value": "0"
+                },
+                {
+                  "key": "size",
+                  "value": "20"
+                }
+              ]
+            }
+          }
         }
       ]
     }

--- a/src/main/java/com/remake/gone/conduct/config/ConductProperties.java
+++ b/src/main/java/com/remake/gone/conduct/config/ConductProperties.java
@@ -1,0 +1,17 @@
+package com.remake.gone.conduct.config;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+/**
+ * 상/벌점 도메인 설정 값.
+ *
+ * @param demeritThreshold 누적 벌점 임계치. 절댓값 기준으로 이 값 이상이면 임계치 초과로 판정한다
+ */
+@ConfigurationProperties(prefix = "conduct")
+@Validated
+public record ConductProperties(
+    @NotNull @Positive Integer demeritThreshold
+) {}

--- a/src/main/java/com/remake/gone/conduct/controller/ConductController.java
+++ b/src/main/java/com/remake/gone/conduct/controller/ConductController.java
@@ -1,16 +1,22 @@
 package com.remake.gone.conduct.controller;
 
 import com.remake.gone.common.response.ApiResponse;
+import com.remake.gone.common.response.PageResponse;
 import com.remake.gone.common.security.UserPrincipal;
 import com.remake.gone.conduct.dto.ConductAmendRequest;
 import com.remake.gone.conduct.dto.ConductCancelRequest;
 import com.remake.gone.conduct.dto.ConductCategoryResponse;
 import com.remake.gone.conduct.dto.ConductGrantRequest;
 import com.remake.gone.conduct.dto.ConductRecordResponse;
+import com.remake.gone.conduct.dto.ConductStudentRecordResponse;
+import com.remake.gone.conduct.dto.ConductSummaryResponse;
+import com.remake.gone.conduct.enums.ConductType;
 import com.remake.gone.conduct.service.ConductService;
 import jakarta.validation.Valid;
+import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -20,13 +26,15 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 /**
  * 상/벌점(Conduct) 도메인 API 컨트롤러.
  *
- * <p>#92에서 카테고리 목록 조회, #94에서 상/벌점 부여, #107에서 정정·취소 엔드포인트를 구현했다.
+ * <p>#92에서 카테고리 목록 조회, #94에서 상/벌점 부여, #107에서 정정·취소,
+ * #111에서 학생 본인 조회 엔드포인트를 구현했다.
  */
 @RestController
 @RequestMapping("/api/v1/conduct-records")
@@ -104,5 +112,50 @@ public class ConductController {
     return ApiResponse.success(
         conductService.cancelConduct(principal.userId(), id, request),
         "상/벌점 기록이 취소되었습니다.");
+  }
+
+  /**
+   * 학생 본인의 누적 상/벌점 요약을 조회합니다.
+   *
+   * <p>전체 기간 기준 총 상점·벌점·순 점수와 벌점 임계치 초과 여부를 반환합니다.
+   *
+   * @param principal 인증된 학생 정보
+   * @return 누적 점수 요약
+   */
+  @GetMapping("/me/summary")
+  @PreAuthorize("hasRole('STUDENT')")
+  public ApiResponse<ConductSummaryResponse> getStudentSummary(
+      @AuthenticationPrincipal UserPrincipal principal) {
+    return ApiResponse.success(
+        conductService.getStudentSummary(principal.userId()),
+        "누적 점수를 조회했습니다.");
+  }
+
+  /**
+   * 학생 본인의 상/벌점 이력을 조회합니다.
+   *
+   * <p>취소된 기록도 포함하며, {@code type}·기간 필터와 페이지네이션을 지원합니다.
+   *
+   * @param principal 인증된 학생 정보
+   * @param type      종류 필터({@code MERIT}/{@code DEMERIT}, 생략 시 전체)
+   * @param dateFrom  조회 시작일({@code yyyyMMdd}, {@code dateTo}와 함께 써야 함)
+   * @param dateTo    조회 종료일({@code yyyyMMdd}, {@code dateFrom}과 함께 써야 함)
+   * @param page      페이지 번호(기본값 {@code 0})
+   * @param size      페이지 크기(기본값 {@code 20}, 1~100)
+   * @return 페이지네이션된 이력 목록
+   */
+  @GetMapping("/me")
+  @PreAuthorize("hasRole('STUDENT')")
+  public ApiResponse<PageResponse<ConductStudentRecordResponse>> getStudentRecords(
+      @AuthenticationPrincipal UserPrincipal principal,
+      @RequestParam(required = false) ConductType type,
+      @RequestParam(required = false) @DateTimeFormat(pattern = "yyyyMMdd") LocalDate dateFrom,
+      @RequestParam(required = false) @DateTimeFormat(pattern = "yyyyMMdd") LocalDate dateTo,
+      @RequestParam(defaultValue = "0") int page,
+      @RequestParam(defaultValue = "20") int size) {
+    return ApiResponse.success(
+        conductService.getStudentRecords(
+            principal.userId(), type, dateFrom, dateTo, page, size),
+        "상/벌점 이력을 조회했습니다.");
   }
 }

--- a/src/main/java/com/remake/gone/conduct/dto/ConductStudentRecordResponse.java
+++ b/src/main/java/com/remake/gone/conduct/dto/ConductStudentRecordResponse.java
@@ -1,0 +1,59 @@
+package com.remake.gone.conduct.dto;
+
+import com.remake.gone.conduct.entity.ConductRecord;
+import com.remake.gone.conduct.enums.ConductStatus;
+import com.remake.gone.conduct.enums.ConductType;
+import java.time.LocalDateTime;
+
+/**
+ * 학생 본인 상/벌점 이력 응답 DTO.
+ *
+ * <p>{@link ConductRecordResponse}에서 학생 본인 정보({@code studentUserId},
+ * {@code studentNickname})를 제외한 축약형이다 — 학생이 본인 이력을 조회할 때
+ * 항목마다 자신의 정보를 반복 노출할 필요가 없다.
+ *
+ * @param id              기록 식별자
+ * @param teacherUserId   부여 교사 사용자 ID
+ * @param teacherNickname 부여 교사 별명
+ * @param categoryId      카테고리 ID
+ * @param categoryLabel   카테고리 표시명
+ * @param type            상점({@code MERIT}) 또는 벌점({@code DEMERIT})
+ * @param points          부여 시점 점수 스냅샷(부호 포함)
+ * @param detail          추가 상세 사유(없으면 {@code null})
+ * @param status          기록 상태
+ * @param createdAt       부여 일시
+ */
+public record ConductStudentRecordResponse(
+    Long id,
+    Long teacherUserId,
+    String teacherNickname,
+    Long categoryId,
+    String categoryLabel,
+    ConductType type,
+    int points,
+    String detail,
+    ConductStatus status,
+    LocalDateTime createdAt
+) {
+
+  /**
+   * {@link ConductRecord} 엔티티를 학생 본인 조회용 응답 DTO로 변환합니다.
+   *
+   * @param record 변환 대상 기록 엔티티
+   * @return 변환된 {@link ConductStudentRecordResponse}
+   */
+  public static ConductStudentRecordResponse from(ConductRecord record) {
+    return new ConductStudentRecordResponse(
+        record.getId(),
+        record.getTeacher().getId(),
+        record.getTeacher().getName(),
+        record.getCategory().getId(),
+        record.getCategory().getLabel(),
+        record.getType(),
+        record.getPoints(),
+        record.getDetail(),
+        record.getStatus(),
+        record.getCreatedAt()
+    );
+  }
+}

--- a/src/main/java/com/remake/gone/conduct/dto/ConductSummaryResponse.java
+++ b/src/main/java/com/remake/gone/conduct/dto/ConductSummaryResponse.java
@@ -1,0 +1,18 @@
+package com.remake.gone.conduct.dto;
+
+/**
+ * 학생 본인 누적 상/벌점 요약 응답 DTO.
+ *
+ * @param totalMeritPoints    전체 기간 상점 합계(양수)
+ * @param totalDemeritPoints  전체 기간 벌점 합계(음수로 저장된 값 그대로)
+ * @param netScore            순 점수({@code totalMeritPoints + totalDemeritPoints})
+ * @param demeritThreshold    벌점 임계치(설정값)
+ * @param overDemeritThreshold 누적 벌점 절댓값이 임계치 이상인지 여부
+ */
+public record ConductSummaryResponse(
+    int totalMeritPoints,
+    int totalDemeritPoints,
+    int netScore,
+    int demeritThreshold,
+    boolean overDemeritThreshold
+) {}

--- a/src/main/java/com/remake/gone/conduct/exception/ConductErrorCode.java
+++ b/src/main/java/com/remake/gone/conduct/exception/ConductErrorCode.java
@@ -29,7 +29,13 @@ public enum ConductErrorCode implements ErrorCode {
   STUDENT_NOT_FOUND(HttpStatus.NOT_FOUND, "CONDUCT_005", "대상 학생을 찾을 수 없습니다."),
 
   /** 대상 사용자가 학생 역할이 아닙니다. */
-  NOT_STUDENT_ROLE(HttpStatus.BAD_REQUEST, "CONDUCT_006", "대상 사용자가 학생 역할이 아닙니다.");
+  NOT_STUDENT_ROLE(HttpStatus.BAD_REQUEST, "CONDUCT_006", "대상 사용자가 학생 역할이 아닙니다."),
+
+  /** 페이지 파라미터가 유효하지 않습니다. */
+  INVALID_PAGE(HttpStatus.BAD_REQUEST, "CONDUCT_007", "페이지 파라미터가 유효하지 않습니다."),
+
+  /** 날짜 범위 파라미터가 유효하지 않습니다. */
+  INVALID_DATE_RANGE(HttpStatus.BAD_REQUEST, "CONDUCT_008", "날짜 범위 파라미터가 유효하지 않습니다.");
 
   private final HttpStatus httpStatus;
   private final String code;

--- a/src/main/java/com/remake/gone/conduct/repository/ConductRecordRepository.java
+++ b/src/main/java/com/remake/gone/conduct/repository/ConductRecordRepository.java
@@ -50,7 +50,7 @@ public interface ConductRecordRepository extends JpaRepository<ConductRecord, Lo
       + "AND (:type IS NULL OR r.type = :type) "
       + "AND (:dateFrom IS NULL OR CAST(r.createdAt AS LocalDate) >= :dateFrom) "
       + "AND (:dateTo IS NULL OR CAST(r.createdAt AS LocalDate) <= :dateTo) "
-      + "ORDER BY r.createdAt DESC")
+      + "ORDER BY r.createdAt DESC, r.id DESC")
   Page<ConductRecord> findByStudentWithFilters(
       @Param("studentUserId") Long studentUserId,
       @Param("type") ConductType type,

--- a/src/main/java/com/remake/gone/conduct/repository/ConductRecordRepository.java
+++ b/src/main/java/com/remake/gone/conduct/repository/ConductRecordRepository.java
@@ -44,6 +44,8 @@ public interface ConductRecordRepository extends JpaRepository<ConductRecord, Lo
    * @return 필터링된 기록 페이지
    */
   @Query("SELECT r FROM ConductRecord r "
+      + "LEFT JOIN FETCH r.teacher "
+      + "LEFT JOIN FETCH r.category "
       + "WHERE r.student.id = :studentUserId "
       + "AND (:type IS NULL OR r.type = :type) "
       + "AND (:dateFrom IS NULL OR CAST(r.createdAt AS LocalDate) >= :dateFrom) "

--- a/src/main/java/com/remake/gone/conduct/repository/ConductRecordRepository.java
+++ b/src/main/java/com/remake/gone/conduct/repository/ConductRecordRepository.java
@@ -1,7 +1,58 @@
 package com.remake.gone.conduct.repository;
 
 import com.remake.gone.conduct.entity.ConductRecord;
+import com.remake.gone.conduct.enums.ConductStatus;
+import com.remake.gone.conduct.enums.ConductType;
+import java.time.LocalDate;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 /** {@link ConductRecord} 리포지토리. */
-public interface ConductRecordRepository extends JpaRepository<ConductRecord, Long> {}
+public interface ConductRecordRepository extends JpaRepository<ConductRecord, Long> {
+
+  /**
+   * 특정 학생의 특정 종류·상태 기록의 점수 합계를 반환합니다.
+   *
+   * <p>해당하는 기록이 없으면 {@code 0}을 반환합니다.
+   *
+   * @param studentUserId 대상 학생 사용자 ID
+   * @param type          집계할 종류({@code MERIT} 또는 {@code DEMERIT})
+   * @param status        집계할 상태({@code ACTIVE} 또는 {@code CANCELED})
+   * @return 점수 합계(부호 포함)
+   */
+  @Query("SELECT COALESCE(SUM(r.points), 0) FROM ConductRecord r "
+      + "WHERE r.student.id = :studentUserId AND r.type = :type AND r.status = :status")
+  int sumPointsByStudentAndType(
+      @Param("studentUserId") Long studentUserId,
+      @Param("type") ConductType type,
+      @Param("status") ConductStatus status);
+
+  /**
+   * 특정 학생의 상/벌점 이력을 필터·페이지네이션해 반환합니다.
+   *
+   * <p>{@code type}, {@code dateFrom}, {@code dateTo}가 {@code null}이면 해당 조건을 적용하지
+   * 않습니다. 결과는 부여 일시 내림차순으로 정렬됩니다.
+   *
+   * @param studentUserId 대상 학생 사용자 ID
+   * @param type          종류 필터({@code null}이면 전체)
+   * @param dateFrom      조회 시작일 필터({@code null}이면 제한 없음)
+   * @param dateTo        조회 종료일 필터({@code null}이면 제한 없음)
+   * @param pageable      페이지네이션 정보
+   * @return 필터링된 기록 페이지
+   */
+  @Query("SELECT r FROM ConductRecord r "
+      + "WHERE r.student.id = :studentUserId "
+      + "AND (:type IS NULL OR r.type = :type) "
+      + "AND (:dateFrom IS NULL OR CAST(r.createdAt AS LocalDate) >= :dateFrom) "
+      + "AND (:dateTo IS NULL OR CAST(r.createdAt AS LocalDate) <= :dateTo) "
+      + "ORDER BY r.createdAt DESC")
+  Page<ConductRecord> findByStudentWithFilters(
+      @Param("studentUserId") Long studentUserId,
+      @Param("type") ConductType type,
+      @Param("dateFrom") LocalDate dateFrom,
+      @Param("dateTo") LocalDate dateTo,
+      Pageable pageable);
+}

--- a/src/main/java/com/remake/gone/conduct/service/ConductService.java
+++ b/src/main/java/com/remake/gone/conduct/service/ConductService.java
@@ -2,24 +2,32 @@ package com.remake.gone.conduct.service;
 
 import com.remake.gone.common.exception.CommonErrorCode;
 import com.remake.gone.common.exception.CustomException;
+import com.remake.gone.common.response.PageResponse;
+import com.remake.gone.conduct.config.ConductProperties;
 import com.remake.gone.conduct.dto.ConductAmendRequest;
 import com.remake.gone.conduct.dto.ConductCancelRequest;
 import com.remake.gone.conduct.dto.ConductCategoryResponse;
 import com.remake.gone.conduct.dto.ConductGrantRequest;
 import com.remake.gone.conduct.dto.ConductRecordResponse;
+import com.remake.gone.conduct.dto.ConductStudentRecordResponse;
+import com.remake.gone.conduct.dto.ConductSummaryResponse;
 import com.remake.gone.conduct.entity.ConductCategory;
 import com.remake.gone.conduct.entity.ConductRecord;
 import com.remake.gone.conduct.enums.ConductStatus;
+import com.remake.gone.conduct.enums.ConductType;
 import com.remake.gone.conduct.exception.ConductErrorCode;
 import com.remake.gone.conduct.repository.ConductCategoryRepository;
 import com.remake.gone.conduct.repository.ConductRecordRepository;
 import com.remake.gone.role.repository.UserRoleRepository;
 import com.remake.gone.user.entity.User;
 import com.remake.gone.user.repository.UserRepository;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -35,6 +43,7 @@ public class ConductService {
   private final ConductRecordRepository conductRecordRepository;
   private final UserRepository userRepository;
   private final UserRoleRepository userRoleRepository;
+  private final ConductProperties conductProperties;
 
   /**
    * 활성 카테고리 목록을 조회합니다.
@@ -167,5 +176,71 @@ public class ConductService {
     record.setCancelReason(request.cancelReason());
 
     return ConductRecordResponse.from(record);
+  }
+
+  /**
+   * 학생 본인의 누적 상/벌점 요약을 반환합니다.
+   *
+   * <p>전체 기간 기준으로 {@code ACTIVE} 상태인 기록만 집계합니다.
+   *
+   * @param studentUserId 조회 대상 학생 사용자 ID (Access Token에서 추출됨)
+   * @return 총 상점·벌점·순 점수·임계치 초과 여부
+   */
+  @Transactional(readOnly = true)
+  public ConductSummaryResponse getStudentSummary(Long studentUserId) {
+    int totalMeritPoints = conductRecordRepository.sumPointsByStudentAndType(
+        studentUserId, ConductType.MERIT, ConductStatus.ACTIVE);
+    int totalDemeritPoints = conductRecordRepository.sumPointsByStudentAndType(
+        studentUserId, ConductType.DEMERIT, ConductStatus.ACTIVE);
+    int netScore = totalMeritPoints + totalDemeritPoints;
+    int threshold = conductProperties.demeritThreshold();
+    boolean overThreshold = Math.abs(totalDemeritPoints) >= threshold;
+    return new ConductSummaryResponse(
+        totalMeritPoints, totalDemeritPoints, netScore, threshold, overThreshold);
+  }
+
+  /**
+   * 학생 본인의 상/벌점 이력을 필터·페이지네이션해 반환합니다.
+   *
+   * <p>취소된 기록({@code CANCELED})도 포함합니다.
+   *
+   * @param studentUserId 조회 대상 학생 사용자 ID (Access Token에서 추출됨)
+   * @param type          종류 필터({@code null}이면 전체)
+   * @param dateFrom      조회 시작일({@code null}이면 전체 기간)
+   * @param dateTo        조회 종료일({@code null}이면 전체 기간)
+   * @param page          페이지 번호(0부터 시작)
+   * @param size          페이지 크기(1~100)
+   * @return 페이지네이션된 이력 목록
+   */
+  @Transactional(readOnly = true)
+  public PageResponse<ConductStudentRecordResponse> getStudentRecords(
+      Long studentUserId,
+      ConductType type,
+      LocalDate dateFrom,
+      LocalDate dateTo,
+      int page,
+      int size) {
+    if (page < 0 || size < 1 || size > 100) {
+      throw new CustomException(ConductErrorCode.INVALID_PAGE);
+    }
+    boolean hasFrom = dateFrom != null;
+    boolean hasTo = dateTo != null;
+    if (hasFrom != hasTo || (hasFrom && dateFrom.isAfter(dateTo))) {
+      throw new CustomException(ConductErrorCode.INVALID_DATE_RANGE);
+    }
+
+    Page<ConductRecord> recordPage = conductRecordRepository.findByStudentWithFilters(
+        studentUserId, type, dateFrom, dateTo, PageRequest.of(page, size));
+
+    return new PageResponse<>(
+        recordPage.getContent().stream()
+            .map(ConductStudentRecordResponse::from)
+            .toList(),
+        recordPage.getNumber(),
+        recordPage.getSize(),
+        recordPage.getTotalElements(),
+        recordPage.getTotalPages(),
+        recordPage.hasNext()
+    );
   }
 }

--- a/src/test/java/com/remake/gone/conduct/service/ConductServiceTest.java
+++ b/src/test/java/com/remake/gone/conduct/service/ConductServiceTest.java
@@ -7,11 +7,15 @@ import static org.mockito.BDDMockito.given;
 
 import com.remake.gone.common.exception.CommonErrorCode;
 import com.remake.gone.common.exception.CustomException;
+import com.remake.gone.common.response.PageResponse;
+import com.remake.gone.conduct.config.ConductProperties;
 import com.remake.gone.conduct.dto.ConductAmendRequest;
 import com.remake.gone.conduct.dto.ConductCancelRequest;
 import com.remake.gone.conduct.dto.ConductCategoryResponse;
 import com.remake.gone.conduct.dto.ConductGrantRequest;
 import com.remake.gone.conduct.dto.ConductRecordResponse;
+import com.remake.gone.conduct.dto.ConductStudentRecordResponse;
+import com.remake.gone.conduct.dto.ConductSummaryResponse;
 import com.remake.gone.conduct.entity.ConductCategory;
 import com.remake.gone.conduct.entity.ConductRecord;
 import com.remake.gone.conduct.enums.ConductStatus;
@@ -22,6 +26,8 @@ import com.remake.gone.conduct.repository.ConductRecordRepository;
 import com.remake.gone.role.repository.UserRoleRepository;
 import com.remake.gone.user.entity.User;
 import com.remake.gone.user.repository.UserRepository;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
@@ -31,6 +37,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 
 /**
  * {@link ConductService}에 대한 단위 테스트.
@@ -49,6 +57,9 @@ class ConductServiceTest {
 
   @Mock
   private UserRoleRepository userRoleRepository;
+
+  @Mock
+  private ConductProperties conductProperties;
 
   @InjectMocks
   private ConductService conductService;
@@ -536,6 +547,198 @@ class ConductServiceTest {
           .isInstanceOf(CustomException.class)
           .extracting(e -> ((CustomException) e).getErrorCode())
           .isEqualTo(ConductErrorCode.ALREADY_CANCELED);
+    }
+  }
+
+  @Nested
+  @DisplayName("getStudentSummary")
+  class GetStudentSummary {
+
+    private final Long studentUserId = 101L;
+
+    @Test
+    @DisplayName("ACTIVE 기록 합산으로 totalMeritPoints, totalDemeritPoints, netScore를 계산한다")
+    void calculatesSummaryFromActiveRecords() {
+      given(conductRecordRepository.sumPointsByStudentAndType(
+          studentUserId, ConductType.MERIT, ConductStatus.ACTIVE)).willReturn(6);
+      given(conductRecordRepository.sumPointsByStudentAndType(
+          studentUserId, ConductType.DEMERIT, ConductStatus.ACTIVE)).willReturn(-4);
+      given(conductProperties.demeritThreshold()).willReturn(10);
+
+      ConductSummaryResponse result = conductService.getStudentSummary(studentUserId);
+
+      assertThat(result.totalMeritPoints()).isEqualTo(6);
+      assertThat(result.totalDemeritPoints()).isEqualTo(-4);
+      assertThat(result.netScore()).isEqualTo(2);
+      assertThat(result.demeritThreshold()).isEqualTo(10);
+      assertThat(result.overDemeritThreshold()).isFalse();
+    }
+
+    @Test
+    @DisplayName("누적 벌점 절댓값이 임계치 이상이면 overDemeritThreshold가 true다")
+    void flagsOverThresholdWhenDemeritExceedsLimit() {
+      given(conductRecordRepository.sumPointsByStudentAndType(
+          studentUserId, ConductType.MERIT, ConductStatus.ACTIVE)).willReturn(0);
+      given(conductRecordRepository.sumPointsByStudentAndType(
+          studentUserId, ConductType.DEMERIT, ConductStatus.ACTIVE)).willReturn(-10);
+      given(conductProperties.demeritThreshold()).willReturn(10);
+
+      ConductSummaryResponse result = conductService.getStudentSummary(studentUserId);
+
+      assertThat(result.overDemeritThreshold()).isTrue();
+    }
+
+    @Test
+    @DisplayName("기록이 없으면 모든 점수가 0이다")
+    void returnsZeroWhenNoRecords() {
+      given(conductRecordRepository.sumPointsByStudentAndType(
+          studentUserId, ConductType.MERIT, ConductStatus.ACTIVE)).willReturn(0);
+      given(conductRecordRepository.sumPointsByStudentAndType(
+          studentUserId, ConductType.DEMERIT, ConductStatus.ACTIVE)).willReturn(0);
+      given(conductProperties.demeritThreshold()).willReturn(10);
+
+      ConductSummaryResponse result = conductService.getStudentSummary(studentUserId);
+
+      assertThat(result.totalMeritPoints()).isEqualTo(0);
+      assertThat(result.totalDemeritPoints()).isEqualTo(0);
+      assertThat(result.netScore()).isEqualTo(0);
+      assertThat(result.overDemeritThreshold()).isFalse();
+    }
+  }
+
+  @Nested
+  @DisplayName("getStudentRecords")
+  class GetStudentRecords {
+
+    private final Long studentUserId = 101L;
+
+    private ConductRecord sampleRecord() {
+      return ConductRecord.builder()
+          .id(501L)
+          .student(User.builder().id(studentUserId).name("길동이").build())
+          .teacher(User.builder().id(42L).name("김선생").build())
+          .category(ConductCategory.builder()
+              .id(5L).label("지각").type(ConductType.DEMERIT).points(-1).build())
+          .type(ConductType.DEMERIT)
+          .points(-1)
+          .detail("3교시 10분 지각")
+          .status(ConductStatus.ACTIVE)
+          .createdAt(LocalDateTime.of(2026, 8, 1, 9, 0))
+          .version(0L)
+          .build();
+    }
+
+    @Test
+    @DisplayName("필터 없이 전체 이력을 페이지네이션해 반환한다")
+    void returnsPagedRecordsWithNoFilter() {
+      ConductRecord record = sampleRecord();
+      given(conductRecordRepository.findByStudentWithFilters(
+          studentUserId, null, null, null, PageRequest.of(0, 20)))
+          .willReturn(new PageImpl<>(List.of(record), PageRequest.of(0, 20), 1));
+
+      PageResponse<ConductStudentRecordResponse> result =
+          conductService.getStudentRecords(studentUserId, null, null, null, 0, 20);
+
+      assertThat(result.content()).hasSize(1);
+      assertThat(result.content().get(0).id()).isEqualTo(501L);
+      assertThat(result.totalElements()).isEqualTo(1);
+      assertThat(result.hasNext()).isFalse();
+    }
+
+    @Test
+    @DisplayName("type 필터를 적용하면 해당 종류의 기록만 반환한다")
+    void returnsFilteredRecordsByType() {
+      ConductRecord record = sampleRecord();
+      given(conductRecordRepository.findByStudentWithFilters(
+          studentUserId, ConductType.DEMERIT, null, null, PageRequest.of(0, 20)))
+          .willReturn(new PageImpl<>(List.of(record), PageRequest.of(0, 20), 1));
+
+      PageResponse<ConductStudentRecordResponse> result =
+          conductService.getStudentRecords(
+              studentUserId, ConductType.DEMERIT, null, null, 0, 20);
+
+      assertThat(result.content()).hasSize(1);
+      assertThat(result.content().get(0).type()).isEqualTo(ConductType.DEMERIT);
+    }
+
+    @Test
+    @DisplayName("dateFrom, dateTo를 함께 제공하면 기간 필터를 적용한다")
+    void returnsFilteredRecordsByDateRange() {
+      LocalDate from = LocalDate.of(2026, 8, 1);
+      LocalDate to = LocalDate.of(2026, 8, 31);
+      ConductRecord record = sampleRecord();
+      given(conductRecordRepository.findByStudentWithFilters(
+          studentUserId, null, from, to, PageRequest.of(0, 20)))
+          .willReturn(new PageImpl<>(List.of(record), PageRequest.of(0, 20), 1));
+
+      PageResponse<ConductStudentRecordResponse> result =
+          conductService.getStudentRecords(studentUserId, null, from, to, 0, 20);
+
+      assertThat(result.content()).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("page가 음수이면 CONDUCT_007 예외를 던진다")
+    void throwsWhenPageIsNegative() {
+      assertThatThrownBy(() ->
+          conductService.getStudentRecords(studentUserId, null, null, null, -1, 20))
+          .isInstanceOf(CustomException.class)
+          .extracting(e -> ((CustomException) e).getErrorCode())
+          .isEqualTo(ConductErrorCode.INVALID_PAGE);
+    }
+
+    @Test
+    @DisplayName("size가 0이면 CONDUCT_007 예외를 던진다")
+    void throwsWhenSizeIsZero() {
+      assertThatThrownBy(() ->
+          conductService.getStudentRecords(studentUserId, null, null, null, 0, 0))
+          .isInstanceOf(CustomException.class)
+          .extracting(e -> ((CustomException) e).getErrorCode())
+          .isEqualTo(ConductErrorCode.INVALID_PAGE);
+    }
+
+    @Test
+    @DisplayName("size가 100 초과이면 CONDUCT_007 예외를 던진다")
+    void throwsWhenSizeExceedsMax() {
+      assertThatThrownBy(() ->
+          conductService.getStudentRecords(studentUserId, null, null, null, 0, 101))
+          .isInstanceOf(CustomException.class)
+          .extracting(e -> ((CustomException) e).getErrorCode())
+          .isEqualTo(ConductErrorCode.INVALID_PAGE);
+    }
+
+    @Test
+    @DisplayName("dateFrom만 제공하면 CONDUCT_008 예외를 던진다")
+    void throwsWhenOnlyDateFromProvided() {
+      assertThatThrownBy(() ->
+          conductService.getStudentRecords(
+              studentUserId, null, LocalDate.of(2026, 8, 1), null, 0, 20))
+          .isInstanceOf(CustomException.class)
+          .extracting(e -> ((CustomException) e).getErrorCode())
+          .isEqualTo(ConductErrorCode.INVALID_DATE_RANGE);
+    }
+
+    @Test
+    @DisplayName("dateTo만 제공하면 CONDUCT_008 예외를 던진다")
+    void throwsWhenOnlyDateToProvided() {
+      assertThatThrownBy(() ->
+          conductService.getStudentRecords(
+              studentUserId, null, null, LocalDate.of(2026, 8, 31), 0, 20))
+          .isInstanceOf(CustomException.class)
+          .extracting(e -> ((CustomException) e).getErrorCode())
+          .isEqualTo(ConductErrorCode.INVALID_DATE_RANGE);
+    }
+
+    @Test
+    @DisplayName("dateFrom이 dateTo보다 이후이면 CONDUCT_008 예외를 던진다")
+    void throwsWhenDateFromAfterDateTo() {
+      assertThatThrownBy(() ->
+          conductService.getStudentRecords(
+              studentUserId, null,
+              LocalDate.of(2026, 8, 31), LocalDate.of(2026, 8, 1), 0, 20))
+          .isInstanceOf(CustomException.class)
+          .extracting(e -> ((CustomException) e).getErrorCode())
+          .isEqualTo(ConductErrorCode.INVALID_DATE_RANGE);
     }
   }
 }


### PR DESCRIPTION
## Summary

- `GET /api/v1/conduct-records/me/summary` — 누적 상/벌점 요약(총 상점·벌점·순 점수·임계치 초과 여부) 반환
- `GET /api/v1/conduct-records/me` — 취소 기록 포함 이력 조회, type·기간 필터·페이지네이션 지원
- N+1 쿼리 방지: `findByStudentWithFilters`에 `LEFT JOIN FETCH r.teacher/r.category` 적용
- 신규 에러코드: `CONDUCT_007`(페이지 파라미터 오류), `CONDUCT_008`(날짜 범위 오류)
- `ConductProperties` 도입으로 `conduct.demerit-threshold` 설정값 타입 안전하게 바인딩

## Test plan

- [ ] `GetStudentSummary` — 정상 집계 / 임계치 초과 플래그 / 기록 없음 시 0 반환
- [ ] `GetStudentRecords` — 필터 없음 / type 필터 / 날짜 범위 / 음수 page / size=0 / size=101 / dateFrom만 제공 / dateTo만 제공 / 역순 날짜
- [ ] QA 시나리오 13개 로컬 수동 통과 확인

Closes #111

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added student-only views for cumulative conduct summaries and conduct history.
  * History supports merit/demerit filtering, date ranges, pagination, and includes canceled records.
  * Summaries show merit points, demerit points, net score, and threshold status.

* **Bug Fixes**
  * Improved conduct history loading performance.

* **Documentation**
  * Added feature specifications, code review notes, QA results, and API test scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->