### PR TITLE
feat(conduct): 교사·선도부·관리자 상/벌점 조회 (#117)

### DIFF
--- a/docs/domain/conduct/117-conduct-staff-query-QA.md
+++ b/docs/domain/conduct/117-conduct-staff-query-QA.md
@@ -1,0 +1,42 @@
+# 교사·선도부·관리자 상/벌점 조회 QA 결과 (이슈 #117)
+
+> 환경: `application-dev.yml` (MySQL localhost:3307, Redis localhost:6379, server:9090)
+> 로컬 빌드: `./gradlew build` — BUILD SUCCESSFUL
+> 단위 테스트: 전체 통과
+> CI: PR 생성 시 트리거 예정 (브랜치 push 완료, PR 미생성 상태)
+
+---
+
+## QA 시나리오 결과
+
+| # | 시나리오 | 기대 결과 | 실제 결과 | 판정 |
+|---|---|---|---|---|
+| 1 | `GET /summary?studentUserId=1` — TEACHER 토큰 | `200` studentNickname·점수 포함 | `200` 동일 | ✅ |
+| 2 | `GET /` — 파라미터 없음 (전체 학생) | `200` 전체 이력 3건 | `200` 3건 | ✅ |
+| 3 | `GET /?studentUserId=4` — 특정 학생 | `200` 해당 학생 기록 2건 | `200` 2건 | ✅ |
+| 4 | `GET /?type=MERIT` — 종류 필터 | `200` MERIT 1건 | `200` 1건 | ✅ |
+| 5 | `GET /summary?studentUserId=999` — 존재하지 않는 학생 | `404` CONDUCT_005 | `404` CONDUCT_005 | ✅ |
+| 6 | `GET /summary?studentUserId=2` — TEACHER 역할 사용자 | `400` CONDUCT_006 | `400` CONDUCT_006 | ✅ |
+| 7 | `GET /summary` — studentUserId 미전달 | `400` COMMON_001 | `400` COMMON_001 | ✅ |
+| 8 | `GET /?page=-1` | `400` CONDUCT_007 | `400` CONDUCT_007 | ✅ |
+| 9 | `GET /?size=101` | `400` CONDUCT_007 | `400` CONDUCT_007 | ✅ |
+| 10 | `GET /?dateFrom=20260801` (dateTo 누락) | `400` CONDUCT_008 | `400` CONDUCT_008 | ✅ |
+| 11 | `GET /?dateFrom=20260831&dateTo=20260801` (역순) | `400` CONDUCT_008 | `400` CONDUCT_008 | ✅ |
+| 12 | `GET /summary?studentUserId=1` — 인증 없음 | `401` COMMON_002 | `401` COMMON_002 | ✅ |
+| 13 | `GET /?dateFrom=20260824&dateTo=20260824` — 단일 날짜 | `200` 해당 일 기록 | `200` 3건 반환 | ✅ |
+| 14 | `GET /?page=0&size=1` — 페이지네이션 | `200` 1건, hasNext=true, totalElements=3 | `200` 동일 | ✅ |
+| 15 | `GET /` — 인증 없음 | `401` COMMON_002 | `401` COMMON_002 | ✅ |
+
+---
+
+## 발견 문제
+
+없음. Critical/High/Medium/Low 전 항목 통과.
+
+---
+
+## 비고
+
+- 취소된 기록(status: CANCELED)이 이력 조회에 포함됨 — 기획서 명시 동작 확인
+- `studentUserId` 생략 시 전체 학생 이력 조회 정상 동작 확인
+- TEACHER·ADMIN·DISCIPLINE 외 역할은 `403 COMMON_003` 반환 (Spring Security `@PreAuthorize` 공통 처리)

--- a/docs/domain/conduct/117-conduct-staff-query-code-review.md
+++ b/docs/domain/conduct/117-conduct-staff-query-code-review.md
@@ -1,0 +1,16 @@
+# 교사·선도부·관리자 상/벌점 조회 코드 리뷰 (이슈 #117)
+
+> 격리 에이전트 리뷰 결과 (diff: `dev...feat/#117-conduct-staff-query`, 기획서: `117-conduct-staff-query.md`)
+
+## 리뷰 결과
+
+지적 사항 없음. 검토 항목별 판정:
+
+| 항목 | 판정 | 근거 |
+|---|---|---|
+| `studentNickname` 필드 — `user.getName()` 매핑 | ✅ 정상 | `getName()`이 실제 별명 반환, Javadoc과 일치 |
+| 날짜 범위 검증 — `hasFrom != hasTo` | ✅ 정상 | 단방향 제공·역순 모두 차단 |
+| `dateFrom.isAfter(dateTo)` 호출 시 NPE 위험 | ✅ 정상 | `hasFrom && hasTo` 조건 뒤에서만 호출, 비null 보장 |
+| 페이지 크기 경계 — `size < 1 \|\| size > 100` | ✅ 정상 | [1, 100] 범위 정확히 검증 |
+| `LEFT JOIN FETCH r.student` — nullable studentUserId | ✅ 정상 | `ManyToOne` fetch join, 행 수 팽창 없음 |
+| 테스트 커버리지 | ✅ 정상 | `getStaffSummary` 3개(정상·CONDUCT_005·CONDUCT_006), `getRecords` 6개(전체·특정·페이지·크기·날짜 단방향·날짜 역순) |

--- a/docs/domain/conduct/117-conduct-staff-query.md
+++ b/docs/domain/conduct/117-conduct-staff-query.md
@@ -1,0 +1,233 @@
+# 교사·선도부·관리자 상/벌점 조회 기획서 (이슈 #117)
+
+> 관련 마스터 기획서: [1_conduct-domain.md](./1_conduct-domain.md) — 엔드포인트 7·8번
+
+## 개요/목적
+
+교사·선도부·관리자가 특정 학생의 누적 점수 요약과 전체·특정 학생의 이력을 조회한다.
+학생 본인 조회(#111, 엔드포인트 5·6번)의 교사·관리자 버전이며, 조회 대상을 파라미터로
+지정한다는 점과 `studentUserId`/`studentNickname`을 응답에 포함한다는 점에서 차이가 있다.
+
+---
+
+## 엔드포인트
+
+### 7. `GET /api/v1/conduct-records/summary` — 특정 학생 누적 점수 요약 (교사·선도부·관리자)
+
+**권한**: `TEACHER`, `DISCIPLINE`, `ADMIN`
+(`@PreAuthorize("hasRole('TEACHER') or hasRole('DISCIPLINE') or hasRole('ADMIN')")`)
+
+**요청** (쿼리 파라미터)
+
+| 파라미터 | 타입 | 필수 | 설명 |
+|---|---|---|---|
+| `studentUserId` | `Long` | ✅ | 조회할 학생의 사용자 ID |
+
+**응답** (`200 OK`)
+```json
+{
+  "success": true,
+  "data": {
+    "studentUserId": 101,
+    "studentNickname": "길동이",
+    "totalMeritPoints": 6,
+    "totalDemeritPoints": -4,
+    "netScore": 2,
+    "demeritThreshold": 10,
+    "overDemeritThreshold": false
+  },
+  "message": "누적 점수를 조회했습니다.",
+  "code": null
+}
+```
+
+**구현 로직**
+1. `studentUserId`로 `User` 조회 — 없으면 `404` `CONDUCT_005`
+2. 대상이 `STUDENT` 역할인지 확인 — 아니면 `400` `CONDUCT_006`
+3. `conductRecordRepository.sumPointsByStudentAndType`으로 `totalMeritPoints`·
+   `totalDemeritPoints` 집계(전체 기간, `ACTIVE` 기록만)
+4. `netScore`, `overDemeritThreshold` 계산 — `#111` `getStudentSummary`와 동일 공식
+5. 응답에 `studentUserId`·`studentNickname` 포함 — 학생 본인 조회(5번)와의 차이
+
+**에러**
+- 존재하지 않는 `studentUserId` → `404` `CONDUCT_005`
+- 대상이 `STUDENT` 역할이 아님 → `400` `CONDUCT_006`
+- `studentUserId` 미전달 → `400` (공통 `MissingServletRequestParameterException`)
+
+---
+
+### 8. `GET /api/v1/conduct-records` — 이력 상세 목록 조회 (교사·선도부·관리자)
+
+**권한**: 7번과 동일
+
+**요청** (쿼리 파라미터, 전부 선택)
+
+| 파라미터 | 타입 | 기본값 | 설명 |
+|---|---|---|---|
+| `studentUserId` | `Long` | — | 특정 학생만 조회(생략 시 전체 학생 대상) |
+| `type` | `MERIT`/`DEMERIT` | — | 종류 필터(생략 시 전체) |
+| `dateFrom` | `yyyyMMdd` | — | 조회 시작일(`dateTo`와 함께 써야 함) |
+| `dateTo` | `yyyyMMdd` | — | 조회 종료일(`dateFrom`과 함께 써야 함) |
+| `page` | `int` | `0` | 페이지 번호(0부터 시작) |
+| `size` | `int` | `20` | 페이지 크기(1~100) |
+
+**응답** (`200 OK`)
+```json
+{
+  "success": true,
+  "data": {
+    "content": [
+      {
+        "id": 501,
+        "studentUserId": 101,
+        "studentNickname": "길동이",
+        "teacherUserId": 42,
+        "teacherNickname": "김선생",
+        "categoryId": 5,
+        "categoryLabel": "지각",
+        "type": "DEMERIT",
+        "points": -1,
+        "detail": "3교시 10분 지각",
+        "status": "ACTIVE",
+        "createdAt": "2026-08-12T09:15:00"
+      }
+    ],
+    "page": 0,
+    "size": 20,
+    "totalElements": 1,
+    "totalPages": 1,
+    "hasNext": false
+  },
+  "message": "상/벌점 이력을 조회했습니다.",
+  "code": null
+}
+```
+
+> 응답 항목은 기존 `ConductRecordResponse` DTO를 그대로 사용한다 — `studentUserId`·
+> `studentNickname`을 이미 포함하고 있어 `studentUserId` 생략(전체 학생) 조회에서도 각
+> 기록의 학생을 식별할 수 있다.
+
+**구현 로직**
+1. `page`/`size` 검증 — 범위 밖이면 `400` `CONDUCT_007`
+2. `dateFrom`/`dateTo` 검증 — 한 쪽만 오거나 역순이면 `400` `CONDUCT_008`
+3. `studentUserId`가 있으면 해당 학생만, 없으면 전체 학생 대상으로 `type`·기간 필터를
+   적용한 `Page<ConductRecord>` 조회(DB 레벨 페이지네이션)
+4. `ConductRecordResponse`로 변환해 `PageResponse`로 반환 — 취소 기록 포함
+
+**에러**
+- `page`/`size` 범위 밖 → `400` `CONDUCT_007`
+- `dateFrom`/`dateTo` 중 하나만 옴 또는 역순 → `400` `CONDUCT_008`
+
+---
+
+## 데이터 모델 변경
+
+### 신규 응답 DTO
+
+**`ConductStaffSummaryResponse`** (신규)
+
+| 필드 | 타입 | 설명 |
+|---|---|---|
+| `studentUserId` | `Long` | 조회 대상 학생 ID |
+| `studentNickname` | `String` | 조회 대상 학생 별명 |
+| `totalMeritPoints` | `int` | 전체 기간 상점 합계(양수) |
+| `totalDemeritPoints` | `int` | 전체 기간 벌점 합계(음수) |
+| `netScore` | `int` | 순 점수 |
+| `demeritThreshold` | `int` | 벌점 임계치 |
+| `overDemeritThreshold` | `boolean` | 임계치 초과 여부 |
+
+> `ConductSummaryResponse`(#111 학생 본인용)에 `studentUserId`·`studentNickname` 두 필드만
+> 추가한 구조다. 기존 DTO를 상속하지 않고 별도 record로 만들어, 두 DTO의 필드 진화가
+> 서로를 깨트리지 않게 한다.
+
+### 기존 DTO 재사용
+
+**`ConductRecordResponse`** — 8번 엔드포인트 응답에 그대로 사용. `studentUserId`·
+`studentNickname` 필드가 이미 있어 별도 DTO가 필요 없다.
+
+### 신규 Repository 메서드
+
+**`findWithFilters`** — `studentUserId`가 nullable한 필터 확장판.
+`findByStudentWithFilters`(#111)와 유사하지만 `studentUserId`가 `null`이면 전체 학생을
+조회하는 JPQL 조건을 추가한다.
+
+```jpql
+SELECT r FROM ConductRecord r
+LEFT JOIN FETCH r.teacher
+LEFT JOIN FETCH r.category
+LEFT JOIN FETCH r.student
+WHERE (:studentUserId IS NULL OR r.student.id = :studentUserId)
+AND (:type IS NULL OR r.type = :type)
+AND (:dateFrom IS NULL OR CAST(r.createdAt AS LocalDate) >= :dateFrom)
+AND (:dateTo IS NULL OR CAST(r.createdAt AS LocalDate) <= :dateTo)
+ORDER BY r.createdAt DESC, r.id DESC
+```
+
+> `r.student`도 `LEFT JOIN FETCH`로 가져온다 — `ConductRecordResponse.from(record)`에서
+> `record.getStudent().getId()`·`record.getStudent().getName()`을 접근하기 때문이다.
+
+### Flyway 마이그레이션
+
+불필요. 신규 테이블/컬럼 없음.
+
+---
+
+## 영향 받는 기존 코드
+
+| 파일 | 변경 내용 |
+|---|---|
+| `ConductRecordRepository` | `findWithFilters` 메서드 추가 |
+| `ConductService` | `getStaffSummary`, `getRecords` 메서드 추가 |
+| `ConductController` | `GET /summary`, `GET /` 두 엔드포인트 추가 |
+| `ConductServiceTest` | `GetStaffSummary`, `GetRecords` 중첩 클래스 추가 |
+
+---
+
+## 리스크 및 고려사항
+
+### API 설계 6원칙 체크
+
+1. **한 가지를 잘하기**: 요약(7번)과 이력(8번)을 분리해 단일 책임. 마스터 기획서와 동일한
+   판단 유지.
+2. **빠른 시작**: 요청/응답 예시 포함.
+3. **일관성**:
+   - `GET /me/summary`(학생) ↔ `GET /summary`(교사·관리자) 대칭 구조 유지.
+   - `GET /me`(학생) ↔ `GET /`(교사·관리자) 대칭 구조 유지.
+   - `page`/`size`/`dateFrom`/`dateTo` 파라미터 이름·검증 로직은 `#111`과 동일.
+4. **의미 있는 오류**: `CONDUCT_005`(학생 없음)·`CONDUCT_006`(학생 역할 아님)·
+   `CONDUCT_007`(페이지 오류)·`CONDUCT_008`(날짜 오류) 모두 기존 코드 재사용 — 새 에러
+   코드 없음.
+5. **확장성·성능**:
+   - 8번 `studentUserId` 생략 시 전체 학생 대상 조회 — 기간 필터 없이 호출하면 전체 기간
+     스캔이 된다. 마스터 기획서(#58)에서 "데이터가 실제로 쌓인 뒤 성능이 문제 되면 기본
+     기간 강제를 재검토한다"고 명시했으므로 이번 범위에선 제한 없이 구현하고, 인덱스
+     `(student_user_id, created_at)`·`(teacher_user_id, created_at)`(V16 마이그레이션에 이미
+     존재)으로 성능을 보완한다.
+   - `ManyToOne`(`teacher`·`category`·`student`) 세 관계 모두 `LEFT JOIN FETCH`로 N+1 방지.
+6. **하위 호환성**: 신규 엔드포인트 추가만이므로 기존 API에 영향 없음.
+
+### 라우트 충돌 확인
+
+- `GET /api/v1/conduct-records/me/summary` — 학생용(#111)
+- `GET /api/v1/conduct-records/me` — 학생용(#111)
+- `GET /api/v1/conduct-records/summary` — 교사·관리자용(이번)
+- `GET /api/v1/conduct-records/categories` — 카테고리 목록(#92)
+- `GET /api/v1/conduct-records` — 교사·관리자용(이번)
+
+`/me`는 고정 문자열이라 `/{id}`와 충돌하지 않는다. `GET /` 자체는 Spring MVC에서
+`@RequestMapping("/api/v1/conduct-records")` 레벨에 `@GetMapping`을 붙이면 된다.
+`/summary`도 고정 문자열이라 `GET /`와 구분된다.
+
+### `student` fetch join과 페이지네이션
+
+`student`는 `ManyToOne`이라 `LEFT JOIN FETCH`를 추가해도 행 수가 팽창하지 않는다 —
+`ManyToMany`나 `OneToMany` fetch join + `Pageable` 조합에서 발생하는
+"HHH90003004 in-memory pagination" 경고와 무관하다. #111에서 `teacher`·`category`에
+동일하게 적용해 검증한 패턴이다.
+
+### `ConductStaffSummaryResponse` vs `ConductSummaryResponse` 재사용
+
+`ConductSummaryResponse`에 `studentUserId`/`studentNickname`을 추가해 재사용하는 방법도
+있지만, 그렇게 하면 학생 본인 조회(5번) 응답에 의미 없는 null 필드가 생긴다. 학생 본인은
+"내 기록을 보고 있음"을 이미 알고 있어 응답에 `studentUserId`를 넣을 이유가 없다 — 별도
+record로 분리하는 것이 더 명확하다.

--- a/postman/collections/gone-conduct.postman_collection.json
+++ b/postman/collections/gone-conduct.postman_collection.json
@@ -1810,7 +1810,29 @@
                 "login"
               ]
             }
-          }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test(\"200 OK\", function () {",
+                  "    pm.response.to.have.status(200);",
+                  "});",
+                  "",
+                  "if (pm.response.code === 200) {",
+                  "    const body = pm.response.json();",
+                  "    if (body.success && body.data) {",
+                  "        pm.environment.set(\"teacherAccessToken\", body.data.accessToken);",
+                  "        const payload = JSON.parse(atob(body.data.accessToken.split('.')[1].replace(/-/g,'+').replace(/_/g,'/')));",
+                  "        pm.environment.set(\"teacherUserId\", payload.sub);",
+                  "    }",
+                  "}"
+                ]
+              }
+            }
+          ]
         },
         {
           "name": "2. 특정 학생 누적 점수 요약 조회",

--- a/postman/collections/gone-conduct.postman_collection.json
+++ b/postman/collections/gone-conduct.postman_collection.json
@@ -404,6 +404,77 @@
       }
     },
     {
+      "name": "특정 학생 누적 점수 요약 조회",
+      "request": {
+        "method": "GET",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          },
+          {
+            "key": "Authorization",
+            "value": "Bearer {{teacherAccessToken}}"
+          }
+        ],
+        "url": {
+          "raw": "{{baseUrl}}/api/v1/conduct-records/summary?studentUserId=1",
+          "host": [
+            "{{baseUrl}}"
+          ],
+          "path": [
+            "api",
+            "v1",
+            "conduct-records",
+            "summary"
+          ],
+          "query": [
+            {
+              "key": "studentUserId",
+              "value": "1"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "name": "전체·특정 학생 이력 조회",
+      "request": {
+        "method": "GET",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          },
+          {
+            "key": "Authorization",
+            "value": "Bearer {{teacherAccessToken}}"
+          }
+        ],
+        "url": {
+          "raw": "{{baseUrl}}/api/v1/conduct-records?page=0&size=20",
+          "host": [
+            "{{baseUrl}}"
+          ],
+          "path": [
+            "api",
+            "v1",
+            "conduct-records"
+          ],
+          "query": [
+            {
+              "key": "page",
+              "value": "0"
+            },
+            {
+              "key": "size",
+              "value": "20"
+            }
+          ]
+        }
+      }
+    },
+    {
       "name": "에러 케이스",
       "item": [
         {
@@ -1034,6 +1105,102 @@
               ]
             }
           }
+        },
+        {
+          "name": "studentUserId 없이 /summary 호출 → 400 COMMON_001",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{teacherAccessToken}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/conduct-records/summary",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "conduct-records",
+                "summary"
+              ]
+            }
+          }
+        },
+        {
+          "name": "존재하지 않는 studentUserId → 404 CONDUCT_005 (summary)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{teacherAccessToken}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/conduct-records/summary?studentUserId=999",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "conduct-records",
+                "summary"
+              ],
+              "query": [
+                {
+                  "key": "studentUserId",
+                  "value": "999"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "STUDENT 역할 아닌 userId → 400 CONDUCT_006 (summary)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{teacherAccessToken}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/conduct-records/summary?studentUserId=2",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "conduct-records",
+                "summary"
+              ],
+              "query": [
+                {
+                  "key": "studentUserId",
+                  "value": "2"
+                }
+              ]
+            }
+          }
         }
       ]
     },
@@ -1590,6 +1757,237 @@
                 "v1",
                 "conduct-records",
                 "me"
+              ],
+              "query": [
+                {
+                  "key": "dateFrom",
+                  "value": "20260824"
+                },
+                {
+                  "key": "dateTo",
+                  "value": "20260824"
+                },
+                {
+                  "key": "page",
+                  "value": "0"
+                },
+                {
+                  "key": "size",
+                  "value": "20"
+                }
+              ]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "교사·선도부·관리자 조회 확인 (#117)",
+      "item": [
+        {
+          "name": "1. 교사 로그인",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\"identifier\": \"qatest_teacher\", \"password\": \"{{teacherPassword}}\"}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/auth/login",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "auth",
+                "login"
+              ]
+            }
+          }
+        },
+        {
+          "name": "2. 특정 학생 누적 점수 요약 조회",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{teacherAccessToken}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/conduct-records/summary?studentUserId=1",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "conduct-records",
+                "summary"
+              ],
+              "query": [
+                {
+                  "key": "studentUserId",
+                  "value": "1"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "3. 전체 학생 이력 조회 (필터 없음)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{teacherAccessToken}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/conduct-records?page=0&size=20",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "conduct-records"
+              ],
+              "query": [
+                {
+                  "key": "page",
+                  "value": "0"
+                },
+                {
+                  "key": "size",
+                  "value": "20"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "4. 특정 학생 이력 조회",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{teacherAccessToken}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/conduct-records?studentUserId=1&page=0&size=20",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "conduct-records"
+              ],
+              "query": [
+                {
+                  "key": "studentUserId",
+                  "value": "1"
+                },
+                {
+                  "key": "page",
+                  "value": "0"
+                },
+                {
+                  "key": "size",
+                  "value": "20"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "5. MERIT 필터 조회",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{teacherAccessToken}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/conduct-records?type=MERIT&page=0&size=20",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "conduct-records"
+              ],
+              "query": [
+                {
+                  "key": "type",
+                  "value": "MERIT"
+                },
+                {
+                  "key": "page",
+                  "value": "0"
+                },
+                {
+                  "key": "size",
+                  "value": "20"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "6. 날짜 범위 필터 조회",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{teacherAccessToken}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/conduct-records?dateFrom=20260824&dateTo=20260824&page=0&size=20",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "conduct-records"
               ],
               "query": [
                 {

--- a/src/main/java/com/remake/gone/conduct/controller/ConductController.java
+++ b/src/main/java/com/remake/gone/conduct/controller/ConductController.java
@@ -8,6 +8,7 @@ import com.remake.gone.conduct.dto.ConductCancelRequest;
 import com.remake.gone.conduct.dto.ConductCategoryResponse;
 import com.remake.gone.conduct.dto.ConductGrantRequest;
 import com.remake.gone.conduct.dto.ConductRecordResponse;
+import com.remake.gone.conduct.dto.ConductStaffSummaryResponse;
 import com.remake.gone.conduct.dto.ConductStudentRecordResponse;
 import com.remake.gone.conduct.dto.ConductSummaryResponse;
 import com.remake.gone.conduct.enums.ConductType;
@@ -34,7 +35,7 @@ import org.springframework.web.bind.annotation.RestController;
  * 상/벌점(Conduct) 도메인 API 컨트롤러.
  *
  * <p>#92에서 카테고리 목록 조회, #94에서 상/벌점 부여, #107에서 정정·취소,
- * #111에서 학생 본인 조회 엔드포인트를 구현했다.
+ * #111에서 학생 본인 조회, #117에서 교사·선도부·관리자 조회 엔드포인트를 구현했다.
  */
 @RestController
 @RequestMapping("/api/v1/conduct-records")
@@ -156,6 +157,52 @@ public class ConductController {
     return ApiResponse.success(
         conductService.getStudentRecords(
             principal.userId(), type, dateFrom, dateTo, page, size),
+        "상/벌점 이력을 조회했습니다.");
+  }
+
+  /**
+   * 특정 학생의 누적 상/벌점 요약을 조회합니다.
+   *
+   * <p>전체 기간 기준 총 상점·벌점·순 점수와 벌점 임계치 초과 여부를 반환합니다.
+   * 교사·선도부·관리자가 사용합니다.
+   *
+   * @param studentUserId 조회할 학생의 사용자 ID
+   * @return 누적 점수 요약(학생 식별 정보 포함)
+   */
+  @GetMapping("/summary")
+  @PreAuthorize("hasRole('TEACHER') or hasRole('DISCIPLINE') or hasRole('ADMIN')")
+  public ApiResponse<ConductStaffSummaryResponse> getStaffSummary(
+      @RequestParam Long studentUserId) {
+    return ApiResponse.success(
+        conductService.getStaffSummary(studentUserId),
+        "누적 점수를 조회했습니다.");
+  }
+
+  /**
+   * 전체·특정 학생의 상/벌점 이력을 조회합니다.
+   *
+   * <p>취소된 기록도 포함하며, {@code studentUserId}·{@code type}·기간 필터와
+   * 페이지네이션을 지원합니다. 교사·선도부·관리자가 사용합니다.
+   *
+   * @param studentUserId 특정 학생만 조회할 때의 학생 사용자 ID(생략 시 전체 학생)
+   * @param type          종류 필터({@code MERIT}/{@code DEMERIT}, 생략 시 전체)
+   * @param dateFrom      조회 시작일({@code yyyyMMdd}, {@code dateTo}와 함께 써야 함)
+   * @param dateTo        조회 종료일({@code yyyyMMdd}, {@code dateFrom}과 함께 써야 함)
+   * @param page          페이지 번호(기본값 {@code 0})
+   * @param size          페이지 크기(기본값 {@code 20}, 1~100)
+   * @return 페이지네이션된 이력 목록
+   */
+  @GetMapping
+  @PreAuthorize("hasRole('TEACHER') or hasRole('DISCIPLINE') or hasRole('ADMIN')")
+  public ApiResponse<PageResponse<ConductRecordResponse>> getRecords(
+      @RequestParam(required = false) Long studentUserId,
+      @RequestParam(required = false) ConductType type,
+      @RequestParam(required = false) @DateTimeFormat(pattern = "yyyyMMdd") LocalDate dateFrom,
+      @RequestParam(required = false) @DateTimeFormat(pattern = "yyyyMMdd") LocalDate dateTo,
+      @RequestParam(defaultValue = "0") int page,
+      @RequestParam(defaultValue = "20") int size) {
+    return ApiResponse.success(
+        conductService.getRecords(studentUserId, type, dateFrom, dateTo, page, size),
         "상/벌점 이력을 조회했습니다.");
   }
 }

--- a/src/main/java/com/remake/gone/conduct/dto/ConductStaffSummaryResponse.java
+++ b/src/main/java/com/remake/gone/conduct/dto/ConductStaffSummaryResponse.java
@@ -1,0 +1,24 @@
+package com.remake.gone.conduct.dto;
+
+/**
+ * 교사·선도부·관리자용 특정 학생 누적 상/벌점 요약 응답 DTO.
+ *
+ * <p>{@link ConductSummaryResponse}(학생 본인 조회용)에 조회 대상 학생 식별 정보를 추가한 구조다.
+ *
+ * @param studentUserId       조회 대상 학생 사용자 ID
+ * @param studentNickname     조회 대상 학생 별명
+ * @param totalMeritPoints    전체 기간 상점 합계(양수)
+ * @param totalDemeritPoints  전체 기간 벌점 합계(음수로 저장된 값 그대로)
+ * @param netScore            순 점수({@code totalMeritPoints + totalDemeritPoints})
+ * @param demeritThreshold    벌점 임계치(설정값)
+ * @param overDemeritThreshold 누적 벌점 절댓값이 임계치 이상인지 여부
+ */
+public record ConductStaffSummaryResponse(
+    Long studentUserId,
+    String studentNickname,
+    int totalMeritPoints,
+    int totalDemeritPoints,
+    int netScore,
+    int demeritThreshold,
+    boolean overDemeritThreshold
+) {}

--- a/src/main/java/com/remake/gone/conduct/repository/ConductRecordRepository.java
+++ b/src/main/java/com/remake/gone/conduct/repository/ConductRecordRepository.java
@@ -57,4 +57,34 @@ public interface ConductRecordRepository extends JpaRepository<ConductRecord, Lo
       @Param("dateFrom") LocalDate dateFrom,
       @Param("dateTo") LocalDate dateTo,
       Pageable pageable);
+
+  /**
+   * 전체·특정 학생의 상/벌점 이력을 필터·페이지네이션해 반환합니다.
+   *
+   * <p>{@code studentUserId}가 {@code null}이면 전체 학생을 대상으로 조회합니다.
+   * {@code type}, {@code dateFrom}, {@code dateTo}가 {@code null}이면 해당 조건을 적용하지
+   * 않습니다. 결과는 부여 일시·기록 ID 내림차순으로 정렬됩니다.
+   *
+   * @param studentUserId 대상 학생 사용자 ID({@code null}이면 전체)
+   * @param type          종류 필터({@code null}이면 전체)
+   * @param dateFrom      조회 시작일 필터({@code null}이면 제한 없음)
+   * @param dateTo        조회 종료일 필터({@code null}이면 제한 없음)
+   * @param pageable      페이지네이션 정보
+   * @return 필터링된 기록 페이지
+   */
+  @Query("SELECT r FROM ConductRecord r "
+      + "LEFT JOIN FETCH r.teacher "
+      + "LEFT JOIN FETCH r.category "
+      + "LEFT JOIN FETCH r.student "
+      + "WHERE (:studentUserId IS NULL OR r.student.id = :studentUserId) "
+      + "AND (:type IS NULL OR r.type = :type) "
+      + "AND (:dateFrom IS NULL OR CAST(r.createdAt AS LocalDate) >= :dateFrom) "
+      + "AND (:dateTo IS NULL OR CAST(r.createdAt AS LocalDate) <= :dateTo) "
+      + "ORDER BY r.createdAt DESC, r.id DESC")
+  Page<ConductRecord> findWithFilters(
+      @Param("studentUserId") Long studentUserId,
+      @Param("type") ConductType type,
+      @Param("dateFrom") LocalDate dateFrom,
+      @Param("dateTo") LocalDate dateTo,
+      Pageable pageable);
 }

--- a/src/main/java/com/remake/gone/conduct/service/ConductService.java
+++ b/src/main/java/com/remake/gone/conduct/service/ConductService.java
@@ -9,6 +9,7 @@ import com.remake.gone.conduct.dto.ConductCancelRequest;
 import com.remake.gone.conduct.dto.ConductCategoryResponse;
 import com.remake.gone.conduct.dto.ConductGrantRequest;
 import com.remake.gone.conduct.dto.ConductRecordResponse;
+import com.remake.gone.conduct.dto.ConductStaffSummaryResponse;
 import com.remake.gone.conduct.dto.ConductStudentRecordResponse;
 import com.remake.gone.conduct.dto.ConductSummaryResponse;
 import com.remake.gone.conduct.entity.ConductCategory;
@@ -235,6 +236,79 @@ public class ConductService {
     return new PageResponse<>(
         recordPage.getContent().stream()
             .map(ConductStudentRecordResponse::from)
+            .toList(),
+        recordPage.getNumber(),
+        recordPage.getSize(),
+        recordPage.getTotalElements(),
+        recordPage.getTotalPages(),
+        recordPage.hasNext()
+    );
+  }
+
+  /**
+   * 특정 학생의 누적 상/벌점 요약을 반환합니다.
+   *
+   * <p>전체 기간 기준으로 {@code ACTIVE} 상태인 기록만 집계합니다.
+   * 교사·선도부·관리자가 특정 학생을 지정해 조회할 때 사용합니다.
+   *
+   * @param studentUserId 조회 대상 학생 사용자 ID
+   * @return 총 상점·벌점·순 점수·임계치 초과 여부(학생 식별 정보 포함)
+   */
+  @Transactional(readOnly = true)
+  public ConductStaffSummaryResponse getStaffSummary(Long studentUserId) {
+    User student = userRepository.findById(studentUserId)
+        .orElseThrow(() -> new CustomException(ConductErrorCode.STUDENT_NOT_FOUND));
+    List<String> roles = userRoleRepository.findRoleCodesByUserId(studentUserId);
+    if (!roles.contains(STUDENT_ROLE_CODE)) {
+      throw new CustomException(ConductErrorCode.NOT_STUDENT_ROLE);
+    }
+    int totalMeritPoints = conductRecordRepository.sumPointsByStudentAndType(
+        studentUserId, ConductType.MERIT, ConductStatus.ACTIVE);
+    int totalDemeritPoints = conductRecordRepository.sumPointsByStudentAndType(
+        studentUserId, ConductType.DEMERIT, ConductStatus.ACTIVE);
+    int netScore = totalMeritPoints + totalDemeritPoints;
+    int threshold = conductProperties.demeritThreshold();
+    boolean overThreshold = Math.abs(totalDemeritPoints) >= threshold;
+    return new ConductStaffSummaryResponse(
+        student.getId(), student.getName(),
+        totalMeritPoints, totalDemeritPoints, netScore, threshold, overThreshold);
+  }
+
+  /**
+   * 전체·특정 학생의 상/벌점 이력을 필터·페이지네이션해 반환합니다.
+   *
+   * <p>취소된 기록({@code CANCELED})도 포함합니다. {@code studentUserId}가 {@code null}이면
+   * 전체 학생을 대상으로 조회합니다.
+   *
+   * @param studentUserId 조회 대상 학생 사용자 ID({@code null}이면 전체)
+   * @param type          종류 필터({@code null}이면 전체)
+   * @param dateFrom      조회 시작일({@code null}이면 전체 기간)
+   * @param dateTo        조회 종료일({@code null}이면 전체 기간)
+   * @param page          페이지 번호(0부터 시작)
+   * @param size          페이지 크기(1~100)
+   * @return 페이지네이션된 이력 목록
+   */
+  @Transactional(readOnly = true)
+  public PageResponse<ConductRecordResponse> getRecords(
+      Long studentUserId,
+      ConductType type,
+      LocalDate dateFrom,
+      LocalDate dateTo,
+      int page,
+      int size) {
+    if (page < 0 || size < 1 || size > 100) {
+      throw new CustomException(ConductErrorCode.INVALID_PAGE);
+    }
+    boolean hasFrom = dateFrom != null;
+    boolean hasTo = dateTo != null;
+    if (hasFrom != hasTo || (hasFrom && dateFrom.isAfter(dateTo))) {
+      throw new CustomException(ConductErrorCode.INVALID_DATE_RANGE);
+    }
+    Page<ConductRecord> recordPage = conductRecordRepository.findWithFilters(
+        studentUserId, type, dateFrom, dateTo, PageRequest.of(page, size));
+    return new PageResponse<>(
+        recordPage.getContent().stream()
+            .map(ConductRecordResponse::from)
             .toList(),
         recordPage.getNumber(),
         recordPage.getSize(),

--- a/src/test/java/com/remake/gone/conduct/service/ConductServiceTest.java
+++ b/src/test/java/com/remake/gone/conduct/service/ConductServiceTest.java
@@ -14,6 +14,7 @@ import com.remake.gone.conduct.dto.ConductCancelRequest;
 import com.remake.gone.conduct.dto.ConductCategoryResponse;
 import com.remake.gone.conduct.dto.ConductGrantRequest;
 import com.remake.gone.conduct.dto.ConductRecordResponse;
+import com.remake.gone.conduct.dto.ConductStaffSummaryResponse;
 import com.remake.gone.conduct.dto.ConductStudentRecordResponse;
 import com.remake.gone.conduct.dto.ConductSummaryResponse;
 import com.remake.gone.conduct.entity.ConductCategory;
@@ -735,6 +736,157 @@ class ConductServiceTest {
       assertThatThrownBy(() ->
           conductService.getStudentRecords(
               studentUserId, null,
+              LocalDate.of(2026, 8, 31), LocalDate.of(2026, 8, 1), 0, 20))
+          .isInstanceOf(CustomException.class)
+          .extracting(e -> ((CustomException) e).getErrorCode())
+          .isEqualTo(ConductErrorCode.INVALID_DATE_RANGE);
+    }
+  }
+
+  @Nested
+  @DisplayName("getStaffSummary")
+  class GetStaffSummary {
+
+    private final Long studentUserId = 101L;
+
+    @Test
+    @DisplayName("학생 존재·역할 확인 후 누적 점수를 집계해 반환한다")
+    void returnsStaffSummaryWithStudentInfo() {
+      User student = User.builder().id(studentUserId).name("길동이").build();
+      given(userRepository.findById(studentUserId)).willReturn(Optional.of(student));
+      given(userRoleRepository.findRoleCodesByUserId(studentUserId))
+          .willReturn(List.of("STUDENT"));
+      given(conductRecordRepository.sumPointsByStudentAndType(
+          studentUserId, ConductType.MERIT, ConductStatus.ACTIVE)).willReturn(6);
+      given(conductRecordRepository.sumPointsByStudentAndType(
+          studentUserId, ConductType.DEMERIT, ConductStatus.ACTIVE)).willReturn(-4);
+      given(conductProperties.demeritThreshold()).willReturn(10);
+
+      ConductStaffSummaryResponse result = conductService.getStaffSummary(studentUserId);
+
+      assertThat(result.studentUserId()).isEqualTo(studentUserId);
+      assertThat(result.studentNickname()).isEqualTo("길동이");
+      assertThat(result.totalMeritPoints()).isEqualTo(6);
+      assertThat(result.totalDemeritPoints()).isEqualTo(-4);
+      assertThat(result.netScore()).isEqualTo(2);
+      assertThat(result.overDemeritThreshold()).isFalse();
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 studentUserId이면 CONDUCT_005 예외를 던진다")
+    void throwsWhenStudentNotFound() {
+      given(userRepository.findById(studentUserId)).willReturn(Optional.empty());
+
+      assertThatThrownBy(() -> conductService.getStaffSummary(studentUserId))
+          .isInstanceOf(CustomException.class)
+          .extracting(e -> ((CustomException) e).getErrorCode())
+          .isEqualTo(ConductErrorCode.STUDENT_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("대상이 STUDENT 역할이 아니면 CONDUCT_006 예외를 던진다")
+    void throwsWhenNotStudentRole() {
+      User teacher = User.builder().id(studentUserId).name("김선생").build();
+      given(userRepository.findById(studentUserId)).willReturn(Optional.of(teacher));
+      given(userRoleRepository.findRoleCodesByUserId(studentUserId))
+          .willReturn(List.of("TEACHER"));
+
+      assertThatThrownBy(() -> conductService.getStaffSummary(studentUserId))
+          .isInstanceOf(CustomException.class)
+          .extracting(e -> ((CustomException) e).getErrorCode())
+          .isEqualTo(ConductErrorCode.NOT_STUDENT_ROLE);
+    }
+  }
+
+  @Nested
+  @DisplayName("getRecords")
+  class GetRecords {
+
+    private final Long studentUserId = 101L;
+
+    private ConductRecord sampleRecord() {
+      return ConductRecord.builder()
+          .id(501L)
+          .student(User.builder().id(studentUserId).name("길동이").build())
+          .teacher(User.builder().id(42L).name("김선생").build())
+          .category(ConductCategory.builder()
+              .id(5L).label("지각").type(ConductType.DEMERIT).points(-1).build())
+          .type(ConductType.DEMERIT)
+          .points(-1)
+          .detail("3교시 10분 지각")
+          .status(ConductStatus.ACTIVE)
+          .createdAt(LocalDateTime.of(2026, 8, 1, 9, 0))
+          .version(0L)
+          .build();
+    }
+
+    @Test
+    @DisplayName("studentUserId 없이 전체 학생 이력을 페이지네이션해 반환한다")
+    void returnsAllStudentsRecordsWhenNoFilter() {
+      ConductRecord record = sampleRecord();
+      given(conductRecordRepository.findWithFilters(
+          null, null, null, null, PageRequest.of(0, 20)))
+          .willReturn(new PageImpl<>(List.of(record), PageRequest.of(0, 20), 1));
+
+      PageResponse<ConductRecordResponse> result =
+          conductService.getRecords(null, null, null, null, 0, 20);
+
+      assertThat(result.content()).hasSize(1);
+      assertThat(result.content().get(0).studentUserId()).isEqualTo(studentUserId);
+      assertThat(result.totalElements()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("studentUserId를 지정하면 해당 학생의 이력만 반환한다")
+    void returnsFilteredRecordsByStudentUserId() {
+      ConductRecord record = sampleRecord();
+      given(conductRecordRepository.findWithFilters(
+          studentUserId, null, null, null, PageRequest.of(0, 20)))
+          .willReturn(new PageImpl<>(List.of(record), PageRequest.of(0, 20), 1));
+
+      PageResponse<ConductRecordResponse> result =
+          conductService.getRecords(studentUserId, null, null, null, 0, 20);
+
+      assertThat(result.content()).hasSize(1);
+      assertThat(result.content().get(0).studentUserId()).isEqualTo(studentUserId);
+    }
+
+    @Test
+    @DisplayName("page가 음수이면 CONDUCT_007 예외를 던진다")
+    void throwsWhenPageIsNegative() {
+      assertThatThrownBy(() ->
+          conductService.getRecords(null, null, null, null, -1, 20))
+          .isInstanceOf(CustomException.class)
+          .extracting(e -> ((CustomException) e).getErrorCode())
+          .isEqualTo(ConductErrorCode.INVALID_PAGE);
+    }
+
+    @Test
+    @DisplayName("size가 100 초과이면 CONDUCT_007 예외를 던진다")
+    void throwsWhenSizeExceedsMax() {
+      assertThatThrownBy(() ->
+          conductService.getRecords(null, null, null, null, 0, 101))
+          .isInstanceOf(CustomException.class)
+          .extracting(e -> ((CustomException) e).getErrorCode())
+          .isEqualTo(ConductErrorCode.INVALID_PAGE);
+    }
+
+    @Test
+    @DisplayName("dateFrom만 제공하면 CONDUCT_008 예외를 던진다")
+    void throwsWhenOnlyDateFromProvided() {
+      assertThatThrownBy(() ->
+          conductService.getRecords(null, null, LocalDate.of(2026, 8, 1), null, 0, 20))
+          .isInstanceOf(CustomException.class)
+          .extracting(e -> ((CustomException) e).getErrorCode())
+          .isEqualTo(ConductErrorCode.INVALID_DATE_RANGE);
+    }
+
+    @Test
+    @DisplayName("dateFrom이 dateTo보다 이후이면 CONDUCT_008 예외를 던진다")
+    void throwsWhenDateFromAfterDateTo() {
+      assertThatThrownBy(() ->
+          conductService.getRecords(
+              null, null,
               LocalDate.of(2026, 8, 31), LocalDate.of(2026, 8, 1), 0, 20))
           .isInstanceOf(CustomException.class)
           .extracting(e -> ((CustomException) e).getErrorCode())

--- a/src/test/java/com/remake/gone/conduct/service/ConductServiceTest.java
+++ b/src/test/java/com/remake/gone/conduct/service/ConductServiceTest.java
@@ -872,6 +872,26 @@ class ConductServiceTest {
     }
 
     @Test
+    @DisplayName("size가 0이면 CONDUCT_007 예외를 던진다")
+    void throwsWhenSizeIsZero() {
+      assertThatThrownBy(() ->
+          conductService.getRecords(null, null, null, null, 0, 0))
+          .isInstanceOf(CustomException.class)
+          .extracting(e -> ((CustomException) e).getErrorCode())
+          .isEqualTo(ConductErrorCode.INVALID_PAGE);
+    }
+
+    @Test
+    @DisplayName("dateTo만 제공하면 CONDUCT_008 예외를 던진다")
+    void throwsWhenOnlyDateToProvided() {
+      assertThatThrownBy(() ->
+          conductService.getRecords(null, null, null, LocalDate.of(2026, 8, 31), 0, 20))
+          .isInstanceOf(CustomException.class)
+          .extracting(e -> ((CustomException) e).getErrorCode())
+          .isEqualTo(ConductErrorCode.INVALID_DATE_RANGE);
+    }
+
+    @Test
     @DisplayName("dateFrom만 제공하면 CONDUCT_008 예외를 던진다")
     void throwsWhenOnlyDateFromProvided() {
       assertThatThrownBy(() ->


### PR DESCRIPTION
## 관련 이슈
closes #117

## 작업 내용
교사·선도부·관리자가 특정 학생의 누적 상/벌점 요약과 전체·특정 학생의 이력을 조회하는 엔드포인트 2개를 추가한다.

- `GET /api/v1/conduct-records/summary?studentUserId={id}` — 특정 학생 누적 점수 요약(`TEACHER`·`DISCIPLINE`·`ADMIN`)
- `GET /api/v1/conduct-records` — 전체·특정 학생 이력 목록(`TEACHER`·`DISCIPLINE`·`ADMIN`)

## 변경 사항 상세
- **ConductStaffSummaryResponse** (신규 DTO): `studentUserId`, `studentNickname`, `totalMeritPoints`, `totalDemeritPoints`, `netScore`, `demeritThreshold`, `overDemeritThreshold`
- **ConductRecordRepository**: `findWithFilters` 추가 — `studentUserId IS NULL OR ...` 패턴으로 전체/특정 학생 단일 쿼리 처리, `LEFT JOIN FETCH` + `ORDER BY createdAt DESC, id DESC`
- **ConductService**: `getStaffSummary` (학생 존재 확인 → STUDENT 역할 확인 → 집계), `getRecords` (페이지·날짜 검증 → 페이지네이션 조회)
- **ConductController**: 두 엔드포인트 추가, `@PreAuthorize("hasRole('TEACHER') or hasRole('DISCIPLINE') or hasRole('ADMIN')")`
- **ConductServiceTest**: `GetStaffSummary` 3건, `GetRecords` 8건 단위 테스트
- **Postman**: conduct 컬렉션에 최상위 엔드포인트 2개, 에러 케이스 3건, `#117` 검증 폴더 추가
- 기획서(`docs/domain/conduct/117-conduct-staff-query.md`)와 실제 구현 간 차이 없음

## 확인 사항
- [x] 로컬 빌드 통과 (`./gradlew build`)
- [x] Checkstyle 통과 (`./gradlew checkstyleMain`)
- [ ] CI(checkstyle, build-and-test) 통과
- [ ] (해당 시) Notion 기능정의서/기획 문서 반영
- [x] (해당 시) 관련 도메인 라벨 지정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added staff-facing conduct summary queries for individual students, including merit, demerit, net score, and threshold status.
  * Added paginated conduct-record searches for all students or a selected student.
  * Added filtering by conduct type and date range.
  * Enabled access for teachers, discipline staff, and administrators.
  * Added validation for student identifiers, dates, pagination, and authorization.

* **Documentation**
  * Added API planning, QA results, code-review notes, and Postman verification scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->