### PR TITLE
feat(notification): 알림 목록 조회 구현

### DIFF
--- a/docs/domain/notification/119-notification-list.md
+++ b/docs/domain/notification/119-notification-list.md
@@ -1,0 +1,215 @@
+# 알림 목록 조회 기획서
+
+> 관련 Issue: [#119 알림 목록 조회 구현](https://github.com/GBSW-ReMake/GONE-server-V1/issues/119)
+>
+> 마스터 기획서: [`1_notification-domain.md`](./1_notification-domain.md)
+>
+> 기능정의서: `알림 목록 조회`
+
+## 1. 배경 및 목적
+
+사용자가 본인이 받은 알림을 인앱 알림함에서 최신순으로 확인할 수 있도록 목록 조회 API를
+구현한다.
+
+FCM 푸시는 기기 설정, 네트워크, 토큰 만료 등의 이유로 전달이 보장되지 않는다. 따라서
+알림은 DB에 저장된 이력을 조회하는 인앱 알림함을 기준으로 제공하며, 이번 기능은 Firebase나
+APNs에 의존하지 않는다.
+
+## 2. 범위
+
+### 포함
+
+- `GET /api/v1/notifications` 엔드포인트
+- Access Token의 `principal.userId()`를 기준으로 본인 알림만 조회
+- DB 페이지네이션
+- 최신 알림 우선 정렬
+- `Notification` 정보를 응답 DTO로 변환
+- 페이지 파라미터 검증
+- 정상 및 예외 테스트
+
+### 제외
+
+- 단건 알림 읽음 처리
+- 전체 알림 읽음 처리
+- 안 읽은 알림 개수 조회
+- FCM 디바이스 토큰 등록·삭제 및 푸시 발송
+- 외출·스쿨캠핑·상벌점 도메인의 실제 알림 발송 연동
+- 딥링크 연결
+
+위 기능은 각각 별도 Issue에서 진행한다.
+
+## 3. 권한 및 보안
+
+- 인증된 사용자만 호출할 수 있다.
+- 역할과 관계없이 인증된 사용자가 호출할 수 있다.
+- 조회 대상 사용자 ID를 요청 파라미터로 받지 않는다.
+- 항상 `UserPrincipal.userId()`를 사용해 본인 알림만 조회한다.
+- 다른 사용자의 알림이 응답에 포함되지 않도록 Repository 조회 조건에서 사용자 ID를
+  제한한다.
+
+## 4. API 명세
+
+### 4.1 요청
+
+```http
+GET /api/v1/notifications?page=0&size=20
+Authorization: Bearer {accessToken}
+```
+
+| 파라미터 | 타입 | 필수 | 기본값 | 제약 |
+|---|---|---:|---:|---|
+| `page` | `int` | 아니오 | `0` | `0` 이상 |
+| `size` | `int` | 아니오 | `20` | `1` 이상 `100` 이하 |
+
+### 4.2 성공 응답
+
+HTTP 상태 코드: `200 OK`
+
+```json
+{
+  "success": true,
+  "data": {
+    "content": [
+      {
+        "id": 501,
+        "title": "외출증이 승인되었습니다",
+        "body": "김선생님이 12:30 외출을 승인했어요.",
+        "type": "OUTING",
+        "isRead": false,
+        "createdAt": "2026-08-14T12:29:10"
+      }
+    ],
+    "page": 0,
+    "size": 20,
+    "totalElements": 1,
+    "totalPages": 1,
+    "hasNext": false
+  },
+  "message": "알림 목록을 조회했습니다.",
+  "code": null
+}
+```
+
+응답은 프로젝트 공통 `ApiResponse<PageResponse<NotificationResponse>>` 형식을 사용한다.
+
+### 4.3 응답 필드
+
+| 필드 | 타입 | 설명 |
+|---|---|---|
+| `id` | `Long` | 알림 식별자 |
+| `title` | `String` | 알림 제목 |
+| `body` | `String` | 알림 본문 |
+| `type` | `NotificationType` 또는 `null` | 도메인별 이모지 매핑용 타입 |
+| `isRead` | `boolean` | 읽음 여부 |
+| `createdAt` | `LocalDateTime` | 알림 저장 시각 |
+
+`type`은 다음 Enum 값을 그대로 응답한다.
+
+- `OUTING`
+- `SCHOOLCAMP`
+- `MERIT`
+- `DEMERIT`
+- `null`
+
+### 4.4 오류 응답
+
+| 상황 | HTTP 상태 | 에러 코드 |
+|---|---:|---|
+| 인증 정보가 없거나 유효하지 않음 | `401` | `COMMON_002` |
+| `page < 0` 또는 `size`가 `1~100` 범위를 벗어남 | `400` | `NOTIFICATION_003` |
+
+페이지 범위를 넘어선 페이지를 요청한 경우에는 오류로 처리하지 않고 빈 `content`와 정상적인
+페이지 메타데이터를 반환한다. 페이지네이션에서 마지막 페이지 다음 요청은 정상적인 클라이언트
+동작일 수 있기 때문이다.
+
+## 5. 조회 및 정렬 정책
+
+Repository에 사용자 ID와 `Pageable`을 전달하는 DB 페이지네이션 메서드를 추가한다.
+
+```java
+Page<Notification> findByUserId(Long userId, Pageable pageable);
+```
+
+호출부에서 다음 정렬을 지정한다.
+
+```text
+createdAt DESC, id DESC
+```
+
+알림 저장 시각이 같은 데이터가 있을 수 있으므로 `id DESC`를 보조 정렬 키로 사용해 페이지
+경계에서 순서가 흔들리는 것을 방지한다.
+
+조회 결과는 `PageResponse.of(page)`로 변환한다. 이미 DB에서 페이지 단위로 조회한 결과를
+다시 메모리에서 자르거나 전체 알림을 조회하지 않는다.
+
+## 6. 구현 구조
+
+### Controller
+
+- `@RestController`와 `/api/v1/notifications` 경로 사용
+- `@AuthenticationPrincipal UserPrincipal`에서 사용자 ID 추출
+- `page`, `size` 기본값 적용
+- Service 호출 후 `ApiResponse.success(...)` 반환
+- 컨트롤러에서 DB 조회나 소유권 판단을 하지 않음
+
+### Service
+
+- 페이지 파라미터 검증
+- `PageRequest.of(page, size, sort)` 생성
+- `principal.userId()`를 Repository에 전달
+- `Notification`을 `NotificationResponse`로 변환
+- `PageResponse.of(Page<T>)` 반환
+
+### Repository
+
+- 사용자 ID 조건으로 알림을 제한
+- `Pageable`을 받아 DB에서 페이지네이션
+- 정렬은 호출부의 `Pageable`을 사용
+
+### DTO
+
+조회 응답 전용 `NotificationResponse`를 추가한다. 엔티티를 API 응답으로 직접 노출하지
+않으며, `Notification.type`의 Enum과 `createdAt`을 응답에 포함한다.
+
+## 7. 테스트 계획
+
+### Service 단위 테스트
+
+- 정상적으로 본인 알림 페이지를 조회한다.
+- 사용자 ID가 Repository 조회 조건에 전달되는지 확인한다.
+- 최신순 정렬을 포함한 `Pageable`이 전달되는지 확인한다.
+- `Notification`이 `NotificationResponse`로 올바르게 변환된다.
+- `type`이 `null`인 알림도 정상 변환된다.
+- `page < 0`이면 `NOTIFICATION_003`을 발생시킨다.
+- `size < 1` 또는 `size > 100`이면 `NOTIFICATION_003`을 발생시킨다.
+
+### Controller/API 테스트
+
+- 인증된 사용자가 `200 OK`와 페이지 응답을 받는다.
+- `page`, `size`를 생략하면 각각 `0`, `20`이 적용된다.
+- 잘못된 페이지 파라미터에 `400`과 `NOTIFICATION_003`이 반환된다.
+- 인증되지 않은 요청은 `401`과 `COMMON_002`로 처리된다.
+- 응답에 `id`, `title`, `body`, `type`, `isRead`, `createdAt`이 포함된다.
+
+## 8. 검증 방법
+
+- `./gradlew test`
+- `./gradlew checkstyleMain`
+- `./gradlew checkstyleTest`
+- `./gradlew build`
+- 테스트용 알림 데이터를 DB에 준비한 뒤 Postman으로 다음을 확인한다.
+  - 기본 페이지 조회
+  - 사용자별 데이터 격리
+  - 최신순 정렬
+  - `page`, `size` 경계값
+  - 잘못된 페이지 파라미터
+  - 인증되지 않은 요청
+
+## 9. 결정 사항 및 주의점
+
+- Firebase/APNs 인증 정보는 이번 기능에 필요하지 않다.
+- 알림 타입은 이벤트 종류가 아니라 도메인 분류이므로 조회 API에서 Enum 값을 그대로
+  전달한다.
+- 요청으로 사용자 ID를 받지 않아 IDOR를 방지한다.
+- 전체 목록을 메모리에 올리는 방식 대신 DB 페이지네이션을 사용한다.
+- 읽음 처리와 FCM 발송은 이번 브랜치의 범위를 벗어난다.

--- a/docs/domain/notification/119-notification-list.md
+++ b/docs/domain/notification/119-notification-list.md
@@ -127,7 +127,8 @@ HTTP 상태 코드: `200 OK`
 Repository에 사용자 ID와 `Pageable`을 전달하는 DB 페이지네이션 메서드를 추가한다.
 
 ```java
-Page<Notification> findByUserId(Long userId, Pageable pageable);
+@Query("select n from Notification n where n.user.id = :userId")
+Page<Notification> findByUserId(@Param("userId") Long userId, Pageable pageable);
 ```
 
 호출부에서 다음 정렬을 지정한다.

--- a/src/main/java/com/remake/gone/common/config/SecurityConfig.java
+++ b/src/main/java/com/remake/gone/common/config/SecurityConfig.java
@@ -156,6 +156,7 @@ public class SecurityConfig {
             .requestMatchers("/api/v1/outings/**").authenticated()
             .requestMatchers("/api/v1/school-camps/**").authenticated()
             .requestMatchers("/api/v1/conduct-records/**").authenticated()
+            .requestMatchers("/api/v1/notifications/**").authenticated()
             .anyRequest().permitAll())
         .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 

--- a/src/main/java/com/remake/gone/notification/controller/NotificationController.java
+++ b/src/main/java/com/remake/gone/notification/controller/NotificationController.java
@@ -1,0 +1,45 @@
+package com.remake.gone.notification.controller;
+
+import com.remake.gone.common.response.ApiResponse;
+import com.remake.gone.common.response.PageResponse;
+import com.remake.gone.common.security.UserPrincipal;
+import com.remake.gone.notification.dto.NotificationResponse;
+import com.remake.gone.notification.service.NotificationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 알림(Notification) 도메인 API 컨트롤러.
+ */
+@RestController
+@RequestMapping("/api/v1/notifications")
+@RequiredArgsConstructor
+public class NotificationController {
+
+  private final NotificationService notificationService;
+
+  /**
+   * 현재 사용자가 받은 알림을 최신순으로 조회합니다.
+   *
+   * @param principal 인증 필터가 Access Token에서 추출한 현재 사용자
+   * @param page      페이지 번호(0부터 시작, 생략 시 0)
+   * @param size      페이지 크기(1~100, 생략 시 20)
+   * @return 페이지네이션된 알림 목록
+   */
+  @GetMapping
+  @PreAuthorize("isAuthenticated()")
+  public ApiResponse<PageResponse<NotificationResponse>> getNotifications(
+      @AuthenticationPrincipal UserPrincipal principal,
+      @RequestParam(defaultValue = "0") int page,
+      @RequestParam(defaultValue = "20") int size
+  ) {
+    PageResponse<NotificationResponse> response =
+        notificationService.getNotifications(principal.userId(), page, size);
+    return ApiResponse.success(response, "알림 목록을 조회했습니다.");
+  }
+}

--- a/src/main/java/com/remake/gone/notification/dto/NotificationResponse.java
+++ b/src/main/java/com/remake/gone/notification/dto/NotificationResponse.java
@@ -1,0 +1,41 @@
+package com.remake.gone.notification.dto;
+
+import com.remake.gone.notification.entity.Notification;
+import com.remake.gone.notification.enums.NotificationType;
+import java.time.LocalDateTime;
+
+/**
+ * 알림 목록 조회 응답 DTO.
+ *
+ * @param id        알림 식별자
+ * @param title     알림 제목
+ * @param body      알림 본문
+ * @param type      알림 도메인 타입
+ * @param isRead    읽음 여부
+ * @param createdAt 알림 생성 시각
+ */
+public record NotificationResponse(
+    Long id,
+    String title,
+    String body,
+    NotificationType type,
+    boolean isRead,
+    LocalDateTime createdAt
+) {
+
+  /**
+   * 알림 엔티티를 목록 조회 응답으로 변환합니다.
+   *
+   * @param notification 변환할 알림
+   * @return 변환된 알림 응답
+   */
+  public static NotificationResponse from(Notification notification) {
+    return new NotificationResponse(
+        notification.getId(),
+        notification.getTitle(),
+        notification.getBody(),
+        notification.getType(),
+        notification.isRead(),
+        notification.getCreatedAt());
+  }
+}

--- a/src/main/java/com/remake/gone/notification/entity/Notification.java
+++ b/src/main/java/com/remake/gone/notification/entity/Notification.java
@@ -26,8 +26,7 @@ import org.hibernate.annotations.CreationTimestamp;
  *
  * <p>{@code db/migration/V9__add_notification.sql}의 {@code notification} 테이블에 대응한다.
  * 저장은 {@link com.remake.gone.notification.service.NotificationService#send}가 전담하고,
- * 이 이슈(#59)에는 조회/읽음 처리 API가 없다 — {@link #isRead}는 후속 이슈가 그대로 재사용할
- * 수 있도록 미리 포함해둔 컬럼이다.
+ * 목록 조회와 읽음 처리에서 {@link #isRead}를 사용한다.
  */
 @Entity
 @Table(name = "notification")

--- a/src/main/java/com/remake/gone/notification/exception/NotificationErrorCode.java
+++ b/src/main/java/com/remake/gone/notification/exception/NotificationErrorCode.java
@@ -1,0 +1,41 @@
+package com.remake.gone.notification.exception;
+
+import com.remake.gone.common.exception.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+/**
+ * 알림(Notification) 도메인 에러 코드.
+ */
+public enum NotificationErrorCode implements ErrorCode {
+
+  /** 페이지 조회 조건이 올바르지 않습니다. */
+  INVALID_PAGE_PARAMS(
+      HttpStatus.BAD_REQUEST,
+      "NOTIFICATION_003",
+      "페이지 조회 조건이 올바르지 않습니다(page>=0, 1<=size<=100).");
+
+  private final HttpStatus httpStatus;
+  private final String code;
+  private final String defaultMessage;
+
+  NotificationErrorCode(HttpStatus httpStatus, String code, String defaultMessage) {
+    this.httpStatus = httpStatus;
+    this.code = code;
+    this.defaultMessage = defaultMessage;
+  }
+
+  @Override
+  public HttpStatus getStatus() {
+    return httpStatus;
+  }
+
+  @Override
+  public String getCode() {
+    return code;
+  }
+
+  @Override
+  public String getDefaultMessage() {
+    return defaultMessage;
+  }
+}

--- a/src/main/java/com/remake/gone/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/remake/gone/notification/repository/NotificationRepository.java
@@ -1,10 +1,24 @@
 package com.remake.gone.notification.repository;
 
 import com.remake.gone.notification.entity.Notification;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 /**
  * {@link Notification} 리포지토리.
  */
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
+
+  /**
+   * 특정 사용자가 받은 알림을 페이지 단위로 조회합니다.
+   *
+   * @param userId   알림 수신자 사용자 ID
+   * @param pageable 페이지 번호, 크기, 정렬 정보
+   * @return 사용자의 알림 페이지
+   */
+  @Query("select n from Notification n where n.user.id = :userId")
+  Page<Notification> findByUserId(@Param("userId") Long userId, Pageable pageable);
 }

--- a/src/main/java/com/remake/gone/notification/service/NotificationService.java
+++ b/src/main/java/com/remake/gone/notification/service/NotificationService.java
@@ -1,24 +1,38 @@
 package com.remake.gone.notification.service;
 
+import com.remake.gone.common.exception.CustomException;
+import com.remake.gone.common.response.PageResponse;
+import com.remake.gone.notification.dto.NotificationResponse;
 import com.remake.gone.notification.entity.Notification;
 import com.remake.gone.notification.enums.NotificationType;
+import com.remake.gone.notification.exception.NotificationErrorCode;
 import com.remake.gone.notification.repository.NotificationRepository;
 import com.remake.gone.user.entity.User;
 import com.remake.gone.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 /**
- * 알림 저장을 전담하는 공통 발송 모듈.
+ * 알림 저장과 조회를 처리하는 서비스.
  *
  * <p>다른 도메인은 이 빈을 주입받아 {@link #send}만 호출하면 알림 저장이 끝난다. 저장 실패는
  * 그대로 예외로 전파한다 — 알림 저장은 이 모듈의 핵심 책임이라, 호출자(향후 {@code outing}/
  * {@code schoolcamp}) 트랜잭션과 함께 롤백되는 게 맞는 동작이다(마스터 기획서 "정책 가정"
- * 참고). FCM 발송(2단계), 조회/읽음 처리 API(후속 이슈)는 이 이슈 범위 밖이다.
+ * 참고). FCM 발송(후속 이슈)은 이 이슈 범위 밖이다.
  */
 @Service
 @RequiredArgsConstructor
 public class NotificationService {
+
+  private static final int MIN_PAGE_SIZE = 1;
+  private static final int MAX_PAGE_SIZE = 100;
+  private static final Sort LIST_QUERY_SORT = Sort.by(
+      Sort.Order.desc("createdAt"), Sort.Order.desc("id"));
 
   private final NotificationRepository notificationRepository;
   private final UserRepository userRepository;
@@ -45,5 +59,29 @@ public class NotificationService {
         .isRead(false)
         .build();
     notificationRepository.save(notification);
+  }
+
+  /**
+   * 현재 사용자가 받은 알림을 최신순으로 페이지 조회합니다.
+   *
+   * @param userId 현재 인증 사용자 ID
+   * @param page   페이지 번호(0부터 시작)
+   * @param size   페이지 크기(1~100)
+   * @return 페이지네이션된 알림 목록
+   */
+  @Transactional(readOnly = true)
+  public PageResponse<NotificationResponse> getNotifications(Long userId, int page, int size) {
+    validatePageParams(page, size);
+    Pageable pageable = PageRequest.of(page, size, LIST_QUERY_SORT);
+    Page<NotificationResponse> notifications = notificationRepository
+        .findByUserId(userId, pageable)
+        .map(NotificationResponse::from);
+    return PageResponse.of(notifications);
+  }
+
+  private void validatePageParams(int page, int size) {
+    if (page < 0 || size < MIN_PAGE_SIZE || size > MAX_PAGE_SIZE) {
+      throw new CustomException(NotificationErrorCode.INVALID_PAGE_PARAMS);
+    }
   }
 }

--- a/src/test/java/com/remake/gone/notification/controller/NotificationControllerTest.java
+++ b/src/test/java/com/remake/gone/notification/controller/NotificationControllerTest.java
@@ -1,0 +1,50 @@
+package com.remake.gone.notification.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import com.remake.gone.common.response.ApiResponse;
+import com.remake.gone.common.response.PageResponse;
+import com.remake.gone.common.security.UserPrincipal;
+import com.remake.gone.notification.dto.NotificationResponse;
+import com.remake.gone.notification.enums.NotificationType;
+import com.remake.gone.notification.service.NotificationService;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+/**
+ * {@link NotificationController}에 대한 웹 계층(슬라이스) 테스트.
+ */
+@WebMvcTest(NotificationController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class NotificationControllerTest {
+
+  @MockitoBean
+  private NotificationService notificationService;
+
+  @Test
+  @DisplayName("인증된 사용자의 userId와 페이지 조건을 서비스에 전달한다")
+  void callsServiceWithAuthenticatedUserAndPageRequest() {
+    UserPrincipal principal = new UserPrincipal(1L);
+    PageResponse<NotificationResponse> expected = new PageResponse<>(
+        List.of(new NotificationResponse(
+            1L, "알림", "내용", NotificationType.OUTING, false,
+            LocalDateTime.of(2026, 8, 31, 9, 0))),
+        1, 10, 1, 1, false);
+    given(notificationService.getNotifications(1L, 1, 10)).willReturn(expected);
+    NotificationController controller = new NotificationController(notificationService);
+
+    ApiResponse<PageResponse<NotificationResponse>> response =
+        controller.getNotifications(principal, 1, 10);
+
+    assertThat(response.success()).isTrue();
+    assertThat(response.data()).isEqualTo(expected);
+    verify(notificationService).getNotifications(1L, 1, 10);
+  }
+}

--- a/src/test/java/com/remake/gone/notification/controller/NotificationControllerTest.java
+++ b/src/test/java/com/remake/gone/notification/controller/NotificationControllerTest.java
@@ -1,50 +1,76 @@
 package com.remake.gone.notification.controller;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.remake.gone.common.response.ApiResponse;
-import com.remake.gone.common.response.PageResponse;
-import com.remake.gone.common.security.UserPrincipal;
-import com.remake.gone.notification.dto.NotificationResponse;
-import com.remake.gone.notification.enums.NotificationType;
-import com.remake.gone.notification.service.NotificationService;
-import java.time.LocalDateTime;
-import java.util.List;
+import com.remake.gone.common.security.JwtProvider;
+import java.util.Set;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
-import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
 
 /**
- * {@link NotificationController}에 대한 웹 계층(슬라이스) 테스트.
+ * {@link NotificationController}의 HTTP·인증 통합 테스트.
+ *
+ * <p>실제 Spring Security 필터 체인과 {@code @AuthenticationPrincipal}을 거쳐, 인증·요청
+ * 파라미터 바인딩·예외 응답을 함께 검증합니다.
  */
-@WebMvcTest(NotificationController.class)
-@AutoConfigureMockMvc(addFilters = false)
+@SpringBootTest
+@AutoConfigureMockMvc
 class NotificationControllerTest {
 
-  @MockitoBean
-  private NotificationService notificationService;
+  @Autowired
+  private MockMvc mockMvc;
+
+  @Autowired
+  private JwtProvider jwtProvider;
 
   @Test
-  @DisplayName("인증된 사용자의 userId와 페이지 조건을 서비스에 전달한다")
-  void callsServiceWithAuthenticatedUserAndPageRequest() {
-    UserPrincipal principal = new UserPrincipal(1L);
-    PageResponse<NotificationResponse> expected = new PageResponse<>(
-        List.of(new NotificationResponse(
-            1L, "알림", "내용", NotificationType.OUTING, false,
-            LocalDateTime.of(2026, 8, 31, 9, 0))),
-        1, 10, 1, 1, false);
-    given(notificationService.getNotifications(1L, 1, 10)).willReturn(expected);
-    NotificationController controller = new NotificationController(notificationService);
+  @DisplayName("인증된 사용자가 기본 페이지 조건으로 알림 목록을 조회하면 200을 반환한다")
+  void returns200ForAuthenticatedUser() throws Exception {
+    String token = jwtProvider.createAccessToken(1L, Set.of("STUDENT"));
 
-    ApiResponse<PageResponse<NotificationResponse>> response =
-        controller.getNotifications(principal, 1, 10);
+    mockMvc.perform(get("/api/v1/notifications")
+            .header("Authorization", "Bearer " + token))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.success").value(true))
+        .andExpect(jsonPath("$.data.page").value(0))
+        .andExpect(jsonPath("$.data.size").value(20));
+  }
 
-    assertThat(response.success()).isTrue();
-    assertThat(response.data()).isEqualTo(expected);
-    verify(notificationService).getNotifications(1L, 1, 10);
+  @Test
+  @DisplayName("페이지 번호가 음수면 400 NOTIFICATION_003을 반환한다")
+  void returns400ForNegativePage() throws Exception {
+    String token = jwtProvider.createAccessToken(1L, Set.of("STUDENT"));
+
+    mockMvc.perform(get("/api/v1/notifications")
+            .param("page", "-1")
+            .header("Authorization", "Bearer " + token))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.code").value("NOTIFICATION_003"));
+  }
+
+  @Test
+  @DisplayName("페이지 크기가 범위를 벗어나면 400 NOTIFICATION_003을 반환한다")
+  void returns400ForInvalidSize() throws Exception {
+    String token = jwtProvider.createAccessToken(1L, Set.of("STUDENT"));
+
+    mockMvc.perform(get("/api/v1/notifications")
+            .param("size", "101")
+            .header("Authorization", "Bearer " + token))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.code").value("NOTIFICATION_003"));
+  }
+
+  @Test
+  @DisplayName("인증 없이 요청하면 401 COMMON_002를 반환한다")
+  void returns401WithoutToken() throws Exception {
+    mockMvc.perform(get("/api/v1/notifications"))
+        .andExpect(status().isUnauthorized())
+        .andExpect(jsonPath("$.code").value("COMMON_002"));
   }
 }

--- a/src/test/java/com/remake/gone/notification/service/NotificationServiceTest.java
+++ b/src/test/java/com/remake/gone/notification/service/NotificationServiceTest.java
@@ -1,13 +1,22 @@
 package com.remake.gone.notification.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
+import com.remake.gone.common.exception.CustomException;
+import com.remake.gone.common.response.PageResponse;
+import com.remake.gone.notification.dto.NotificationResponse;
+import com.remake.gone.notification.entity.Notification;
 import com.remake.gone.notification.enums.NotificationType;
 import com.remake.gone.notification.repository.NotificationRepository;
 import com.remake.gone.user.entity.User;
 import com.remake.gone.user.repository.UserRepository;
+import java.time.LocalDateTime;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -15,6 +24,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 
 /**
  * {@link NotificationService}에 대한 단위 테스트.
@@ -32,6 +44,65 @@ class NotificationServiceTest {
 
   @InjectMocks
   private NotificationService notificationService;
+
+  @Nested
+  @DisplayName("getNotifications")
+  class GetNotifications {
+
+    @Test
+    @DisplayName("사용자 ID와 페이지 조건으로 최신순 알림을 조회한다")
+    void returnsNotificationsPage() {
+      Notification notification = mock(Notification.class);
+      given(notification.getId()).willReturn(10L);
+      given(notification.getTitle()).willReturn("외출증 승인");
+      given(notification.getBody()).willReturn("외출증이 승인되었습니다.");
+      given(notification.getType()).willReturn(NotificationType.OUTING);
+      given(notification.isRead()).willReturn(false);
+      given(notification.getCreatedAt()).willReturn(LocalDateTime.of(2026, 8, 31, 9, 0));
+      PageRequest pageable = PageRequest.of(0, 20, Sort.by(
+          Sort.Order.desc("createdAt"), Sort.Order.desc("id")));
+      given(notificationRepository.findByUserId(1L, pageable))
+          .willReturn(new PageImpl<>(List.of(notification), pageable, 1));
+
+      PageResponse<NotificationResponse> response = notificationService.getNotifications(1L, 0, 20);
+
+      assertThat(response.content()).containsExactly(new NotificationResponse(
+          10L, "외출증 승인", "외출증이 승인되었습니다.", NotificationType.OUTING, false,
+          LocalDateTime.of(2026, 8, 31, 9, 0)));
+      assertThat(response.page()).isZero();
+      assertThat(response.size()).isEqualTo(20);
+      assertThat(response.totalElements()).isOne();
+      assertThat(response.hasNext()).isFalse();
+      verify(notificationRepository).findByUserId(1L, pageable);
+    }
+
+    @Test
+    @DisplayName("페이지 번호가 음수면 NOTIFICATION_003 예외를 던진다")
+    void rejectsNegativePage() {
+      assertThatThrownBy(() -> notificationService.getNotifications(1L, -1, 20))
+          .isInstanceOf(CustomException.class)
+          .extracting("errorCode.code")
+          .isEqualTo("NOTIFICATION_003");
+    }
+
+    @Test
+    @DisplayName("페이지 크기가 100을 초과하면 NOTIFICATION_003 예외를 던진다")
+    void rejectsOversizedPage() {
+      assertThatThrownBy(() -> notificationService.getNotifications(1L, 0, 101))
+          .isInstanceOf(CustomException.class)
+          .extracting("errorCode.code")
+          .isEqualTo("NOTIFICATION_003");
+    }
+
+    @Test
+    @DisplayName("페이지 크기가 1보다 작으면 NOTIFICATION_003 예외를 던진다")
+    void rejectsEmptyPage() {
+      assertThatThrownBy(() -> notificationService.getNotifications(1L, 0, 0))
+          .isInstanceOf(CustomException.class)
+          .extracting("errorCode.code")
+          .isEqualTo("NOTIFICATION_003");
+    }
+  }
 
   @Nested
   @DisplayName("send")
@@ -62,8 +133,7 @@ class NotificationServiceTest {
 
       notificationService.send(USER_ID, "제목", "본문", null);
 
-      verify(notificationRepository).save(argThat(notification ->
-          notification.getType() == null));
+      verify(notificationRepository).save(argThat(notification -> notification.getType() == null));
     }
   }
 }


### PR DESCRIPTION
## 관련 이슈
closes #119

## 작업 내용
- 인증된 사용자의 알림 목록 조회 API를 구현했습니다.
- `GET /api/v1/notifications?page=0&size=20`

## 변경 사항 상세
- `NotificationController`와 목록 조회 응답 DTO를 추가했습니다.
- 사용자 ID 조건의 DB 페이지네이션 조회를 추가했습니다.
- 최신순 정렬(`createdAt DESC`, `id DESC`)을 적용했습니다.
- 페이지 파라미터 검증과 `NOTIFICATION_003` 에러 코드를 추가했습니다.
- `/api/v1/notifications/**` 인증을 적용했습니다.
- 정상 조회 및 페이지 파라미터 예외 테스트를 추가했습니다.

## 확인 사항
- [x] 로컬 빌드/테스트 통과 (`./gradlew check`)
- [x] Checkstyle 통과 (`./gradlew checkstyleMain`)
- [ ] CI(checkstyle, build-and-test) 통과
- [ ] (해당 시) Notion 기능정의서/기획 문서 반영
- [ ] (해당 시) 관련 도메인 라벨 지정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an authenticated API for retrieving a user’s notification history.
  * Supports paginated results with newest notifications first, defaulting to 20 items per page.
  * Responses include notification details, read status, type, and creation time.

* **Bug Fixes**
  * Added validation for page and size parameters, with clear errors for invalid values.

* **Documentation**
  * Added design documentation covering the notification list API, security, pagination, and testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->