### PR TITLE
fix(chore): #135 self-assign 워크플로우가 여러 명 자동 배정을 막던 문제 수정

### DIFF
--- a/.github/workflows/self-assign.yml
+++ b/.github/workflows/self-assign.yml
@@ -38,13 +38,15 @@ jobs:
             // 작성자 본인이 이미 담당자인 경우"(같은 사람이 /assign을 다시 입력)로만 한정한다.
             const alreadySelfAssigned = (issue.assignees || []).some((a) => a.login === commenter);
             if (alreadySelfAssigned) {
+              // 아래 코멘트 작성이 실패(이슈 잠김, secondary rate limit 등)해도 Discord
+              // 알림은 별개로 나가야 하므로, exportVariable을 먼저 호출해둔다.
+              core.exportVariable('ASSIGN_STATUS', 'skipped');
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: issue.number,
                 body: `@${commenter}님은 이미 이 이슈의 담당자로 배정되어 있습니다.`,
               });
-              core.exportVariable('ASSIGN_STATUS', 'skipped');
               return;
             }
 
@@ -83,8 +85,8 @@ jobs:
             skipped)
               TITLE="ℹ️ 이슈 배정 요청 — 이미 본인이 담당자"
               COLOR=3447003
-              DETAIL_NAME="요청자"
-              DETAIL_VALUE="@${COMMENTER} — 이미 이 이슈의 담당자임"
+              DETAIL_NAME="배정 상태"
+              DETAIL_VALUE="이미 이 이슈의 담당자임"
               ;;
             failed)
               TITLE="⚠️ 이슈 자동 배정 실패 (배정 불가 사용자)"

--- a/.github/workflows/self-assign.yml
+++ b/.github/workflows/self-assign.yml
@@ -33,19 +33,18 @@ jobs:
             core.exportVariable('COMMENTER', commenter);
             core.exportVariable('COMMENT_URL', context.payload.comment.html_url);
 
-            // 같은 이슈에 담당자가 이미 있어도, 이 프로젝트는 이슈 1개에 여러 담당자를
-            // 두는 것을 허용한다. 다만 /assign 자동 배정은 "담당자가 아직 없을 때"만
-            // 동작하고, 이미 있으면 추가로 배정하지 않고 안내 코멘트만 남긴다.
-            if (issue.assignees && issue.assignees.length > 0) {
-              const names = issue.assignees.map((a) => `@${a.login}`).join(', ');
+            // 이 프로젝트는 이슈 1개에 여러 담당자를 두는 것을 허용하므로, 다른 사람이
+            // 이미 배정되어 있어도 /assign 자동 배정을 막지 않는다. 스킵은 "코멘트
+            // 작성자 본인이 이미 담당자인 경우"(같은 사람이 /assign을 다시 입력)로만 한정한다.
+            const alreadySelfAssigned = (issue.assignees || []).some((a) => a.login === commenter);
+            if (alreadySelfAssigned) {
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: issue.number,
-                body: `이미 담당자(${names})가 배정되어 있어 자동 배정을 건너뜁니다.`,
+                body: `@${commenter}님은 이미 이 이슈의 담당자로 배정되어 있습니다.`,
               });
               core.exportVariable('ASSIGN_STATUS', 'skipped');
-              core.exportVariable('EXISTING_ASSIGNEES', names);
               return;
             }
 
@@ -82,10 +81,10 @@ jobs:
               DETAIL_VALUE="@${COMMENTER}"
               ;;
             skipped)
-              TITLE="ℹ️ 이슈 배정 요청 — 이미 담당자 있음"
+              TITLE="ℹ️ 이슈 배정 요청 — 이미 본인이 담당자"
               COLOR=3447003
-              DETAIL_NAME="기존 담당자"
-              DETAIL_VALUE="${EXISTING_ASSIGNEES}"
+              DETAIL_NAME="요청자"
+              DETAIL_VALUE="@${COMMENTER} — 이미 이 이슈의 담당자임"
               ;;
             failed)
               TITLE="⚠️ 이슈 자동 배정 실패 (배정 불가 사용자)"

--- a/docs/domain/chore/135-chore-self-assign-multi-assignee-code-review.md
+++ b/docs/domain/chore/135-chore-self-assign-multi-assignee-code-review.md
@@ -1,0 +1,50 @@
+# #135 self-assign 다중 담당자 배정 — 코드 리뷰 결과
+
+리뷰 대상: `fix/#135-self-assign-multi-assignee` 브랜치, `.github/workflows/self-assign.yml`
+리뷰 방법: 컨텍스트가 격리된 code-reviewer 에이전트에게 위임. YAML 파싱, 임베디드
+github-script JS `node --check`, `run:` 블록 `bash -n`, `ASSIGN_STATUS` 5개 분기 전부
+실제 실행해 jq 페이로드 생성 확인, 레포 전체 `EXISTING_ASSIGNEES` 잔존 참조 grep을 수행함.
+
+## 요약
+Critical/High 없음. Medium 3건 중 이번 diff가 만든 회귀 2건은 반영 완료. 나머지 1건과
+Low 6건은 기존부터 있던 이슈이거나 이번 수정 범위 밖이라 별도 이슈로 분리함(아래 참고).
+
+## 반영 완료
+
+### 1. 🟡 Medium — Discord 임베드 필드 이름 중복 (이번 diff가 만든 회귀)
+
+**문제**: skipped 분기의 `DETAIL_NAME`을 기존 `"기존 담당자"`에서 `"요청자"`로 바꾸면서,
+이미 하드코딩된 `{name: "요청자", value: "@$actor"}`(self-assign.yml:126)와 이름이
+겹쳐 같은 임베드에 "요청자" 필드가 두 번 나타남.
+
+**해결 방안**: DETAIL_NAME을 `"배정 상태"`로, DETAIL_VALUE를 `"이미 이 이슈의 담당자임"`으로
+바꿔 124번째 줄 필드와 겹치지 않게 함. (반영: `04638fa`)
+
+### 2. 🟡 Medium — 스킵 분기의 `createComment`가 try/catch 밖에 있어 실패 시 알림 자체가 생략됨
+
+**문제**: `createComment`가 던지면(이슈 잠김, secondary rate limit 등)
+`core.exportVariable('ASSIGN_STATUS', 'skipped')`에 도달하지 못해 `ASSIGN_STATUS`가
+비어버리고, 알림 스텝의 `*)` 분기가 `exit 0`으로 조용히 끝나 Discord 알림이 아예 안 감.
+
+**해결 방안**: `exportVariable` 호출을 `createComment` 호출 앞으로 옮김 — 코멘트 작성
+성공 여부와 무관하게 배정 판정(스킵) 자체는 이미 끝난 상태이므로 상태값을 먼저 확정.
+(반영: `04638fa`)
+
+## 별도 이슈로 분리 (이번 PR 범위 밖)
+
+### 3. 🟡 Medium — `failed` 상태 메시지가 "권한 없음"으로 원인을 단정
+GitHub은 이슈당 담당자 최대 10명 제한이 있고 초과분도 조용히 무시한다. 다중 배정 경로가
+열린 지금은 이 상한 초과도 `failed`의 실제 발생 가능한 원인이 되는데, 메시지는 "레포
+write 권한 없음 등"으로 고정되어 있어 오진단 소지가 있음. `failed`일 때 이슈 코멘트가
+전혀 남지 않는 것도 함께 검토 필요.
+
+### 4~9. 🟢 Low (전부 기존 이슈이거나 이번 변경과 무관)
+- `/assign @다른사람` 시 코멘트 작성자가 배정됨(경고 없음) — self-assign 설계상 의도된
+  동작이나 다중 담당자 허용 후 혼동 가능성 커짐
+- 로그인 비교 대소문자 구분 (`a.login === commenter`)
+- payload 스냅샷 staleness로 인한 중복 알림 가능성 (연속 `/assign` 시)
+- Discord 임베드 마크다운 링크 스푸핑 (이슈 제목에 마크다운 삽입 가능)
+- 퍼블릭 레포 + `issue_comment` 트리거로 인한 Discord 웹훅 알림 스팸 벡터 (권한 상승 없음)
+- `ERROR_MESSAGE` 길이 무제한 (Discord 필드 1024자 제한 초과 시 알림 유실)
+
+이 중 우선순위가 있다고 판단되면 후속 이슈로 등록.


### PR DESCRIPTION
## 관련 이슈
closes #135

## 작업 내용
`/assign` 자동 배정 워크플로우가 이슈에 담당자가 1명이라도 있으면 이후 다른 사람의 `/assign` 코멘트를 전부 스킵하던 문제를 고친다. 스킵 조건을 "이슈에 담당자가 있으면"에서 "코멘트 작성자 본인이 이미 담당자면"으로 좁혀, 서로 다른 사람이 각자 `/assign`을 달면 전부 자동 배정되게 한다.

## 변경 사항 상세
- `.github/workflows/self-assign.yml`: 스킵 판정을 `issue.assignees.length > 0`에서 `issue.assignees`에 커멘터 본인이 포함되는지로 변경
- 격리된 code-reviewer 에이전트 리뷰에서 나온 Medium 2건(이번 diff가 만든 회귀) 반영:
  - Discord 임베드 skipped 분기의 `DETAIL_NAME`이 기존 "요청자" 필드와 이름이 겹치던 문제 → "배정 상태"로 변경
  - 스킵 분기의 안내 코멘트 작성이 실패해도 `ASSIGN_STATUS`는 먼저 설정되도록 순서 변경(실패 시 Discord 알림 자체가 조용히 생략되는 경로 제거)
- 코드 리뷰 결과 전체는 `docs/domain/chore/135-chore-self-assign-multi-assignee-code-review.md` 참고 (Medium 1건 + Low 6건은 이번 수정 범위 밖이라 후속 이슈로 분리)

## 확인 사항
- [ ] 로컬 빌드 통과 (`./gradlew build`) — 해당 없음(Java 코드 변경 없음, YAML/워크플로우 스크립트만 변경)
- [ ] Checkstyle 통과 (`./gradlew checkstyleMain`) — 해당 없음
- [x] CI(checkstyle, build-and-test) 통과
- [ ] (해당 시) Notion 기능정의서/기획 문서 반영 — 해당 없음(도메인 API 아님)
- [x] (해당 시) 관련 도메인 라벨 지정 (chore)
- [ ] 관련 마일스톤 지정 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Issue self-assignment now allows additional assignees when the commenter is not already assigned.
  - Skip notifications now correctly indicate when the requester is already assigned.
  - Assignment status is preserved when posting an explanatory comment fails.
  - Corrected duplicate field names in Discord notifications.

- **Documentation**
  - Added a Korean code-review report covering validation results, resolved regressions, and remaining follow-up issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->