### PR TITLE
fix(common): #141 ScheduledTaskExecutor 핸들러 미등록 시 즉시 FAILED 격리

### DIFF
--- a/docs/domain/common/141-common-scheduled-task-handler-missing-QA.md
+++ b/docs/domain/common/141-common-scheduled-task-handler-missing-QA.md
@@ -10,6 +10,8 @@
 
 1. `./gradlew checkstyleMain checkstyleTest` — 통과.
 2. `./gradlew test --tests ScheduledTaskExecutorTest` — 변경된 테스트 포함 4건 전부 통과.
+   (PR #145 CodeRabbit 지적 반영 후) `./gradlew test --tests
+   ScheduledTaskExecutorIntegrationTest` — 신규 폴링 제외 테스트 포함 4건 전부 통과.
 3. `./gradlew build`(checkstyle + 전체 테스트 607건) — 1건 실패
    (`OutingLocationReminderConcurrencyIntegrationTest.onlyOneNotificationSentWhenConcurrentPingsWithinSchoolRadius`,
    `RedisConnectionFailureException: Unable to connect to Redis`). 이번 변경과 무관한
@@ -26,9 +28,12 @@
    - `ScheduledTaskRepository.findDueTaskIds(PENDING, now+10분)` 조회 결과에 해당
      task id가 더 이상 포함되지 않음 — 다음 폴링 틱부터 재claim되지 않는다는 기획서
      주장이 실제 DB 조회로 확인됨.
-   - 이 검증은 QA 목적의 임시 테스트 파일로 실행 후 즉시 삭제했다(커밋되지 않음) —
-     기획서 "영향받는 기존 코드/테스트" 절이 명시한 범위(`ScheduledTaskExecutorTest`)를
-     벗어나는 신규 테스트를 영구 반영하지 않기 위함.
+   - (PR #145 CodeRabbit 지적 반영) 이 검증은 최초에는 QA 목적의 임시 테스트 파일로
+     실행 후 삭제했었으나, "폴링 제외"라는 핵심 동작이 커밋된 테스트로 고정돼 있지
+     않다는 지적에 따라 `ScheduledTaskExecutorIntegrationTest`에
+     `excludesTaskFromPollingAfterMarkedFailedForMissingHandler()`로 정식 반영했다 —
+     handler 미등록 task를 실제로 등록·실행한 뒤 `findDueTaskIds` 결과에서 빠지는지까지
+     같은 테스트에서 검증한다.
 5. **CI(GitHub Actions) 확인은 이번 QA에서 생략했다.** 이 저장소 CI는 `dev`/`main`/`staging`
    대상 `pull_request` 또는 그 브랜치로의 `push`에서만 트리거되어, feature 브랜치 push만으로는
    확인할 수 없다. CI 확인용 draft PR을 열지 여부를 보스에게 확인했고, 보스가 명시적으로
@@ -43,6 +48,11 @@
 
 ## 결론
 handler 미등록 시 즉시 `FAILED`로 격리되고 이후 폴링에서 빠진다는 기획서의 핵심 동작을
-실제 DB/트랜잭션 경로로 재현·확인했다. 코드 리뷰(9단계)와 로컬 빌드(체크스타일 전체
-통과, 관련 테스트 전체 통과)까지 완료되어 이 이슈의 완료 조건(Definition of Done: 로컬
-빌드/테스트 통과, CI 통과)에서 CI 통과 확인만 16단계 PR 생성 시점으로 남는다.
+실제 DB/트랜잭션 경로로 재현·확인했다. 코드 리뷰(9단계)와 관련 테스트(체크스타일,
+`ScheduledTaskExecutorTest`, `common/schedule` 패키지 전체)는 통과했다.
+
+다만 이 이슈의 완료 조건(Definition of Done: 로컬 빌드 전체 통과, CI 통과)은 아직
+**충족되지 않았다** — `./gradlew build`가 1건 실패했고(위 3번, 이번 변경과 무관하다고
+판단은 했으나 전체 빌드 자체는 실패), CI 확인은 이번 QA에서 생략했다. 두 항목 모두
+16단계 PR 생성 후 실제 CI 결과로 확인되기 전까지는 이 이슈를 **완료로 처리하지 않고
+보류(pending) 상태로 둔다.**

--- a/docs/domain/common/141-common-scheduled-task-handler-missing-QA.md
+++ b/docs/domain/common/141-common-scheduled-task-handler-missing-QA.md
@@ -1,0 +1,48 @@
+# #141 ScheduledTaskExecutor 핸들러 미등록 시 즉시 FAILED 격리 — QA 결과
+
+관련 기획서: [141-common-scheduled-task-handler-missing.md](./141-common-scheduled-task-handler-missing.md)
+관련 코드 리뷰: [141-common-scheduled-task-handler-missing-code-review.md](./141-common-scheduled-task-handler-missing-code-review.md)
+(9단계 코드 리뷰 지적 사항 없음 — 이 문서는 QA에서 새로 확인한 내용만 다룬다)
+
+## 검증 방법/범위
+이 이슈는 새 HTTP 엔드포인트가 없는 내부 로직 수정이라(기획서 "개요/목적" 참고),
+엔드포인트별 정상/에러 케이스 검증 대신 아래 순서로 확인했다.
+
+1. `./gradlew checkstyleMain checkstyleTest` — 통과.
+2. `./gradlew test --tests ScheduledTaskExecutorTest` — 변경된 테스트 포함 4건 전부 통과.
+3. `./gradlew build`(checkstyle + 전체 테스트 607건) — 1건 실패
+   (`OutingLocationReminderConcurrencyIntegrationTest.onlyOneNotificationSentWhenConcurrentPingsWithinSchoolRadius`,
+   `RedisConnectionFailureException: Unable to connect to Redis`). 이번 변경과 무관한
+   기존 테스트다 — 스택트레이스에 `schedule` 패키지 코드가 전혀 없고, 원인은 로컬
+   환경에 Redis가 떠 있지 않아서다(outing 위치 알림 동시성 테스트가 Redis에 의존).
+   `common/schedule` 관련 테스트 전부(단위+통합)는 이 실패와 무관하게 전부 통과했다.
+4. **실제 DB/트랜잭션 검증**: `@SpringBootTest` 컨텍스트에서 `ScheduledTaskService.schedule()`로
+   존재하지 않는 taskType(`QA_141_UNKNOWN_TYPE`)의 task를 실제로 등록한 뒤
+   `ScheduledTaskExecutor.execute()`를 직접 호출해, `ScheduledTaskExecutionStore`의 실제
+   `REQUIRES_NEW` 트랜잭션 경로를 통해 DB에 반영되는지 확인했다.
+   - 실행 직후 재조회 결과: `status=FAILED`, `failureCount=1`,
+     `lastError`에 taskType 포함(`"등록된 ScheduledTaskHandler가 없습니다:
+     taskType=QA_141_UNKNOWN_TYPE"`).
+   - `ScheduledTaskRepository.findDueTaskIds(PENDING, now+10분)` 조회 결과에 해당
+     task id가 더 이상 포함되지 않음 — 다음 폴링 틱부터 재claim되지 않는다는 기획서
+     주장이 실제 DB 조회로 확인됨.
+   - 이 검증은 QA 목적의 임시 테스트 파일로 실행 후 즉시 삭제했다(커밋되지 않음) —
+     기획서 "영향받는 기존 코드/테스트" 절이 명시한 범위(`ScheduledTaskExecutorTest`)를
+     벗어나는 신규 테스트를 영구 반영하지 않기 위함.
+5. **CI(GitHub Actions) 확인은 이번 QA에서 생략했다.** 이 저장소 CI는 `dev`/`main`/`staging`
+   대상 `pull_request` 또는 그 브랜치로의 `push`에서만 트리거되어, feature 브랜치 push만으로는
+   확인할 수 없다. CI 확인용 draft PR을 열지 여부를 보스에게 확인했고, 보스가 명시적으로
+   거부했다(불필요하다는 판단) — 16단계에서 실제 PR을 생성하면 그때 CI 결과가 자연히
+   확인된다.
+
+## 발견 사항
+- **Critical/High**: 없음.
+- **Medium**: 없음 (위 3번 Redis 테스트 실패는 이번 변경과 무관한 기존 환경 제약이라
+  이 이슈의 발견 사항으로 집계하지 않는다).
+- **Low**: 없음.
+
+## 결론
+handler 미등록 시 즉시 `FAILED`로 격리되고 이후 폴링에서 빠진다는 기획서의 핵심 동작을
+실제 DB/트랜잭션 경로로 재현·확인했다. 코드 리뷰(9단계)와 로컬 빌드(체크스타일 전체
+통과, 관련 테스트 전체 통과)까지 완료되어 이 이슈의 완료 조건(Definition of Done: 로컬
+빌드/테스트 통과, CI 통과)에서 CI 통과 확인만 16단계 PR 생성 시점으로 남는다.

--- a/docs/domain/common/141-common-scheduled-task-handler-missing-code-review.md
+++ b/docs/domain/common/141-common-scheduled-task-handler-missing-code-review.md
@@ -3,8 +3,9 @@
 관련 기획서: [141-common-scheduled-task-handler-missing.md](./141-common-scheduled-task-handler-missing.md)
 
 ## 리뷰 범위/방법
-- 대상: `git diff dev...HEAD` (fix/#141-scheduled-task-handler-missing 브랜치가 dev에서
-  분기된 이후 전체 변경, 4 files changed, 106 insertions, 5 deletions):
+- 대상: `git diff dev...HEAD` 중 구현 diff만 (fix/#141-scheduled-task-handler-missing
+  브랜치가 dev에서 분기된 이후 전체 변경 중 아래 4개 파일, 106 insertions, 5 deletions —
+  이 문서와 QA 결과 문서는 리뷰 대상 diff 이후에 추가되어 집계에서 제외):
   - `docs/domain/common/141-common-scheduled-task-handler-missing.md` (신규 기획서)
   - `src/main/java/com/remake/gone/common/schedule/service/RetryPolicy.java`
   - `src/main/java/com/remake/gone/common/schedule/service/ScheduledTaskExecutor.java`

--- a/docs/domain/common/141-common-scheduled-task-handler-missing-code-review.md
+++ b/docs/domain/common/141-common-scheduled-task-handler-missing-code-review.md
@@ -1,0 +1,91 @@
+# #141 ScheduledTaskExecutor 핸들러 미등록 무한 재시도 수정 — 코드 리뷰 결과
+
+관련 기획서: [141-common-scheduled-task-handler-missing.md](./141-common-scheduled-task-handler-missing.md)
+
+## 리뷰 범위/방법
+- 대상: `git diff dev...HEAD` (fix/#141-scheduled-task-handler-missing 브랜치가 dev에서
+  분기된 이후 전체 변경, 4 files changed, 106 insertions, 5 deletions):
+  - `docs/domain/common/141-common-scheduled-task-handler-missing.md` (신규 기획서)
+  - `src/main/java/com/remake/gone/common/schedule/service/RetryPolicy.java`
+  - `src/main/java/com/remake/gone/common/schedule/service/ScheduledTaskExecutor.java`
+  - `src/test/java/com/remake/gone/common/schedule/service/ScheduledTaskExecutorTest.java`
+- 방법: 구현 과정의 대화/추론은 전달받지 않고, 기획서와 diff만으로 독립적으로 점검했다.
+  - 기획서에서 "승인된 범위"(handler 미등록 시 `RetryPolicy.NON_RETRYABLE`로 즉시 FAILED
+    격리, 새 상태값·API 변경 없음)를 먼저 파악한 뒤 diff가 그 범위를 벗어나는지 확인.
+  - `docs/rules/code-style.md`, `docs/rules/test-convention.md`와 대조해 컨벤션 준수 여부
+    확인.
+  - 로직 확인을 위해 `ScheduledTask.markFailed()`(`entity/ScheduledTask.java:182-201`),
+    `ScheduledTaskExecutionStore.recordFailure/claim/executeAndRecordSuccess`,
+    `ScheduledTaskRepository.findDueTaskIds`(`status = :status` 조건, PENDING만 조회)를
+    함께 읽고 트랜잭션 경계·상태 전이를 직접 추적.
+  - `RetryPolicy`를 참조하는 나머지 6개 파일(`ScheduledTaskHandler`,
+    `ScheduledTaskExecutionStore`, `ScheduledTask`, 관련 테스트 3개)을 grep해 다른
+    handler/도메인 코드가 `RetryPolicy`의 특정 상수 존재를 가정하고 있지 않은지 확인 —
+    각 handler는 자신의 `retryPolicy()`만 오버라이드하므로 `NON_RETRYABLE` 추가가 기존
+    handler 동작에 영향을 주지 않음을 확인.
+  - `./gradlew checkstyleMain checkstyleTest --rerun-tasks` 실행 — BUILD SUCCESSFUL
+    (경고 0건, `maxWarnings=0` 통과).
+  - `./gradlew test --tests ScheduledTaskExecutorTest --rerun-tasks` 실행 — BUILD
+    SUCCESSFUL (변경된 테스트 포함 전체 통과).
+
+## 결과: Critical/High/Medium/Low 없음
+
+기획서 범위, 컨벤션, 로직 세 축 모두에서 지적 사항을 찾지 못했다. 근거:
+
+- **범위 일치**: 기획서 "영향받는 기존 코드/테스트" 절이 명시한 3개 파일
+  (`RetryPolicy.java`, `ScheduledTaskExecutor.execute()`, `ScheduledTaskExecutorTest`)
+  외에 다른 파일 변경이 없다. 새 HTTP 엔드포인트, DB 스키마, 응답 포맷 변경 없음 — 기획서의
+  "API 계약이나 DB 스키마 변경이 없다" 서술과 일치.
+- **컨벤션 준수**:
+  - `RetryPolicy.NON_RETRYABLE`은 기존 `DEFAULT`와 동일한 패턴(정적 상수 + Javadoc)으로
+    추가됐고, 생성자 검증(`maxFailureCount <= 0` 거부, `requirePositiveWholeSeconds`)을
+    그대로 통과한다 — `new RetryPolicy(1, Duration.ofSeconds(30), Duration.ofSeconds(30))`은
+    `maxFailureCount=1 > 0`, `baseBackoff == maxBackoff`(30초, `maxBackoff >= baseBackoff`
+    조건 충족)라 예외 없이 생성된다.
+  - `ScheduledTaskExecutor.execute()`의 수정은 기존 `catch` 블록의
+    `executionStore.recordFailure(taskId, now, e.getMessage(), handler.retryPolicy())`
+    호출 패턴을 그대로 재사용했다(`ScheduledTaskExecutor.java:60-62` vs `:75`) — 새로운
+    코드 경로를 만들지 않고 기존 실패 기록 경로에 합류시킨다는 기획서 설계를 그대로
+    구현했다.
+  - 주석은 WHY 위주(예: "재시도로 해결되지 않는 구성 오류이므로 NON_RETRYABLE로 즉시
+    FAILED 격리")로 `code-style.md`의 "WHAT은 지양" 규칙에 부합한다.
+  - 테스트는 `test-convention.md`대로 `@Nested`(`EdgeCases`) + 한글
+    `@DisplayName` 구조를 유지했고, `DisplayName`을 새 동작("handler를 호출하지 않고
+    즉시 FAILED로 격리한다")에 맞게 갱신했다 — 이름과 검증 내용(`status`, `failureCount`,
+    `lastError`, `verify(handler, never()).handle(...)`)이 일치한다.
+  - checkstyle(`checkstyleMain`/`checkstyleTest`, `google_checks.xml`,
+    `maxWarnings=0`) 통과 확인 완료.
+- **로직 결함 없음**:
+  - `RetryPolicy.NON_RETRYABLE` 도입이 다른 handler에 영향을 주지 않는다 — 각 handler는
+    `retryPolicy()`를 개별적으로 오버라이드하거나 `DEFAULT`를 쓰며, `NON_RETRYABLE`은
+    `ScheduledTaskExecutor.execute()`의 `handler == null` 분기에서만 참조된다
+    (`ScheduledTaskExecutor.java:60-62`). `Map<String, ScheduledTaskHandler> handlers`
+    조회/매핑 로직 자체는 변경되지 않았다.
+  - `ScheduledTask.markFailed(now, msg, maxFailureCount=1, ...)`는
+    `failureCount++` 후 `1 >= 1`이 참이 되어 `nextAttemptAt` 갱신 없이 곧장
+    `status=FAILED`로 전이한다(`ScheduledTask.java:185-193`). `findDueTaskIds`는
+    `status = :status`(PENDING) 조건으로만 조회하므로(`ScheduledTaskRepository.java:41`)
+    FAILED 전이 이후 다음 폴링 틱부터 이 task가 더 이상 걸리지 않는다 — 기획서가 주장한
+    "무한 재시도/로그 스팸 종료" 효과가 실제 코드 경로로 성립한다.
+  - `recordFailure`는 기존과 동일하게 `@Transactional(REQUIRES_NEW)`인
+    `ScheduledTaskExecutionStore.recordFailure`를 그대로 호출하므로
+    (`ScheduledTaskExecutor.java:60-62`), 새로운 트랜잭션 경계가 생기지 않는다 —
+    `execute()` 자신은 여전히 `@Transactional`이 아니고, `claim`/`recordFailure`는 각각
+    독립된 REQUIRES_NEW 트랜잭션이라는 클래스 설계(`ScheduledTaskExecutor.java:14-24`
+    Javadoc)가 그대로 유지된다.
+  - 새 테스트 `marksFailedImmediatelyWhenHandlerMissing`(`ScheduledTaskExecutorTest.java:
+    188-200`)은 실제로 새 동작을 검증한다: `status == FAILED`, `failureCount == 1`,
+    `lastError`에 `taskType`("UNKNOWN_TYPE") 포함, `handler.handle()`이 호출되지 않음을
+    모두 단언한다 — 이전 테스트가 `status == PENDING`을 확인하던 것과 정반대 방향으로
+    뒤집혔고, 세 단언 모두 스텁이 아닌 실제 `ScheduledTaskExecutionStore`
+    (mock 아님, mock `ScheduledTaskRepository` 위에서 실행) 경로를 거쳐 검증되므로
+    회귀를 잡을 수 있다.
+  - `./gradlew test --tests ScheduledTaskExecutorTest --rerun-tasks` 실행 결과
+    BUILD SUCCESSFUL로, 변경된 테스트를 포함해 기존 `HandleResult`/`HandleFailure`/
+    `EdgeCases` 전체가 통과함을 확인했다 — `NON_RETRYABLE` 추가나 분기 수정이 기존
+    시나리오(기본 backoff, handler별 정책 오버라이드, claim 실패/예외 등)를 깨지 않았다.
+
+## 참고: 독립 검증 에이전트 교차 확인
+`docs/rules/code-review-isolation.md`에 따라 별도로 실행한 `code-review` 스킬 기반
+독립 리뷰 에이전트도 동일한 3개 파일 + 주변 컨텍스트(엔티티/스토어/리포지토리/기획서)를
+검토한 뒤 findings 없음(빈 목록)으로 결론 내려, 이 문서의 결론과 교차 확인됐다.

--- a/docs/domain/common/141-common-scheduled-task-handler-missing.md
+++ b/docs/domain/common/141-common-scheduled-task-handler-missing.md
@@ -1,0 +1,86 @@
+# #141 ScheduledTaskExecutor 핸들러 미등록 시 무한 재시도/로그 스팸 — 기획서
+
+관련 이슈: [#141 fix(common): ScheduledTaskExecutor 핸들러 미등록 시 무한 재시도/로그 스팸](https://github.com/GBSW-ReMake/GONE-server-V1/issues/141)
+계기: PR #140 Copilot 리뷰([`ScheduledTaskExecutor.java:59`](../../../src/main/java/com/remake/gone/common/schedule/service/ScheduledTaskExecutor.java#L59))
+선행 이슈: [#120 범용 이벤트 스케줄링 인프라](./120-common-scheduled-task-infra.md),
+[#126 스케줄 task 모니터링](./126-common-scheduled-task-monitoring.md)
+
+## 개요/목적
+`ScheduledTaskExecutor.execute()`는 `claimed.taskType()`에 대응하는
+`ScheduledTaskHandler` 빈이 없으면 warn 로그만 남기고 return한다. 이때
+`ScheduledTaskExecutionStore.claim()`은 `lastAttemptedAt`만 갱신할 뿐 `status`를
+`PENDING`에서 바꾸지 않으므로(`ScheduledTaskRepository.claim()` 쿼리 참고), 이 task는
+`nextAttemptAt`도 그대로 남아 매 폴링 틱(`@Scheduled(fixedDelay=10000)`, #120)마다
+`findDueTaskIds`에 다시 걸린다. 결과적으로 claim → warn 로그 → return이 무한 반복되며,
+handler 등록 누락은 재시도로 해결되지 않는 배포 구성 오류인데도 시스템이 이를 "일시적
+실패"처럼 영원히 재시도한다. 이번 수정은 handler 미등록도 기존 실패 경로(`recordFailure`)를
+타게 하되, 재시도 자체가 무의미한 오류이므로 첫 시도에 곧장 `FAILED`로 격리한다. 새 HTTP
+엔드포인트는 없다.
+
+## 기존 로직 수정 — 변경 전/후 동작 차이
+
+**변경 전** (`ScheduledTaskExecutor.execute()`):
+```java
+ScheduledTaskHandler handler = handlers.get(claimed.taskType());
+if (handler == null) {
+  log.warn("등록된 ScheduledTaskHandler가 없습니다(taskType={})", claimed.taskType());
+  return; // status=PENDING, nextAttemptAt 그대로 → 다음 틱에 즉시 재claim
+}
+```
+
+**변경 후**: handler 미등록도 `executionStore.recordFailure(...)`를 호출해 기존
+`ScheduledTask.markFailed()` 경로(실패 카운트 증가 → `maxFailureCount` 도달 시 `FAILED`
+격리)를 그대로 재사용한다. 다만 handler 미등록은 배포 구성 오류라 재시도로 해결되지 않으므로,
+handler별 `retryPolicy()`를 조회할 handler 자체가 없는 것과 별개로 `RetryPolicy.DEFAULT`(5회
+백오프)가 아닌 `maxFailureCount=1`짜리 전용 정책(`RetryPolicy.NON_RETRYABLE`)을 써서 첫 claim에
+바로 `FAILED`로 격리한다.
+
+```java
+// RetryPolicy.java에 DEFAULT와 나란히 추가
+public static final RetryPolicy NON_RETRYABLE =
+    new RetryPolicy(1, Duration.ofSeconds(30), Duration.ofSeconds(30));
+```
+
+```java
+ScheduledTaskHandler handler = handlers.get(claimed.taskType());
+if (handler == null) {
+  log.warn("등록된 ScheduledTaskHandler가 없습니다(taskType={})", claimed.taskType());
+  executionStore.recordFailure(taskId, now,
+      "등록된 ScheduledTaskHandler가 없습니다: taskType=" + claimed.taskType(),
+      RetryPolicy.NON_RETRYABLE);
+  return;
+}
+```
+
+- `ScheduledTask.markFailed()`는 `failureCount >= maxFailureCount`가 되는 즉시
+  `nextAttemptAt`을 갱신하지 않고 `status=FAILED`로 격리한다(`ScheduledTask.java:190-193`).
+  `maxFailureCount=1`이므로 첫 실패에서 바로 이 분기를 타 별도 코드 경로 없이 즉시 격리가
+  된다 — 로그 스팸과 불필요한 재claim이 다음 폴링 틱부터 바로 멈춘다.
+- `FAILED`로 격리된 task는 #126에서 만든 관리자 모니터링 API(`GET
+  /api/v1/admin/scheduled-tasks`)에 그대로 노출된다. `lastError`에 "등록된
+  ScheduledTaskHandler가 없습니다: taskType=..." 문구가 그대로 남으므로, 별도 상태값이나
+  API 스펙 변경 없이도 배포 담당자가 "일시적 실행 실패로 인한 FAILED"와 "설정 누락으로 인한
+  FAILED"를 `lastError` 텍스트만으로 구분할 수 있다.
+- `recordFailure`는 이미 `REQUIRES_NEW` 독립 트랜잭션이라(`ScheduledTaskExecutionStore`
+  기존 구조) 이 변경으로 트랜잭션 경계가 새로 생기지 않는다.
+
+## 영향받는 기존 코드/테스트
+- `RetryPolicy.java`: `DEFAULT` 옆에 `NON_RETRYABLE`(`maxFailureCount=1`) 상수 추가
+- `ScheduledTaskExecutor.execute()`: `handler == null` 분기 수정
+- `ScheduledTaskExecutorTest`(또는 해당 테스트 클래스): handler 미등록 케이스에서
+  - 첫 claim에서 곧장 `status=FAILED`로 전환되는지
+  - `lastError`에 taskType을 포함한 안내 메시지가 남는지
+  - 이후 폴링 틱(`findDueTaskIds`)에 더 이상 잡히지 않는지
+  검증하는 테스트 추가
+
+## 리스크 및 고려사항
+- 이 변경은 순수하게 실패 격리 경로를 재사용하는 것이라 API 계약이나 DB 스키마 변경이
+  없다 — [api-design.md](../../rules/api-design.md) 6원칙 검토 대상 아님.
+- handler 미등록은 재시도로 해결되지 않는 배포 구성 오류이므로, taskType별 커스텀
+  `retryPolicy()`를 조회할 handler 자체가 없다는 점과 별개로 `maxFailureCount=1`로 즉시
+  격리하는 것이 backoff를 거치는 `RetryPolicy.DEFAULT`보다 합리적이다 — 원인이 배포
+  설정 누락이라 30초든 31분이든 기다린다고 해결되지 않는다.
+- 별도 상태값(enum) 신설은 고려하지 않는다. 지금 구분해야 할 "재시도 불가능한 설정
+  오류" 종류가 handler 미등록 하나뿐이라, 기존 `lastError` 텍스트 필드만으로 모니터링
+  구분이 충분하다 — enum·마이그레이션·`ScheduledTaskResponse`/#126 API 스펙 변경까지
+  가는 것은 이번 이슈 범위를 넘어서는 과설계다.

--- a/src/main/java/com/remake/gone/common/schedule/service/RetryPolicy.java
+++ b/src/main/java/com/remake/gone/common/schedule/service/RetryPolicy.java
@@ -40,4 +40,12 @@ public record RetryPolicy(int maxFailureCount, Duration baseBackoff, Duration ma
   /** 별도로 재정의하지 않는 모든 핸들러가 쓰는 기본값 — 5회 실패, 30초~30분 백오프. */
   public static final RetryPolicy DEFAULT =
       new RetryPolicy(5, Duration.ofSeconds(30), Duration.ofMinutes(30));
+
+  /**
+   * 재시도로 해결되지 않는 오류에 쓴다(예: handler 미등록). 첫 실패에서 곧장
+   * {@code maxFailureCount}에 도달해 {@code ScheduledTask.markFailed()}가 backoff 없이
+   * 바로 FAILED로 격리하므로, backoff 값 자체는 계산에 쓰이지 않는다.
+   */
+  public static final RetryPolicy NON_RETRYABLE =
+      new RetryPolicy(1, Duration.ofSeconds(30), Duration.ofSeconds(30));
 }

--- a/src/main/java/com/remake/gone/common/schedule/service/ScheduledTaskExecutor.java
+++ b/src/main/java/com/remake/gone/common/schedule/service/ScheduledTaskExecutor.java
@@ -53,9 +53,13 @@ public class ScheduledTaskExecutor {
     }
     ScheduledTaskHandler handler = handlers.get(claimed.taskType());
     if (handler == null) {
-      // 매핑이 없다는 건 배포 실수(핸들러 등록을 빠뜨림)일 가능성이 높다 — 다음 폴링
-      // 틱에서 다시 같은 경고가 반복되므로 로그로 바로 드러난다.
+      // 매핑이 없다는 건 배포 실수(핸들러 등록을 빠뜨림)일 가능성이 높다 — 재시도로
+      // 해결되지 않는 구성 오류이므로 NON_RETRYABLE로 즉시 FAILED 격리해, 다음 폴링
+      // 틱부터는 findDueTaskIds(status=PENDING만 조회)에 다시 걸리지 않게 한다.
       log.warn("등록된 ScheduledTaskHandler가 없습니다(taskType={})", claimed.taskType());
+      executionStore.recordFailure(taskId, now,
+          "등록된 ScheduledTaskHandler가 없습니다: taskType=" + claimed.taskType(),
+          RetryPolicy.NON_RETRYABLE);
       return;
     }
     try {

--- a/src/test/java/com/remake/gone/common/schedule/service/ScheduledTaskExecutorIntegrationTest.java
+++ b/src/test/java/com/remake/gone/common/schedule/service/ScheduledTaskExecutorIntegrationTest.java
@@ -7,6 +7,7 @@ import com.remake.gone.common.schedule.enums.ScheduledTaskStatus;
 import com.remake.gone.common.schedule.repository.ScheduledTaskRepository;
 import java.time.Duration;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.AfterEach;
@@ -43,6 +44,8 @@ class ScheduledTaskExecutorIntegrationTest {
   private static final Long SIDE_EFFECT_REFERENCE_ID = -3L;
   private static final String SIDE_EFFECT_MARK_TASK_TYPE = "QA_INTEGRATION_SIDE_EFFECT_MARK";
   private static final Long SIDE_EFFECT_MARK_REFERENCE_ID = -4L;
+  private static final String UNKNOWN_HANDLER_TASK_TYPE = "QA_INTEGRATION_UNKNOWN_HANDLER";
+  private static final Long UNKNOWN_HANDLER_REFERENCE_ID = -5L;
 
   @Autowired
   private ScheduledTaskService scheduledTaskService;
@@ -61,7 +64,36 @@ class ScheduledTaskExecutorIntegrationTest {
     scheduledTaskService.cancel(THROWING_TASK_TYPE, REFERENCE_ID);
     scheduledTaskService.cancel(SIDE_EFFECT_TASK_TYPE, SIDE_EFFECT_REFERENCE_ID);
     scheduledTaskService.cancel(SIDE_EFFECT_MARK_TASK_TYPE, SIDE_EFFECT_MARK_REFERENCE_ID);
+    scheduledTaskService.cancel(UNKNOWN_HANDLER_TASK_TYPE, UNKNOWN_HANDLER_REFERENCE_ID);
     throwingHandlerProbe.reset();
+  }
+
+  @Test
+  @DisplayName("(d) 등록된 handler가 없는 taskType은 즉시 FAILED로 격리되고 이후 "
+      + "findDueTaskIds 폴링 결과에서 제외된다(#141, #145 CodeRabbit 지적 — 폴링 제외를 "
+      + "커밋된 테스트로 고정)")
+  void excludesTaskFromPollingAfterMarkedFailedForMissingHandler() {
+    LocalDateTime now = LocalDateTime.now();
+    // 배경 폴러와의 경합을 피하는 이유는 위 (a) 테스트의 주석 참고.
+    scheduledTaskService.schedule(
+        UNKNOWN_HANDLER_TASK_TYPE, UNKNOWN_HANDLER_REFERENCE_ID, now.plusDays(1),
+        Duration.ofMinutes(1), null);
+    Long taskId = scheduledTaskRepository
+        .findByTaskTypeAndReferenceId(UNKNOWN_HANDLER_TASK_TYPE, UNKNOWN_HANDLER_REFERENCE_ID)
+        .orElseThrow().getId();
+
+    scheduledTaskExecutor.execute(taskId, now.plusDays(1));
+
+    ScheduledTask reloaded = scheduledTaskRepository.findById(taskId).orElseThrow();
+    assertThat(reloaded.getStatus()).isEqualTo(ScheduledTaskStatus.FAILED);
+    assertThat(reloaded.getFailureCount()).isEqualTo(1);
+    assertThat(reloaded.getLastError()).contains(UNKNOWN_HANDLER_TASK_TYPE);
+    // nextAttemptAt은 원래 scheduledAt(now+1일)로 due 조건(<= now+10분)에 걸리지 않지만,
+    // status=PENDING 조건도 더 이상 만족하지 않으므로 FAILED 이후에는 어느 쪽이든 폴링
+    // 결과에서 빠져야 한다 — 넉넉히 미래 시점(now+2일)까지 조회해 확인한다.
+    List<Long> dueTaskIds = scheduledTaskRepository.findDueTaskIds(
+        ScheduledTaskStatus.PENDING, now.plusDays(2));
+    assertThat(dueTaskIds).doesNotContain(taskId);
   }
 
   @Test

--- a/src/test/java/com/remake/gone/common/schedule/service/ScheduledTaskExecutorTest.java
+++ b/src/test/java/com/remake/gone/common/schedule/service/ScheduledTaskExecutorTest.java
@@ -185,14 +185,17 @@ class ScheduledTaskExecutorTest {
   class EdgeCases {
 
     @Test
-    @DisplayName("등록된 핸들러가 없는 taskType이면 예외 없이 조용히 건너뛴다")
-    void skipsSilentlyWhenHandlerMissing() {
+    @DisplayName("등록된 핸들러가 없는 taskType이면 handler를 호출하지 않고 즉시 FAILED로 "
+        + "격리한다(#141 — 재시도로 해결되지 않는 배포 구성 오류라 backoff 없이 곧장 격리)")
+    void marksFailedImmediatelyWhenHandlerMissing() {
       ScheduledTask task = new ScheduledTask("UNKNOWN_TYPE", REFERENCE_ID, NOW, null, null);
       given(scheduledTaskRepository.findById(TASK_ID)).willReturn(Optional.of(task));
 
       executor.execute(TASK_ID, NOW);
 
-      assertThat(task.getStatus()).isEqualTo(ScheduledTaskStatus.PENDING);
+      assertThat(task.getStatus()).isEqualTo(ScheduledTaskStatus.FAILED);
+      assertThat(task.getFailureCount()).isEqualTo(1);
+      assertThat(task.getLastError()).contains("UNKNOWN_TYPE");
       verify(handler, never()).handle(anyLong());
     }
 


### PR DESCRIPTION
## 관련 이슈
closes #141

## 작업 내용
- `ScheduledTaskExecutor.execute()`가 `taskType`에 매핑된 handler가 없을 때 warn 로그만
  남기고 `PENDING` 상태를 그대로 두던 문제를 고쳤다. 이 경우 `status`가 바뀌지 않아 매
  폴링 틱(10초)마다 claim → warn 로그 → return이 무한 반복됐다.
- handler 미등록은 재시도로 해결되지 않는 배포 구성 오류이므로, 첫 claim에서 곧장
  `FAILED`로 격리하도록 기존 실패 처리 경로(`recordFailure`)를 재사용했다.

## 변경 사항 상세
- `RetryPolicy`에 `maxFailureCount=1`짜리 `NON_RETRYABLE` 상수를 추가했다. 기존
  `DEFAULT`(5회, 30초~30분 백오프)와 나란히 둔 정적 상수다.
- `ScheduledTaskExecutor.execute()`의 `handler == null` 분기에서
  `executionStore.recordFailure(taskId, now, "...taskType=...", RetryPolicy.NON_RETRYABLE)`를
  호출하도록 수정했다. `ScheduledTask.markFailed()`는 `maxFailureCount=1`이므로 첫 실패에서
  바로 `status=FAILED`로 전이한다 — 별도 코드 경로 없이 기존 로직을 그대로 재사용한다.
- 별도 상태값(enum) 신설은 하지 않았다. 관리자 모니터링 API(`GET
  /api/v1/scheduled-tasks`, #126)가 이미 노출하는 `lastError` 텍스트("등록된
  ScheduledTaskHandler가 없습니다: taskType=...")만으로 "설정 누락으로 인한 FAILED"와
  "일시적 실행 실패로 인한 FAILED"를 구분할 수 있어, 스키마/API 변경까지 가는 건 과설계라고
  판단했다(기획서 "리스크 및 고려사항" 참고).
- 새 HTTP 엔드포인트/DB 스키마 변경 없음.
- `ScheduledTaskExecutorTest`의 `skipsSilentlyWhenHandlerMissing`을
  `marksFailedImmediatelyWhenHandlerMissing`으로 교체해, 즉시 FAILED 전환/`failureCount`/
  `lastError`/handler 미호출을 검증한다.

## 확인 사항
- [x] 로컬 빌드 통과 (`./gradlew build`) — 607건 중 1건(`OutingLocationReminderConcurrencyIntegrationTest`)
      실패했으나 로컬에 Redis가 떠 있지 않아 나는 실패로 이번 변경과 무관(자세한 내용은
      [141-common-scheduled-task-handler-missing-QA.md](../blob/dev/docs/domain/common/141-common-scheduled-task-handler-missing-QA.md)
      참고). `common/schedule` 관련 테스트는 전부 통과.
- [x] Checkstyle 통과 (`./gradlew checkstyleMain`)
- [ ] CI(checkstyle, build-and-test) 통과 — PR 생성 후 확인 예정
- [ ] (해당 시) Notion 기능정의서/기획 문서 반영 — 새 엔드포인트 없어 해당 없음, 17단계(머지 후)는 스킵
- [x] (해당 시) 관련 도메인 라벨 지정 — `bug`, `priority:medium`, `domain:COMMON`
- [ ] 관련 마일스톤 지정 확인 — 이슈에 마일스톤 미지정 상태

## 관련 문서
- 기획서: `docs/domain/common/141-common-scheduled-task-handler-missing.md`
- 코드 리뷰(9단계, 격리 에이전트): `docs/domain/common/141-common-scheduled-task-handler-missing-code-review.md` (발견 사항 없음)
- QA(10단계): `docs/domain/common/141-common-scheduled-task-handler-missing-QA.md` (발견 사항 없음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QvmG1sgF6yJUJcVyKuzxYn

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Scheduled tasks with unregistered handlers are now immediately marked as **FAILED**.
  * Failed tasks are excluded from subsequent polling attempts, preventing repeated retries and log noise.
  * Failure details now include the task type, with the failure count recorded correctly.

* **Documentation**
  * Added planning, code review, and QA documentation covering the missing-handler behavior and verification results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->