### PR TITLE
fix(auth): #142 Aligo SMS 발송 실패 로그 전화번호 평문 노출 수정

### DIFF
--- a/docs/domain/auth/142-auth-sms-log-pii-QA.md
+++ b/docs/domain/auth/142-auth-sms-log-pii-QA.md
@@ -1,0 +1,38 @@
+# #142 Aligo SMS 발송 실패 로그 전화번호 노출 — QA 결과
+
+관련 기획서: [142-auth-sms-log-pii.md](./142-auth-sms-log-pii.md)
+관련 코드 리뷰: [142-auth-sms-log-pii-code-review.md](./142-auth-sms-log-pii-code-review.md)
+
+## 검증 범위
+이번 변경은 새 엔드포인트나 정책 변경 없이 `AligoSmsSender.send()`의 에러 로그 문구
+1줄만 바꾼다. 정상/에러 케이스 검증은 아래와 같이 진행했다.
+
+## 로컬 검증
+- `./gradlew build` 전체(컴파일 + 테스트 + checkstyle) 통과 확인.
+- `./gradlew test --tests AligoSmsSenderTest` 개별 실행 통과 확인, 신규 테스트
+  `doesNotLogPhoneNumberOnServerError`가 `RestClientException` 경로에서 로그 이벤트가
+  `phoneNumber` 값을 포함하지 않음을 검증.
+- `./gradlew checkstyleMain` 통과 확인.
+
+## 실서버 기동 검증 — 미실시(근거)
+기획서에 정의된 엔드포인트가 없고(내부 에러 로그 문구 변경), 이 로그는 `AligoSmsSender`가
+활성화되는 비-`dev` 프로필(`staging`/`prod`)에서 실제 Aligo API 호출이
+`RestClientException`으로 실패해야만 찍힌다. 실서버를 기동해 이 경로를 재현하려면
+Aligo API 호출을 실제로 실패시켜야 하는데(네트워크 차단, 잘못된 인증키 등), 운영 연동
+API를 상대로 강제 실패를 유발하는 것은 부작용 위험이 있어 시도하지 않았다. 대신
+`MockRestServiceServer`로 동일한 실패 응답을 흉내 낸 단위 테스트가 정확히 이 로그 문구를
+캡처해 검증하므로, 실서버 기동 없이도 변경 사항이 의도대로 동작함을 확인했다고 판단한다.
+(보스 확인 후 실서버 검증 생략에 동의 — 2026-09-09)
+
+## 심각도별 정리
+- **Critical**: 없음.
+- **High**: 없음.
+- **Medium**: 없음.
+- **Low**: 없음(코드 리뷰 단계에서 발견된 Low 2건은
+  [142-auth-sms-log-pii-code-review.md](./142-auth-sms-log-pii-code-review.md)에 이미
+  정리했고, 둘 다 기존 파일의 기존 패턴을 그대로 따른 것이라 이번 PR 범위 밖으로 판단해
+  별도 조치하지 않는다).
+
+## 결론
+로컬 빌드/테스트/checkstyle 모두 통과. 실서버 기동 검증은 위 근거로 생략하고 단위 테스트로
+대체했다. 병합을 막을 문제는 발견되지 않았다.

--- a/docs/domain/auth/142-auth-sms-log-pii-code-review.md
+++ b/docs/domain/auth/142-auth-sms-log-pii-code-review.md
@@ -1,0 +1,88 @@
+# #142 Aligo SMS 발송 실패 로그 전화번호 노출 — 코드 리뷰 결과
+
+관련 기획서: [142-auth-sms-log-pii.md](./142-auth-sms-log-pii.md)
+
+## 리뷰 범위/방법
+- 대상: `git diff dev...HEAD` (`fix/#142-aligo-sms-log-pii` vs `dev`), 커밋 3개
+  1. 기획서 추가 — `docs/domain/auth/142-auth-sms-log-pii.md`
+  2. 로그 수정 — `src/main/java/com/remake/gone/sms/AligoSmsSender.java:43`
+     (`log.error("Aligo SMS API 호출 실패: phoneNumber={}", phoneNumber, e)` →
+     `log.error("Aligo SMS API 호출 실패", e)`)
+  3. 테스트 추가 — `src/test/java/com/remake/gone/sms/AligoSmsSenderTest.java`
+     (Logback `ListAppender` 기반, `GlobalExceptionHandlerTest`와 동일한 패턴)
+- 방법: [code-review-isolation.md](../../rules/code-review-isolation.md)에 따라 구현 대화
+  맥락 없이 diff와 기획서만 전달한 별도 에이전트에서 `code-review` 스킬(effort: medium)을
+  실행. line-by-line / removed-behavior / cross-file tracer / reuse / simplification /
+  efficiency / altitude / conventions 8개 각도로 점검하고, 후보를 실제 소스 대조로 검증.
+- 확인한 것: 로그 오버로드 선택이 올바른지(`log.error(String, Throwable)`), 같은 파일 49번
+  줄의 `result_code` 로그가 이번 변경과 무관한지, `phoneNumber` 문자열을 파싱하는 다른
+  코드/문서가 있는지, 새 테스트가 실제로 검증하려는 것을 검증하는지.
+
+## Critical
+없음.
+
+## High
+없음.
+
+## Medium
+없음.
+
+## Low
+
+### 1. 🟢 Low — `ListAppender` 부착/해제 보일러플레이트가 `GlobalExceptionHandlerTest`와 완전히 중복됨
+
+**문제**: `AligoSmsSenderTest.java:38-61`에 추가된
+`logAppender` 필드 + `@BeforeEach`에서의 attach + `@AfterEach detachLogAppender()` +
+`private Logger logger()` 4종 세트가,
+`src/test/java/com/remake/gone/common/exception/GlobalExceptionHandlerTest.java:45-61`에
+이미 있는 동일한 패턴(필드명·구조까지 거의 동일)을 그대로 복제한 것이다. 두 파일 모두
+독립적으로 `ListAppender`를 생성/`start()`/`addAppender()`/`detachAppender()`한다. 이후
+로그 캡처 방식에 문제가 생기거나(예: `additivity` 설정 때문에 이벤트가 중복 캡처되는 경우,
+`ListAppender`를 `stop()`하지 않아 다음 테스트 클래스에 영향을 주는 경우) 개선이 필요해지면,
+두 파일 중 한쪽만 고치고 다른 쪽을 놓치기 쉽다.
+
+**해결 방안**:
+1. 공용 JUnit5 확장(`@ExtendWith`) 또는 테스트 유틸 클래스로 추출한다 — 예:
+   대상 로거 클래스를 파라미터로 받아 attach/detach를 대신 처리하는
+   `LogCaptureExtension`. 장점: 중복이 완전히 사라지고 이후 로그 캡처 테스트가 늘어나도
+   재사용 가능. 단점: 이번 이슈(#142, 로그 1줄 수정 + 검증 테스트 1건 추가)의 범위보다
+   리팩토링 규모가 크고, 효과를 보려면 기존 `GlobalExceptionHandlerTest`까지 같이
+   고쳐야 하므로 이번 PR 범위를 벗어난다.
+2. 지금은 그대로 두고, 같은 패턴을 쓰는 세 번째 테스트 클래스가 생기는 시점에 추출한다
+   (Rule of Three). 장점: 이번 PR을 기획서 범위(로그 1줄) 안에 유지할 수 있고 리스크가
+   없다. 단점: 이미 두 곳에 동일 코드가 있어 "지금 추출해도 되는" 중복 임계값은 사실상
+   넘은 상태이며, 추출을 미룰수록 세 번째 복제가 생길 가능성이 있다.
+
+### 2. 🟢 Low — 새 테스트가 `test-convention.md`의 `@Nested` 그룹화 규칙을 따르지 않음(기존 파일 패턴을 답습)
+
+**문제**: [test-convention.md](../../rules/test-convention.md)는 "메서드 단위로
+`@Nested` 클래스 + `@DisplayName("메서드명")`으로 그룹화"를 요구한다.
+`AligoSmsSenderTest.java`는 `send()` 메서드 하나만 테스트하는데도, 기존 3개 테스트
+(`sendsSuccessfully`, `throwsWhenResultCodeNegative`, `throwsOnServerError`)부터
+이미 `@Nested`로 묶이지 않고 flat `@Test`로 나열돼 있었다. 이번 diff는 그 위에 4번째
+flat `@Test`(`doesNotLogPhoneNumberOnServerError`, 111-124번 줄)를 추가해 기존
+컨벤션 미준수를 그대로 답습한다. 반대로 `GlobalExceptionHandlerTest.java`는
+`handleException`/`handleMissingServletRequestParameter`/`handleAccessDenied` 등
+메서드별로 정확히 `@Nested @DisplayName(메서드명)`을 지키고 있어(41-166번 줄),
+같은 프로젝트 안에서 파일마다 컨벤션 적용 여부가 갈린다.
+
+**해결 방안**:
+1. 이번 PR에서 `AligoSmsSenderTest` 전체를 `@Nested @DisplayName("send")` 블록으로
+   감싸도록 리팩토링한다. 장점: 컨벤션을 완전히 준수하고 `GlobalExceptionHandlerTest`와
+   동일한 패턴으로 통일된다. 단점: 기획서에 명시된 범위("로그 메시지 1줄만 변경",
+   테스트는 검증 케이스 1건 추가)를 벗어나는 리팩토링이 diff에 섞여, PR 리뷰/변경
+   추적이 어려워진다(#142는 이슈 자체가 로그 노출 1건으로 좁게 정의됨).
+2. 이번 PR은 그대로 두고, 기존 3개 테스트를 포함한 파일 전체의 `@Nested` 정리를
+   별도 이슈(컨벤션 정리용 후속 이슈, 또는 #144와 함께)로 분리한다. 장점: #142 범위를
+   "로그 1줄" 그대로 유지할 수 있어 기획서 원칙과 일관된다. 단점: 컨벤션 미준수 상태가
+   당장 해소되지 않고 남는다.
+
+## 결론
+Critical/High/Medium 없음. 로그 오버로드 선택(`log.error(String, Throwable)`)이 올바르고,
+같은 파일 49번 줄의 `result_code` 로그는 애초에 `phoneNumber`를 남기지 않아 이번 변경과
+무관함을 확인했다. `phoneNumber=` 형식 로그를 파싱하는 다른 코드/모니터링 설정도 없다.
+새 테스트(`doesNotLogPhoneNumberOnServerError`)는 `RestClientException` 경로에서 로그
+이벤트가 정확히 1건만 발생한다는 것까지 검증하므로(49번 줄 로그로 새지 않음을 간접
+확인), 검증 의도에 맞게 작성되어 있다. 기획서에 정의된 범위(로그 1줄 변경) 밖의 변경은
+없다. Low 2건은 모두 스타일/컨벤션/중복 성격으로, 병합을 막을 이유는 아니며 다음 단계
+(QA)로 진행해도 무방하다.

--- a/docs/domain/auth/142-auth-sms-log-pii.md
+++ b/docs/domain/auth/142-auth-sms-log-pii.md
@@ -1,0 +1,65 @@
+# #142 Aligo SMS 발송 실패 로그에 전화번호 평문 노출 — 기획서
+
+관련 이슈: [#142 fix(auth): Aligo SMS 발송 실패 로그에 전화번호 평문 노출](https://github.com/GBSW-ReMake/GONE-server-V1/issues/142)
+관련 PR(원 지적 출처): [#140 dev → staging 승격](https://github.com/GBSW-ReMake/GONE-server-V1/pull/140) — Copilot 리뷰
+선행 코드: [`AligoSmsSender`](../../../src/main/java/com/remake/gone/sms/AligoSmsSender.java)
+
+## 개요/목적
+`AligoSmsSender.send()`가 `RestClientException`으로 실패했을 때
+`log.error("Aligo SMS API 호출 실패: phoneNumber={}", phoneNumber, e)`로 수신자 전화번호를
+그대로 로그에 남긴다. 운영 로그/모니터링 시스템을 통해 개인정보(전화번호)가 노출될 수 있으므로
+이 로그 지점에서 전화번호를 제외한다. 새 엔드포인트나 정책 변경 없이 기존 로그 문구 1건만
+고친다.
+
+**참고**: 같은 파일의 NPE 이슈(`body`가 `null`일 때 `body.path(...)` 호출)와
+`OutingLocationRepository` Javadoc 불일치는 별도 이슈 [#144](https://github.com/GBSW-ReMake/GONE-server-V1/issues/144)에서
+다룬다. #144는 원래 이 로그 노출 건도 포함하고 있었으나, 이슈 #142가 별도로 이미 열려 있어
+로그 노출 수정은 #142로, 나머지(NPE·Javadoc)는 #144로 범위를 나눈다. #144 문서는 이 결정에
+맞춰 별도로 갱신한다.
+
+## 변경 대상
+- `src/main/java/com/remake/gone/sms/AligoSmsSender.java:43`
+
+**변경 전**:
+```java
+} catch (RestClientException e) {
+  log.error("Aligo SMS API 호출 실패: phoneNumber={}", phoneNumber, e);
+  throw new CustomException(AuthErrorCode.SMS_SEND_FAILED);
+}
+```
+
+**변경 후**:
+```java
+} catch (RestClientException e) {
+  log.error("Aligo SMS API 호출 실패", e);
+  throw new CustomException(AuthErrorCode.SMS_SEND_FAILED);
+}
+```
+
+- 로그 메시지에서 `phoneNumber`를 마스킹하지 않고 완전히 제외한다.
+  - 이유: 이 프로젝트에 기존 마스킹 유틸리티가 없고, 실패 원인 파악에는 예외 스택트레이스와
+    Aligo 응답 코드(같은 파일 49번 줄의 `result_code`/`message` 로그)로 충분하다 — 전화번호가
+    로그에 있어야만 파악되는 정보가 아니다. 새 마스킹 로직을 도입하는 대신 제외로 단순하게
+    처리한다.
+- 같은 파일 49번 줄(`log.error("Aligo SMS 발송 실패: result_code={}, message={}", ...)`)은
+  전화번호를 남기지 않으므로 변경 대상이 아니다.
+- `sms` 패키지 내 다른 로그 지점(`ConsoleSmsSender.send()`의 `System.out.println`)은
+  `@Profile("dev")` 전용으로 로컬 개발자 콘솔에만 찍히고 운영 로그/모니터링 시스템으로
+  나가지 않으므로 이번 수정 범위에 포함하지 않는다.
+
+## 영향 받는 기존 코드/테스트
+- 영향 코드: `src/main/java/com/remake/gone/sms/AligoSmsSender.java` (로그 메시지 1줄만 변경,
+  동작/예외 처리 로직 변경 없음)
+- 영향 테스트: `src/test/java/com/remake/gone/sms/AligoSmsSenderTest.java` — 기존
+  `throwsOnServerError()`는 로그 내용을 검증하지 않으므로 그대로 통과한다. 로그에
+  `phoneNumber`가 더 이상 남지 않는지 검증하는 케이스를 하나 추가한다(예: Logback
+  `ListAppender`로 로그 이벤트를 캡처해 메시지에 `PHONE_NUMBER` 값이 없는지 확인).
+
+## 리스크 및 고려사항
+- API 디자인 원칙([api-design.md](../../rules/api-design.md))은 새 엔드포인트가 없으므로
+  해당 없음.
+- 하위 호환성: 로그 포맷 변경은 클라이언트에 영향 없음. 로그를 파싱하는 별도 모니터링 룰이
+  있다면 영향받을 수 있으나, 현재 프로젝트에 그런 룰이 문서화되어 있지 않아 고려 대상에서
+  제외한다.
+- 범위: PR #140 리뷰에서 지적된 4건 중 이 로그 노출 1건만 다룬다. 나머지 3건(스케줄러
+  핸들러 미등록 → #141, NPE·Javadoc → #144)은 각각 별도 이슈로 진행한다.

--- a/src/main/java/com/remake/gone/sms/AligoSmsSender.java
+++ b/src/main/java/com/remake/gone/sms/AligoSmsSender.java
@@ -40,7 +40,7 @@ public class AligoSmsSender implements SmsSender {
           .retrieve()
           .body(JsonNode.class);
     } catch (RestClientException e) {
-      log.error("Aligo SMS API 호출 실패: phoneNumber={}", phoneNumber, e);
+      log.error("Aligo SMS API 호출 실패", e);
       throw new CustomException(AuthErrorCode.SMS_SEND_FAILED);
     }
 

--- a/src/test/java/com/remake/gone/sms/AligoSmsSenderTest.java
+++ b/src/test/java/com/remake/gone/sms/AligoSmsSenderTest.java
@@ -1,5 +1,6 @@
 package com.remake.gone.sms;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.hamcrest.Matchers.containsString;
@@ -8,12 +9,18 @@ import static org.springframework.test.web.client.match.MockRestRequestMatchers.
 import static org.springframework.test.web.client.response.MockRestResponseCreators.withServerError;
 import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 import com.remake.gone.auth.exception.AuthErrorCode;
 import com.remake.gone.common.exception.CustomException;
 import com.remake.gone.sms.config.AligoProperties;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.client.MockRestServiceServer;
 import org.springframework.util.LinkedMultiValueMap;
@@ -28,6 +35,7 @@ class AligoSmsSenderTest {
 
   private MockRestServiceServer mockServer;
   private AligoSmsSender aligoSmsSender;
+  private ListAppender<ILoggingEvent> logAppender;
 
   private static final String PHONE_NUMBER = "01099999999";
   private static final String MESSAGE = "[GONE] 인증번호는 123456 입니다.";
@@ -38,6 +46,19 @@ class AligoSmsSenderTest {
     mockServer = MockRestServiceServer.bindTo(builder).build();
     AligoProperties properties = new AligoProperties("test-key", "test-user-id", "01000000000");
     aligoSmsSender = new AligoSmsSender(builder.build(), properties);
+
+    logAppender = new ListAppender<>();
+    logAppender.start();
+    logger().addAppender(logAppender);
+  }
+
+  @AfterEach
+  void detachLogAppender() {
+    logger().detachAppender(logAppender);
+  }
+
+  private Logger logger() {
+    return (Logger) LoggerFactory.getLogger(AligoSmsSender.class);
   }
 
   @Test
@@ -85,5 +106,20 @@ class AligoSmsSenderTest {
         .isInstanceOf(CustomException.class)
         .extracting(e -> ((CustomException) e).getErrorCode())
         .isEqualTo(AuthErrorCode.SMS_SEND_FAILED);
+  }
+
+  @Test
+  @DisplayName("네트워크/서버 오류 로그에 수신자 전화번호를 남기지 않는다")
+  void doesNotLogPhoneNumberOnServerError() {
+    mockServer.expect(requestTo(containsString("/send/")))
+        .andRespond(withServerError());
+
+    assertThatThrownBy(() -> aligoSmsSender.send(PHONE_NUMBER, MESSAGE))
+        .isInstanceOf(CustomException.class);
+
+    assertThat(logAppender.list).hasSize(1);
+    ILoggingEvent event = logAppender.list.get(0);
+    assertThat(event.getLevel()).isEqualTo(Level.ERROR);
+    assertThat(event.getFormattedMessage()).doesNotContain(PHONE_NUMBER);
   }
 }


### PR DESCRIPTION
## 관련 이슈
closes #142

## 작업 내용
`AligoSmsSender.send()`가 `RestClientException`으로 실패했을 때 에러 로그에 수신자 전화번호를 평문으로 남기던 문제를 고쳤다. 새 엔드포인트나 정책 변경은 없다.

## 변경 사항 상세
- `AligoSmsSender.java:43`의 에러 로그에서 `phoneNumber={}`를 제거했다. 마스킹 대신 완전히 제외하는 방식을 택했다(이유는 기획서 참고 — 마스킹 유틸리티가 없고, 실패 원인 파악에는 전화번호가 필요하지 않음).
- 같은 파일 49번 줄(`result_code`/`message` 로그)은 애초에 전화번호를 남기지 않아 변경하지 않았다.
- `sms` 패키지 내 다른 로그 지점(`ConsoleSmsSender`의 콘솔 출력)은 `dev` 프로필 전용 로컬 콘솔 출력이라 운영 로그가 아니므로 범위에서 제외했다.
- 로그에 전화번호가 더 이상 남지 않는지 검증하는 테스트(`doesNotLogPhoneNumberOnServerError`)를 추가했다.
- 기획서/코드 리뷰/QA 문서: [142-auth-sms-log-pii.md](https://github.com/GBSW-ReMake/GONE-server-V1/blob/fix/%23142-aligo-sms-log-pii/docs/domain/auth/142-auth-sms-log-pii.md), [142-auth-sms-log-pii-code-review.md](https://github.com/GBSW-ReMake/GONE-server-V1/blob/fix/%23142-aligo-sms-log-pii/docs/domain/auth/142-auth-sms-log-pii-code-review.md), [142-auth-sms-log-pii-QA.md](https://github.com/GBSW-ReMake/GONE-server-V1/blob/fix/%23142-aligo-sms-log-pii/docs/domain/auth/142-auth-sms-log-pii-QA.md)
- 코드 리뷰에서 Low 2건(테스트 보일러플레이트 중복, `@Nested` 컨벤션 미준수)이 발견됐으나 기존 파일의 기존 패턴을 그대로 따른 것이라 이번 PR 범위 밖으로 판단해 조치하지 않았다.
- 관련: 같은 파일의 NPE 건·`OutingLocationRepository` Javadoc 불일치는 별도 이슈 #144에서 다룬다.

## 확인 사항
- [x] 로컬 빌드 통과 (`./gradlew build`)
- [x] Checkstyle 통과 (`./gradlew checkstyleMain`)
- [ ] CI(checkstyle, build-and-test) 통과
- [ ] (해당 시) Notion 기능정의서/기획 문서 반영
- [x] (해당 시) 관련 도메인 라벨 지정
- [ ] 관련 마일스톤 지정 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wb5RZkzLNjWTBEN6LmP1ed