### PR TITLE
docs(outing): #143 OutingLocationRepository Javadoc 정밀도 설명 수정

### DIFF
--- a/docs/domain/outing/143-outing-location-javadoc-QA.md
+++ b/docs/domain/outing/143-outing-location-javadoc-QA.md
@@ -1,0 +1,40 @@
+# #143 OutingLocationRepository Javadoc 정밀도 설명 수정 — QA 결과
+
+관련 기획서: [143-outing-location-javadoc.md](./143-outing-location-javadoc.md)
+관련 코드 리뷰: [143-outing-location-javadoc-code-review.md](./143-outing-location-javadoc-code-review.md)
+(9단계 코드 리뷰 지적 사항 없음 — 이 문서는 QA에서 새로 확인한 내용만 다룬다)
+
+## 검증 방법/범위
+Javadoc 문구 3줄만 바뀐 순수 문서 수정이라(기획서 "개요/목적" 참고), 엔드포인트별
+정상/에러 케이스 검증은 대상이 아니다. 아래 순서로 확인했다.
+
+1. `./gradlew checkstyleMain checkstyleTest` — 통과.
+2. `./gradlew test --tests "com.remake.gone.outing.*"` — 206건 전부 통과(실패 0건).
+3. `./gradlew checkstyleMain checkstyleTest build -x javadoc` — 전체 608건 테스트 전부
+   통과(실패 0건, 에러 0건). `-x javadoc`은 아래 4번 사유로 제외했다.
+4. `./gradlew javadoc` 태스크 자체는 실패한다 — 원인은 `AuthController.java`의 기존
+   EUC-KR/윈도우 인코딩 문제(`unmappable character ... for encoding x-windows-949`)로,
+   이번 변경과 무관한 사전 존재 이슈다(변경 파일이 아니고, 표준 `build` 라이프사이클에도
+   포함되지 않는 별도 태스크). 조치하지 않았다 — 이슈 범위(Javadoc 문구 정정) 밖.
+
+### 로컬 환경 이슈 및 해결
+이 QA는 이슈 #143 작업용으로 새로 만든 git worktree
+(`.claude/worktrees/143-outing-location-javadoc`)에서 진행했다. worktree는 git 추적
+파일만 가져오므로, gitignore 대상인 로컬 설정 파일(`.env`, `application-dev.yml`)이
+비어 있어 처음엔 DB 인증 실패(`Access denied for user 'root'@'localhost'`)와 JWT 설정
+바인딩 실패로 outing 패키지 테스트 전부가 애플리케이션 컨텍스트 로딩 단계에서 막혔다.
+보스에게 실제 로컬 DB 계정(`root`/`1234`, Redis는 이미 기동 중)을 확인받아 원본
+체크아웃의 `application-dev.yml`을 worktree에 복사하고 `SPRING_DATASOURCE_PASSWORD=1234`
+환경변수로 재실행해 해결했다 — 두 파일 모두 gitignore 대상이라 이 변경으로 커밋되는 것은
+없다.
+
+## 발견 사항
+- **Critical/High**: 없음.
+- **Medium**: 없음.
+- **Low**: 없음.
+
+## 결론
+Javadoc 문구가 실제 스키마(`DATETIME(6)`, 마이크로초 정밀도)와 더 이상 모순되지 않고,
+로직/스키마/API 변경이 없어 전체 테스트(608건)가 그대로 통과한다. 코드 리뷰(9단계)와
+로컬 빌드/테스트가 모두 통과해 이 이슈의 완료 조건(Definition of Done: 로컬 빌드/테스트
+통과)을 충족했다. CI 통과 확인은 16단계 PR 생성 시점에 확인한다.

--- a/docs/domain/outing/143-outing-location-javadoc-QA.md
+++ b/docs/domain/outing/143-outing-location-javadoc-QA.md
@@ -23,10 +23,10 @@ Javadoc 문구 3줄만 바뀐 순수 문서 수정이라(기획서 "개요/목�
 파일만 가져오므로, gitignore 대상인 로컬 설정 파일(`.env`, `application-dev.yml`)이
 비어 있어 처음엔 DB 인증 실패(`Access denied for user 'root'@'localhost'`)와 JWT 설정
 바인딩 실패로 outing 패키지 테스트 전부가 애플리케이션 컨텍스트 로딩 단계에서 막혔다.
-보스에게 실제 로컬 DB 계정(`root`/`1234`, Redis는 이미 기동 중)을 확인받아 원본
-체크아웃의 `application-dev.yml`을 worktree에 복사하고 `SPRING_DATASOURCE_PASSWORD=1234`
-환경변수로 재실행해 해결했다 — 두 파일 모두 gitignore 대상이라 이 변경으로 커밋되는 것은
-없다.
+보스에게 실제 로컬 DB 계정(Redis는 이미 기동 중)을 확인받아 원본 체크아웃의
+`application-dev.yml`을 worktree에 복사하고 `SPRING_DATASOURCE_PASSWORD` 환경변수로
+재실행해 해결했다 — 두 파일 모두 gitignore 대상이라 이 변경으로 커밋되는 것은 없다.
+실제 자격 증명 값은 이 문서에 남기지 않는다.
 
 ## 발견 사항
 - **Critical/High**: 없음.

--- a/docs/domain/outing/143-outing-location-javadoc-code-review.md
+++ b/docs/domain/outing/143-outing-location-javadoc-code-review.md
@@ -1,0 +1,60 @@
+# #143 OutingLocationRepository Javadoc 정밀도 설명 수정 — 코드 리뷰 결과
+
+관련 기획서: [143-outing-location-javadoc.md](./143-outing-location-javadoc.md)
+
+## 리뷰 범위/방법
+- 대상: `docs/#143-outing-location-javadoc` 브랜치가 dev에서 분기된 이후 커밋 2개
+  (`e16a430`, `b66ea54`)가 건드린 파일 전체 — 각 커밋을 `git show --stat`으로 개별 확인해
+  아래 2개 파일 외 변경이 없음을 확인했다:
+  - `docs/domain/outing/143-outing-location-javadoc.md` (신규 기획서)
+  - `src/main/java/com/remake/gone/outing/repository/OutingLocationRepository.java`
+    (Javadoc 3줄 수정, 로직/시그니처 변경 없음)
+  (이 worktree의 로컬 `dev` ref가 원격보다 뒤처져 있어 `git diff dev...HEAD`는 관련 없는
+  #141/#145 커밋까지 섞여 나온다 — 위 두 커밋 각각의 `--stat`으로 대조해 실제 이슈 #143
+  범위만 확인했다.)
+- 방법: 기획서와 diff만으로 독립적으로 점검했다.
+  - 기획서 "변경 사항 — 변경 전/후" 절의 Javadoc 텍스트가 실제 diff와 문자 단위로
+    일치하는지 대조.
+  - `src/main/resources/db/migration/V20260825160335__add_outing_location.sql:7`에서
+    `recorded_at DATETIME(6) NOT NULL`을 직접 확인해, 새 Javadoc 문구가 실제 스키마와
+    맞는지 검증.
+  - `docs/rules/code-style.md`, `docs/rules/sentence-refinement.md`와 대조.
+  - `./gradlew checkstyleMain` 실행 — BUILD SUCCESSFUL (경고 0건).
+  - `code-review` 스킬 기반 독립 리뷰 에이전트를 별도로 실행 — findings 없음, 이 파일의
+    변경을 "Javadoc-text-only edit with no code impact"로 교차 확인.
+
+## 결과: Critical/High/Medium/Low 없음
+
+기획서 범위, 스키마 정합성, 컨벤션 세 축 모두에서 지적 사항을 찾지 못했다. 근거:
+
+- **범위 일치**: 기획서가 명시한 대로 `OutingLocationRepository.java`의 Javadoc 문구만
+  수정됐다. 로직/시그니처/테스트 변경 없음, 새 HTTP 엔드포인트나 DB 스키마 변경 없음 —
+  기획서 "리스크 및 고려사항" 절의 "API 계약·DB 스키마·런타임 동작 변경이 전혀 없다"는
+  서술과 일치한다.
+- **텍스트 일치**: 실제 diff의 새 Javadoc(`OutingLocationRepository.java:13-16`)이
+  기획서의 "변경 후" 코드 블록과 한 글자도 다르지 않게 일치한다.
+- **스키마 정합성**: 수정 전 Javadoc은 "`recorded_at`이 초 단위 정밀도"라고 명시했으나,
+  실제 컬럼은 `V20260825160335__add_outing_location.sql:7`에서
+  `recorded_at DATETIME(6) NOT NULL`(마이크로초 정밀도)로 정의돼 있어 이 서술은 틀린
+  정보였다. 수정 후 문구는 "같은 timestamp로 동률일 수 있어"로 바꿔 정밀도 수준을
+  특정하지 않고 `id` 보조 정렬의 필요성만 설명한다 — 마이크로초 정밀도에서도 여러 위치
+  핑이 동일한 timestamp로 기록될 가능성 자체는 남아 있으므로(예: 같은 배치/서비스
+  호출에서 동일 시각 값을 공유하는 경우), 이 서술은 스키마와 모순되지 않는다.
+- **컨벤션 준수**:
+  - 한 줄 100자 제한(`code-style.md`) 확인 — `awk`로 파일 전체 줄 길이를 실측한 결과,
+    이번 diff가 건드린 3줄(13~15행, "recorded_at}이 같은..." ~ "LIST_QUERY_SORT} 등
+    참고).")이 각각 115자, 112자로 100자를 넘는다. 다만 수정 전 원본도 같은 줄 길이
+    구조였고, `./gradlew checkstyleMain`이 이 파일 전체를 BUILD SUCCESSFUL로 통과시켰다
+    — 이 프로젝트 checkstyle 설정이 한글 멀티바이트 문자가 섞인 줄에는 100자 제한을
+    그대로 적용하지 않는 것으로 실측 확인됐으므로 별도 조치가 필요 없다.
+  - 문장 표현(`sentence-refinement.md` 원칙 3)의 "모호한 표현 금지"와 관련해 "동률일 수
+    있어"라는 조건부 표현을 쓰지만, 이는 수정 전 원본도 "핑이 있을 수 있어"로 동일하게
+    조건부 표현을 썼던 부분이라 이번 수정이 새로 도입한 패턴이 아니다. 실제로 동시성
+    상황에 따라 발생 여부가 갈리는 사건이라 조건부 표현이 부적절하지 않다.
+  - Javadoc 문체가 나머지 클래스 주석과 톤이 일치한다(`{@code}` 사용, WHY 중심 설명).
+
+## 참고: 독립 검증 에이전트 교차 확인
+`code-review` 스킬 기반 독립 리뷰 에이전트를 별도로 실행한 결과도 findings 없음으로
+결론 내려, 이 문서의 결론과 교차 확인됐다(다만 그 에이전트는 로컬 `dev` ref가 뒤처진
+탓에 범위에 없는 #141/#145 커밋까지 함께 검토했다 — 해당 커밋들도 findings 없음이었고,
+이슈 #143 대상 파일에 대한 결론은 이 문서와 동일하다).

--- a/docs/domain/outing/143-outing-location-javadoc.md
+++ b/docs/domain/outing/143-outing-location-javadoc.md
@@ -1,0 +1,49 @@
+# #143 OutingLocationRepository Javadoc 정밀도 설명 수정 — 기획서
+
+관련 이슈: [#143 docs(outing): OutingLocationRepository Javadoc 정밀도 설명이 스키마와
+불일치](https://github.com/GBSW-ReMake/GONE-server-V1/issues/143)
+계기: PR #140 Copilot 리뷰(`OutingLocationRepository.java:20`)
+
+## 개요/목적
+`findByOutingIdOrderByRecordedAtAscIdAsc`의 Javadoc은 `id` 보조 정렬을 쓰는 이유를
+"`recorded_at`이 초 단위 정밀도라 같은 초에 들어온 핑이 있을 수 있다"고 설명한다. 실제
+`outing_location.recorded_at` 컬럼은 `V20260825160335__add_outing_location.sql`에서
+`DATETIME(6)`(마이크로초 정밀도)로 정의돼 있어 이 설명이 스키마와 맞지 않는다. 동작에는
+영향 없는 순수 문서(Javadoc) 수정이다 — 새 HTTP 엔드포인트나 로직 변경은 없다.
+
+## 변경 사항 — 변경 전/후
+
+**변경 전** (`OutingLocationRepository.java:12-20`):
+```java
+/**
+ * 특정 외출증의 위치 핑을 기록된 시각 오름차순으로 조회합니다(#97, 동선 조회용). {@code
+ * recorded_at}이 초 단위 정밀도라 같은 초에 들어온 핑이 있을 수 있어, {@code id}(삽입 순서와
+ * 일치)를 보조 정렬 키로 둔다 — 이 서비스의 다른 목록 조회들과 같은 이유({@code
+ * OutingService}의 {@code LIST_QUERY_SORT} 등 참고).
+ *
+ * @param outingId 조회할 외출증의 내부 PK
+ * @return 조건에 맞는 위치 핑 목록, {@code recordedAt} 오름차순(동률 시 {@code id} 오름차순)
+ */
+```
+
+**변경 후**: "초 단위 정밀도" 대신 "같은 timestamp로 동률이 발생할 수 있다"는 표현으로
+바꿔, 정밀도 수준을 특정하지 않고도 `id` 보조 정렬의 필요성만 설명한다.
+```java
+/**
+ * 특정 외출증의 위치 핑을 기록된 시각 오름차순으로 조회합니다(#97, 동선 조회용). {@code
+ * recorded_at}이 같은 timestamp로 동률일 수 있어, {@code id}(삽입 순서와 일치)를 보조 정렬
+ * 키로 둔다 — 이 서비스의 다른 목록 조회들과 같은 이유({@code OutingService}의 {@code
+ * LIST_QUERY_SORT} 등 참고).
+ *
+ * @param outingId 조회할 외출증의 내부 PK
+ * @return 조건에 맞는 위치 핑 목록, {@code recordedAt} 오름차순(동률 시 {@code id} 오름차순)
+ */
+```
+
+## 영향받는 기존 코드/테스트
+- `OutingLocationRepository.java`의 Javadoc 문구만 수정. 로직/시그니처 변경이 없어 기존
+  테스트 동작에 영향 없고, 새 테스트도 필요 없다.
+
+## 리스크 및 고려사항
+- 순수 문서 수정이라 API 계약·DB 스키마·런타임 동작 변경이 전혀 없다 —
+  [api-design.md](../../rules/api-design.md) 6원칙 검토 대상 아님.

--- a/src/main/java/com/remake/gone/outing/repository/OutingLocationRepository.java
+++ b/src/main/java/com/remake/gone/outing/repository/OutingLocationRepository.java
@@ -11,9 +11,9 @@ public interface OutingLocationRepository extends JpaRepository<OutingLocation, 
 
   /**
    * 특정 외출증의 위치 핑을 기록된 시각 오름차순으로 조회합니다(#97, 동선 조회용). {@code
-   * recorded_at}이 초 단위 정밀도라 같은 초에 들어온 핑이 있을 수 있어, {@code id}(삽입 순서와
-   * 일치)를 보조 정렬 키로 둔다 — 이 서비스의 다른 목록 조회들과 같은 이유({@code
-   * OutingService}의 {@code LIST_QUERY_SORT} 등 참고).
+   * recorded_at}이 같은 timestamp로 동률일 수 있어, {@code id}(삽입 순서와 일치)를 보조 정렬
+   * 키로 둔다 — 이 서비스의 다른 목록 조회들과 같은 이유({@code OutingService}의 {@code
+   * LIST_QUERY_SORT} 등 참고).
    *
    * @param outingId 조회할 외출증의 내부 PK
    * @return 조건에 맞는 위치 핑 목록, {@code recordedAt} 오름차순(동률 시 {@code id} 오름차순)


### PR DESCRIPTION
## 관련 이슈
closes #143

## 작업 내용
- `OutingLocationRepository.findByOutingIdOrderByRecordedAtAscIdAsc`의 Javadoc이
  `recorded_at`을 "초 단위 정밀도"라고 설명했으나, 실제 마이그레이션
  (`V20260825160335__add_outing_location.sql`)은 `DATETIME(6)`(마이크로초 정밀도)이라
  스키마와 불일치했다. `id` 보조 정렬을 쓰는 이유를 "같은 timestamp로 동률일 수 있어"로
  정정해 정밀도 수준을 특정하지 않고도 설명이 성립하게 했다.
- 로직/API/DB 스키마 변경 없음. Javadoc 문구만 수정.

## 변경 사항 상세
- `OutingLocationRepository.java`: Javadoc 3줄 문구 수정 (초 단위 정밀도 → 동률 가능성)

## 확인 사항
- [x] 로컬 빌드 통과 (`./gradlew checkstyleMain checkstyleTest build -x javadoc`) — 608건
      테스트 전부 통과. (`javadoc` 태스크는 `AuthController.java`의 기존 인코딩 문제로
      실패하나 이번 변경과 무관 — 자세한 내용은
      [143-outing-location-javadoc-QA.md](../blob/dev/docs/domain/outing/143-outing-location-javadoc-QA.md)
      참고)
- [x] Checkstyle 통과 (`./gradlew checkstyleMain checkstyleTest`)
- [ ] CI(checkstyle, build-and-test) 통과 — PR 생성 후 확인 예정
- [ ] (해당 시) Notion 기능정의서/기획 문서 반영 — 새 엔드포인트 없어 해당 없음
- [x] (해당 시) 관련 도메인 라벨 지정 — `docs`, `priority:low`, `domain:OUTING`
- [ ] 관련 마일스톤 지정 확인 — 이슈에 마일스톤 미지정 상태

## 관련 문서
- 기획서: `docs/domain/outing/143-outing-location-javadoc.md`
- 코드 리뷰(9단계, 격리 에이전트): `docs/domain/outing/143-outing-location-javadoc-code-review.md` (발견 사항 없음)
- QA(10단계): `docs/domain/outing/143-outing-location-javadoc-QA.md` (발견 사항 없음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016EPx9fUoB5evjeZAtdGzeK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated repository documentation to accurately explain timestamp ordering when multiple records share the same timestamp.
  * Added planning, code review, and QA documentation for the documentation correction.
  * Confirmed that application behavior, APIs, database schema, and tests remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->