### PR TITLE
fix(common): #121 낙관적 락 409 핸들러 단위 테스트 추가

### DIFF
--- a/docs/domain/common/121-common-optimistic-lock-handler-QA.md
+++ b/docs/domain/common/121-common-optimistic-lock-handler-QA.md
@@ -1,0 +1,35 @@
+# #121 낙관적 락 409 핸들러 — QA 결과
+
+기획서: [121-common-optimistic-lock-handler.md](./121-common-optimistic-lock-handler.md)
+
+## QA 범위
+
+변경 내용: `GlobalExceptionHandlerTest`에 `handleOptimisticLockingFailure` 테스트 1건 추가.
+프로덕션 코드 변경 없음 → 실서버 동작 검증 불필요.
+
+## 빌드 및 테스트 결과
+
+| 항목 | 명령 | 결과 |
+|------|------|------|
+| 컴파일 + Checkstyle | `./gradlew build -x test` | BUILD SUCCESSFUL ✅ |
+| 신규 테스트 | `./gradlew test --tests "com.remake.gone.common.exception.GlobalExceptionHandlerTest"` | BUILD SUCCESSFUL ✅ |
+| 전체 테스트 | `./gradlew test` | 625 tests, 1 failed ⚠️ |
+
+## 전체 테스트 실패 1건 — 기존 결함, #121 무관
+
+**실패 테스트**: `OutingLocationReminderConcurrencyIntegrationTest > 같은 외출증에 학교 반경 안 위치 핑을 동시에 여러 번 보내도 도착 확인 알림은 정확히 한 건만 발송된다`
+
+**원인**: `dev` 브랜치에서도 동일하게 실패함을 확인(`./gradlew test --tests ...` → `FAILED`).
+→ #121 작업 이전부터 존재한 실패. 이 브랜치에서 도입한 회귀 아님.
+
+## 신규 테스트 검증
+
+`handleOptimisticLockingFailure` 테스트:
+- `ObjectOptimisticLockingFailureException` 발생 → HTTP 409 CONFLICT 반환 ✅
+- `success()` = false ✅
+- `code()` = "COMMON_006" ✅
+
+## QA 결론
+
+**통과.** 신규 테스트 정상 동작, 회귀 없음.
+전체 테스트 실패 1건은 기존 결함으로 #121과 무관.

--- a/docs/domain/common/121-common-optimistic-lock-handler-code-review.md
+++ b/docs/domain/common/121-common-optimistic-lock-handler-code-review.md
@@ -1,0 +1,27 @@
+# #121 낙관적 락 409 핸들러 — 코드 리뷰 결과
+
+기획서: [121-common-optimistic-lock-handler.md](./121-common-optimistic-lock-handler.md)
+
+## 코드 리뷰 (9단계, 별도 에이전트)
+
+diff 범위: `docs/domain/common/121-common-optimistic-lock-handler.md` +
+`src/test/java/com/remake/gone/common/exception/GlobalExceptionHandlerTest.java`
+
+### 발견된 항목
+
+**지적 1 — `response.getBody()` null 미확인**
+
+`assertThat(response.getBody().success())` 형태로 null 체크 없이 body에 바로 접근한다.
+→ **수정 안 함.** 파일 내 다른 핸들러 테스트(`handleMissingServletRequestParameter` 등)
+모두 동일 패턴을 사용하고 있고, 핸들러는 항상 body를 세팅하므로 실제 NPE 발생 경로가 없다.
+프로젝트 컨벤션을 따라 일관성을 유지한다.
+
+**지적 2 — 테스트 DisplayName "500이 아니라" 표현**
+
+"500이 아니라 409"보다 "409를 반환한다"가 더 긍정적 표현이라는 의견.
+→ **수정 안 함.** 파일 내 `handleAccessDenied`, `handleNoResourceFound` 등 기존 테스트가
+모두 "500이 아니라 NNN COMMON_NNN으로 응답한다" 패턴을 사용 중이다. 일관성 유지.
+
+### 결론
+
+문제 없음. 추가 수정 없이 다음 단계 진행.

--- a/docs/domain/common/121-common-optimistic-lock-handler.md
+++ b/docs/domain/common/121-common-optimistic-lock-handler.md
@@ -1,0 +1,95 @@
+# GlobalExceptionHandler 낙관적 락 충돌 409 처리 — 기획서 (이슈 #121)
+
+## 개요/목적
+
+`ConductRequest`·`Outing` 엔티티는 `@Version`으로 낙관적 락을 사용한다. 동일한 엔티티를
+두 요청이 동시에 수정하면 나중 트랜잭션에서
+`ObjectOptimisticLockingFailureException`이 발생하는데, 이 예외를 처리하는 핸들러가 없으면
+500 Internal Server Error가 반환된다. 충돌은 정상적인 동시성 상황이므로 409 Conflict가
+올바른 응답이다.
+
+**현재 구현 상태**: 이슈 #121이 생성된 이후 #122 PR 작업 중(커밋 `e075297`) 핸들러가
+선제적으로 추가됐다. 현재 `GlobalExceptionHandler.handleOptimisticLockingFailure`가 존재하며
+기존 `COMMON_006` (CONFLICT)를 사용해 409를 반환한다. 이 기획서는 남은 갭을 확인하고
+마무리 방향을 정리한다.
+
+- **관련 이슈**: #121
+- **현재 상태**: 핸들러 구현 완료 / 단위 테스트 없음 / 메시지 검토 필요
+
+---
+
+## 현 구현 상태 분석
+
+### 구현된 것
+
+`GlobalExceptionHandler`:
+
+```java
+@ExceptionHandler(ObjectOptimisticLockingFailureException.class)
+public ResponseEntity<ApiResponse<Void>> handleOptimisticLockingFailure(
+    ObjectOptimisticLockingFailureException e) {
+  return ResponseEntity
+      .status(CommonErrorCode.CONFLICT.getStatus())
+      .body(ApiResponse.fail(
+          null,
+          CommonErrorCode.CONFLICT.getDefaultMessage(),
+          CommonErrorCode.CONFLICT.getCode()));
+}
+```
+
+`COMMON_006`(HTTP 409)을 재사용한다.
+
+### 미구현 / 검토 필요
+
+1. **`COMMON_006` 메시지 적합성**: `"이미 존재하는 리소스입니다."` — `DataIntegrityViolationException`
+   (UNIQUE 제약 위반)과 같은 코드·메시지를 공유한다. 낙관적 락 충돌과 UNIQUE 충돌은 클라이언트
+   입장에서 다른 상황이지만, 두 경우 모두 현재 `COMMON_006`으로 응답한다.
+
+2. **단위 테스트 없음**: `GlobalExceptionHandlerTest`에 `handleOptimisticLockingFailure`를
+   검증하는 테스트가 없다.
+
+---
+
+## 구현 방향 — 방향 A 확정
+
+`COMMON_006` 유지, 단위 테스트만 추가한다.
+
+**결정 근거**:
+- 에러 코드는 클라이언트 계약이다. 이미 staging에 배포된 `COMMON_006` 응답을 `COMMON_008`로 바꾸면 앱 측 대응 비용이 발생한다.
+- 낙관적 락 충돌 시 앱은 서버 메시지를 사용자에게 그대로 노출하지 않고 자체 문구로 덮는다 — 메시지 부정확이 UX에 직접 영향을 주지 않는다.
+- 로그에서 UNIQUE 위반과 낙관적 락을 구별해야 하면 exception type 자체가 다르므로 로그로 확인 가능하다.
+
+**알려진 한계 (다른 개발자를 위한 기록)**:
+- `COMMON_006`("이미 존재하는 리소스입니다.") 메시지는 `DataIntegrityViolationException`(UNIQUE 제약 위반)과
+  `ObjectOptimisticLockingFailureException`(낙관적 락 충돌) 두 경우에 모두 반환된다.
+  메시지 자체는 낙관적 락 충돌을 정확히 설명하지 못한다.
+  **이 메시지를 사용자에게 직접 노출해서는 안 된다** — 409를 받으면 앱 레이어에서 별도 문구("잠시 후 다시 시도해주세요." 등)로 교체해야 한다.
+  로그에서 두 경우를 구별하려면 에러 코드가 아니라 exception type(`ObjectOptimisticLockingFailureException` vs `DataIntegrityViolationException`)으로 판단한다.
+
+**작업 범위**: `GlobalExceptionHandlerTest`에 테스트 1건 추가.
+
+---
+
+## 에러
+
+해당 없음 — 이 기능 자체가 에러 응답을 올바르게 반환하기 위한 예외 처리기다.
+
+---
+
+## 영향 범위
+
+- `GlobalExceptionHandler` (수정)
+- `CommonErrorCode` (방향 B에서만 수정)
+- `GlobalExceptionHandlerTest` (테스트 추가)
+- `ConductRequest`·`Outing` 낙관적 락 사용 코드 — 변경 없음, 동작만 개선됨.
+
+---
+
+## 리스크 및 고려사항
+
+- **단일 책임**: `COMMON_006`이 두 가지 다른 409 상황을 동시에 담당하게 된다(방향 A).
+  코드를 분리(방향 B)하면 더 명확하지만, 클라이언트 앱이 현재 `COMMON_006`으로 분기 처리를
+  구현해뒀다면 `COMMON_008` 추가 시 앱 측도 함께 대응해야 한다.
+- **하위 호환성**: 방향 B는 새 에러 코드 추가이므로 기존 앱이 `COMMON_006`만 409로 처리했다면
+  `COMMON_008`을 알 수 없는 코드로 처리할 수 있다. 앱 팀과 합의 필요.
+- **페이지네이션/확장성**: 해당 없음.

--- a/src/test/java/com/remake/gone/common/exception/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/remake/gone/common/exception/GlobalExceptionHandlerTest.java
@@ -22,6 +22,7 @@ import org.springframework.core.MethodParameter;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
@@ -139,6 +140,25 @@ class GlobalExceptionHandlerTest {
       assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
       assertThat(response.getBody().success()).isFalse();
       assertThat(response.getBody().code()).isEqualTo("COMMON_001");
+    }
+  }
+
+  @Nested
+  @DisplayName("handleOptimisticLockingFailure")
+  class HandleOptimisticLockingFailure {
+
+    @Test
+    @DisplayName("낙관적 락 충돌이 발생하면 500이 아니라 409 COMMON_006으로 응답한다")
+    void returns409InsteadOfInternalServerError() {
+      ObjectOptimisticLockingFailureException exception =
+          new ObjectOptimisticLockingFailureException("ConductRequest", 1L);
+
+      ResponseEntity<ApiResponse<Void>> response =
+          handler.handleOptimisticLockingFailure(exception);
+
+      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CONFLICT);
+      assertThat(response.getBody().success()).isFalse();
+      assertThat(response.getBody().code()).isEqualTo("COMMON_006");
     }
   }
 


### PR DESCRIPTION
## 관련 이슈

closes #121

## 변경 내용

`GlobalExceptionHandlerTest`에 `handleOptimisticLockingFailure` 단위 테스트 1건 추가.

핸들러 구현은 #122 PR(커밋 `e075297`)에서 이미 완료됨. 이 PR은 누락된 테스트를 보완한다.

**방향 A 선택 근거 (기획서 참조):**
- `COMMON_008` 신규 코드 불추가 — staging 배포 이후 클라이언트 계약 변경 비용 회피
- `COMMON_006` 유지 시 메시지 부정확 문제 존재하나, 앱이 서버 메시지를 직접 노출하지 않으므로 UX 무영향
- 알려진 한계: `COMMON_006`이 `DataIntegrityViolationException`(UNIQUE 위반)과 `ObjectOptimisticLockingFailureException`(낙관적 락) 두 경우 모두 반환됨. 409 수신 시 앱은 자체 문구("잠시 후 다시 시도해주세요.")로 교체 필요. 로그 구별은 exception type으로 판단.

## 테스트 범위

- `handleOptimisticLockingFailure`: `ObjectOptimisticLockingFailureException` → 409 CONFLICT, `COMMON_006` 반환 검증

## QA

- `./gradlew build -x test` → BUILD SUCCESSFUL
- `GlobalExceptionHandlerTest` 전체 → BUILD SUCCESSFUL
- 전체 테스트 625건: `OutingLocationReminderConcurrencyIntegrationTest` 1건 실패 (dev 브랜치 기존 결함, 이 PR과 무관)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added Korean documentation covering optimistic-locking conflict handling, expected responses, validation results, known limitations, and code review findings.
  - Documented that optimistic-locking conflicts return a 409 Conflict response with the existing common error code.

- **Tests**
  - Added automated coverage confirming optimistic-locking conflicts return HTTP 409 instead of HTTP 500, including the expected error code and response details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->